### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/leak.md
+++ b/doc/leak.md
@@ -1,6 +1,6 @@
 # Memory Leaking
 
-Memory leaking is one of the major issues when creating a service infra-structure. A correct detection of tese
+Memory leaking is one of the major issues when creating a service infra-structure. A correct detection of these
 type of problems is important to provide a stable production environment.
 
 ## Status

--- a/src/netius/common/http2.py
+++ b/src/netius/common/http2.py
@@ -1011,7 +1011,7 @@ class HTTP2Stream(netius.Stream):
         if self.status == netius.CLOSED: return
 
         # in case the reset flag is set sends the final, tries to determine
-        # the way of reseting the stream, in case the flush flag is set
+        # the way of resetting the stream, in case the flush flag is set
         # (meaning that a less strict closing is requested) and the current
         # stream is considered ready for request handling the stream reset
         # operation consists of a final chunk sending, otherwise (in case no


### PR DESCRIPTION
There are small typos in:
- doc/leak.md
- src/netius/common/http2.py

Fixes:
- Should read `these` rather than `tese`.
- Should read `resetting` rather than `reseting`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md