### PR TITLE
Fix support for multiple SMTP messages per SMTP session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Support for multiple messages for same SMTP session - [#40](https://github.com/hivesolutions/netius/issues/40)
 
 ## [1.19.4] - 2024-04-22
 

--- a/src/netius/common/smtp.py
+++ b/src/netius/common/smtp.py
@@ -123,7 +123,7 @@ class SMTPParser(parser.Parser):
         if not len(values) > 1: values.append("")
 
         # unpacks the set of values that have just been parsed into the code
-        # and the message items as expected by the smtp specification
+        # and the message items as expected by the SMTP specification
         code, message = values
 
         # verifies if the current line is a final line meaning that no more
@@ -139,7 +139,7 @@ class SMTPParser(parser.Parser):
         is_final = not is_continuation
 
         # triggers the on line event so that the listeners are notified
-        # about the end of the parsing of the smtp line and then
+        # about the end of the parsing of the SMTP line and then
         # returns the count of the parsed bytes of the message
         self.trigger("on_line", code, message, is_final = is_final)
         return index + 1

--- a/src/netius/extra/smtp_r.py
+++ b/src/netius/extra/smtp_r.py
@@ -47,10 +47,10 @@ import netius.servers
 
 class RelaySMTPServer(netius.servers.SMTPServer):
     """
-    Relay version of the smtp server that relays messages
+    Relay version of the SMTP server that relays messages
     that are not considered to be local to other servers.
 
-    The servers uses the default smtp client implementation
+    The servers uses the default SMTP client implementation
     to relay the messages.
     """
 
@@ -72,7 +72,7 @@ class RelaySMTPServer(netius.servers.SMTPServer):
 
         # retrieves the list or remote emails for each a relay
         # operation will have to be performed as requested by
-        # the current smtp specification (federation based)
+        # the current SMTP specification (federation based)
         remotes = self._remotes(to_l)
 
         # updates the current connection with the list of remote
@@ -126,7 +126,7 @@ class RelaySMTPServer(netius.servers.SMTPServer):
             raise netius.SecurityError("User is not allowed to relay from")
 
         # retrieves the current date value formatted according to
-        # the smtp based specification string value, this value
+        # the SMTP based specification string value, this value
         # is going to be used for the replacement of the header
         date = self.date()
 
@@ -161,7 +161,7 @@ class RelaySMTPServer(netius.servers.SMTPServer):
 
         # creates the callback that will close the client once the message
         # is sent to all the recipients (better auto close support), note
-        # that multiple smtp session may be created for the message so that
+        # that multiple SMTP session may be created for the message so that
         # all the hosts associated with the recipients are notified
         callback = lambda smtp_client: smtp_client.close()
 
@@ -172,7 +172,7 @@ class RelaySMTPServer(netius.servers.SMTPServer):
         callback_error = lambda smtp_client, context, exception:\
             self.relay_postmaster(reply_to, context, exception)
 
-        # generates a new smtp client for the sending of the message,
+        # generates a new SMTP client for the sending of the message,
         # uses the current host for identification and then triggers
         # the message event to send the message to the target host
         smtp_client = netius.clients.SMTPClient(host = self.host)

--- a/src/netius/servers/smtp.py
+++ b/src/netius/servers/smtp.py
@@ -335,6 +335,7 @@ class SMTPConnection(netius.Connection):
         self.auth(method, data)
 
     def on_mail(self, message):
+        self.reset_message()
         self.from_l.append(message)
         self.ok()
 
@@ -364,6 +365,11 @@ class SMTPConnection(netius.Connection):
             "by %s (netius) with ESMTP id %s" % (self.host, self.identifier) +\
             (" for %s" % to_s if for_s else "") +\
             "; %s" % date_s
+
+    def reset_message(self):
+        self.from_l = []
+        self.to_l = []
+        self.previous = bytes()
 
 class SMTPServer(netius.StreamServer):
 

--- a/src/netius/servers/smtp.py
+++ b/src/netius/servers/smtp.py
@@ -44,7 +44,7 @@ import datetime
 import netius.common
 
 INITIAL_STATE = 1
-""" The initial state for the smtp communication
+""" The initial state for the SMTP communication
 meaning that no message have been exchanged between
 the server and the client parties """
 
@@ -58,7 +58,7 @@ HEADER_STATE = 3
 the message to be sent is defined """
 
 DATA_STATE = 4
-""" Final stage of the smtp session where the message
+""" Final stage of the SMTP session where the message
 contents are sent over the connection """
 
 USERNAME_STATE = 5
@@ -73,7 +73,7 @@ this step proper authentication is possible under the
 login type of authentication """
 
 TERMINATION_SIZE = 5
-""" The size of the termination sequence of the smtp message
+""" The size of the termination sequence of the SMTP message
 this is going to be used in some parsing calculus, this value
 should be exposed so that it may be re-used by other modules """
 
@@ -82,7 +82,7 @@ CAPABILITIES = (
     "STARTTLS"
 )
 """ The sequence defining the various capabilities that are
-available under the current smtp server implementation, the
+available under the current SMTP server implementation, the
 description of these capabilities should conform with the rfp """
 
 class SMTPConnection(netius.Connection):


### PR DESCRIPTION
# Description

The lack of reset in the message `tos` and `froms` created duplicated email receipts.

Fixes #40 