### PR TITLE
Skip network tests via NO_NETWORK

### DIFF
--- a/src/netius/test/clients/http.py
+++ b/src/netius/test/clients/http.py
@@ -52,6 +52,7 @@ class HTTPClientTest(unittest.TestCase):
         unittest.TestCase.setUp(self)
         if appier.conf("NO_NETWORK", False, cast=bool):
             self.skipTest("Network access is disabled")
+
         self.httpbin = netius.conf("HTTPBIN", "httpbin.org")
 
     def test_simple(self):

--- a/src/netius/test/clients/http.py
+++ b/src/netius/test/clients/http.py
@@ -31,8 +31,6 @@ __license__ = "Apache License, Version 2.0"
 import json
 import unittest
 
-import netius
-
 import netius.clients
 
 

--- a/src/netius/test/clients/http.py
+++ b/src/netius/test/clients/http.py
@@ -31,17 +31,7 @@ __license__ = "Apache License, Version 2.0"
 import json
 import unittest
 
-try:
-    import appier
-except ImportError:  # pragma: no cover
-    import netius.mock
-
-    appier = netius.mock.appier
-
-if not hasattr(appier, "conf"):
-    import netius
-
-    appier.conf = netius.conf
+import netius
 
 import netius.clients
 
@@ -50,7 +40,7 @@ class HTTPClientTest(unittest.TestCase):
 
     def setUp(self):
         unittest.TestCase.setUp(self)
-        if appier.conf("NO_NETWORK", False, cast=bool):
+        if netius.conf("NO_NETWORK", False, cast=bool):
             self.skipTest("Network access is disabled")
 
         self.httpbin = netius.conf("HTTPBIN", "httpbin.org")

--- a/src/netius/test/clients/http.py
+++ b/src/netius/test/clients/http.py
@@ -31,6 +31,18 @@ __license__ = "Apache License, Version 2.0"
 import json
 import unittest
 
+try:
+    import appier
+except ImportError:  # pragma: no cover
+    import netius.mock
+
+    appier = netius.mock.appier
+
+if not hasattr(appier, "conf"):
+    import netius
+
+    appier.conf = netius.conf
+
 import netius.clients
 
 
@@ -38,6 +50,8 @@ class HTTPClientTest(unittest.TestCase):
 
     def setUp(self):
         unittest.TestCase.setUp(self)
+        if appier.conf("NO_NETWORK", False, cast=bool):
+            self.skipTest("Network access is disabled")
         self.httpbin = netius.conf("HTTPBIN", "httpbin.org")
 
     def test_simple(self):

--- a/src/netius/test/common/setup.py
+++ b/src/netius/test/common/setup.py
@@ -51,6 +51,7 @@ class CommonTest(unittest.TestCase):
     def test__download_ca(self):
         if appier.conf("NO_NETWORK", False, cast=bool):
             self.skipTest("Network access is disabled")
+
         netius.common.ensure_ca(path="test.ca")
         file = open("test.ca", "rb")
         try:

--- a/src/netius/test/common/setup.py
+++ b/src/netius/test/common/setup.py
@@ -31,17 +31,7 @@ __license__ = "Apache License, Version 2.0"
 import os
 import unittest
 
-try:
-    import appier
-except ImportError:  # pragma: no cover
-    import netius.mock
-
-    appier = netius.mock.appier
-
-if not hasattr(appier, "conf"):
-    import netius
-
-    appier.conf = netius.conf
+import netius
 
 import netius.common
 
@@ -49,7 +39,7 @@ import netius.common
 class CommonTest(unittest.TestCase):
 
     def test__download_ca(self):
-        if appier.conf("NO_NETWORK", False, cast=bool):
+        if netius.conf("NO_NETWORK", False, cast=bool):
             self.skipTest("Network access is disabled")
 
         netius.common.ensure_ca(path="test.ca")

--- a/src/netius/test/common/setup.py
+++ b/src/netius/test/common/setup.py
@@ -31,8 +31,6 @@ __license__ = "Apache License, Version 2.0"
 import os
 import unittest
 
-import netius
-
 import netius.common
 
 

--- a/src/netius/test/common/setup.py
+++ b/src/netius/test/common/setup.py
@@ -31,12 +31,26 @@ __license__ = "Apache License, Version 2.0"
 import os
 import unittest
 
+try:
+    import appier
+except ImportError:  # pragma: no cover
+    import netius.mock
+
+    appier = netius.mock.appier
+
+if not hasattr(appier, "conf"):
+    import netius
+
+    appier.conf = netius.conf
+
 import netius.common
 
 
 class CommonTest(unittest.TestCase):
 
     def test__download_ca(self):
+        if appier.conf("NO_NETWORK", False, cast=bool):
+            self.skipTest("Network access is disabled")
         netius.common.ensure_ca(path="test.ca")
         file = open("test.ca", "rb")
         try:


### PR DESCRIPTION
## Summary
- avoid network tests when `NO_NETWORK` is set
- skip CA download test when network is disabled
- use `appier.conf` to read the network configuration

## Testing
- `NO_NETWORK=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456bdee8548328a5e99924ac2636d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated test logic to automatically skip network-dependent tests when network access is disabled via configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->