### PR TITLE
Fix memory leaks in WSGI server and client agent

### DIFF
--- a/src/netius/base/agent.py
+++ b/src/netius/base/agent.py
@@ -125,9 +125,19 @@ class ClientAgent(Agent):
         client = cls._clients.get(tid, None)
         if client:
             return client
+        cls._reap_clients_s()
         client = cls(*args, **kwargs)
         cls._clients[tid] = client
         return client
+
+    @classmethod
+    def _reap_clients_s(cls):
+        live_tids = set(thread.ident for thread in threading.enumerate())
+        dead_tids = [tid for tid in cls._clients if tid not in live_tids]
+        for tid in dead_tids:
+            client = cls._clients.pop(tid, None)
+            if client:
+                client.cleanup()
 
     def connect(self, host, port, ssl=False, *args, **kwargs):
         """

--- a/src/netius/servers/wsgi.py
+++ b/src/netius/servers/wsgi.py
@@ -158,6 +158,11 @@ class WSGIServer(http2.HTTP2Server):
                 value = ";".join(value)
             environ[key] = value
 
+        # clears the parser's message data to avoid keeping a duplicate
+        # copy in memory while the request is being processed (the
+        # environ's `wsgi.input` already has a copy of the body)
+        parser.close()
+
         # verifies if the connection already has an iterator associated with
         # it, if that's the case the connection is already in use and the current
         # request processing must be delayed for future processing, this is
@@ -359,6 +364,10 @@ class WSGIServer(http2.HTTP2Server):
                 # the iteration on the overall async generator
                 else:
                     self.delay(lambda: self._send_part(connection), immediately=True)
+
+                # cleans up the future's callback lists to break the
+                # circular reference cycle between connection and future
+                future.cleanup()
 
             def on_ready():
                 return connection.wready

--- a/src/netius/test/base/agent.py
+++ b/src/netius/test/base/agent.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+import threading
+
+from netius.base.agent import ClientAgent
+
+
+class ClientAgentTest(unittest.TestCase):
+
+    def test_reap_clients_removes_dead_threads(self):
+        class MockClient(object):
+            def __init__(self):
+                self.cleaned = False
+
+            def cleanup(self):
+                self.cleaned = True
+
+        # simulate a dead thread entry by using a fake thread ID
+        # that does not correspond to any live thread
+        fake_tid = -9999
+        client = MockClient()
+        ClientAgent._clients[fake_tid] = client
+
+        ClientAgent._reap_clients_s()
+
+        self.assertEqual(client.cleaned, True)
+        self.assertNotIn(fake_tid, ClientAgent._clients)
+
+    def test_reap_clients_keeps_live_threads(self):
+        # the current thread is alive, so its entry should be kept
+        tid = threading.current_thread().ident
+        sentinel = object()
+        ClientAgent._clients[tid] = sentinel
+
+        ClientAgent._reap_clients_s()
+
+        self.assertIn(tid, ClientAgent._clients)
+        self.assertEqual(ClientAgent._clients[tid], sentinel)
+
+        # cleanup
+        del ClientAgent._clients[tid]
+
+    def test_reap_clients_empty_dict(self):
+        # should not raise when _clients is empty
+        original = ClientAgent._clients.copy()
+        ClientAgent._clients.clear()
+
+        ClientAgent._reap_clients_s()
+
+        self.assertEqual(len(ClientAgent._clients), 0)
+
+        # restore
+        ClientAgent._clients.update(original)

--- a/src/netius/test/servers/wsgi.py
+++ b/src/netius/test/servers/wsgi.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius
+
+
+class WSGIFutureTest(unittest.TestCase):
+
+    def test_future_cleanup_clears_callbacks(self):
+        future = netius.Future()
+        future.add_done_callback(lambda f: None)
+        future.add_partial_callback(lambda f, v: None)
+        future.add_ready_callback(lambda: None)
+        future.add_closed_callback(lambda: None)
+
+        self.assertEqual(len(future.done_callbacks), 1)
+        self.assertEqual(len(future.partial_callbacks), 1)
+        self.assertEqual(len(future.ready_callbacks), 1)
+        self.assertEqual(len(future.closed_callbacks), 1)
+
+        future.cleanup()
+
+        self.assertEqual(len(future.done_callbacks), 0)
+        self.assertEqual(len(future.partial_callbacks), 0)
+        self.assertEqual(len(future.ready_callbacks), 0)
+        self.assertEqual(len(future.closed_callbacks), 0)
+
+    def test_future_cleanup_breaks_reference_cycle(self):
+        future = netius.Future()
+
+        class FakeConnection(object):
+            def __init__(self):
+                self.future = None
+
+        connection = FakeConnection()
+        connection.future = future
+
+        # register callbacks that capture connection, simulating
+        # the closure cycle in the WSGI server's _send_part
+        future.add_done_callback(lambda f: setattr(connection, "future", None))
+        future.add_partial_callback(lambda f, v: None)
+
+        # after cleanup the callbacks should be cleared, breaking
+        # the reference from future back to connection
+        future.cleanup()
+
+        self.assertEqual(len(future.done_callbacks), 0)
+        self.assertEqual(len(future.partial_callbacks), 0)


### PR DESCRIPTION
## Summary

- **WSGI future closure cycle**: Call `future.cleanup()` after `on_done` processing to clear callback lists and break the circular reference between connection and future objects
- **Double request body in memory**: Call `parser.close()` after extracting the environ dict to release the parser's internal message buffers, since `wsgi.input` already holds a copy
- **ClientAgent dead thread accumulation**: Add `_reap_clients_s()` classmethod that evicts entries for terminated threads from `_clients` dict, called before creating new clients in `get_client_s()`

## Test plan

- [x] Unit tests for `Future.cleanup()` clearing all callback lists
- [x] Unit tests for `Future.cleanup()` breaking reference cycles
- [x] Unit tests for `_reap_clients_s()` removing dead thread entries and calling cleanup
- [x] Unit tests for `_reap_clients_s()` preserving live thread entries
- [x] Unit tests for `_reap_clients_s()` handling empty dict
- [x] All new tests pass (`python -m unittest`)
- [ ] Manual validation under concurrent WSGI load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of stale client connections from inactive threads to prevent memory leaks.
  * Enhanced resource cleanup in WSGI request handling to release parser and callback data properly.

* **Tests**
  * Added comprehensive test coverage for client cleanup routines and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->