### PR TITLE
feat: SMTP session deliverability info and subject decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* RFC 2047 encoded word subject decoding in `ActivityRelaySMTPServer` so that MIME-encoded subjects are posted as clean unicode strings
+* Per-domain SMTP session deliverability info (`sessions` list) in the activity webhook payload including remote host, port, greeting, queue response, duration and recipients
+* `greeting`, `queue_response` and `start_time` attributes on `SMTPConnection` (client) to capture remote server identification and delivery confirmation
+* `context` parameter passed to `callback` in `SMTPClient.message()` containing session deliverability data
 
 ### Changed
 
-*
+* Reordered `on_relay_smtp` and `on_relay_error_smtp` arguments to lead with `connection`, `context` (and `exception` for error) for consistency
 
 ### Fixed
 

--- a/src/netius/clients/smtp.py
+++ b/src/netius/clients/smtp.py
@@ -28,6 +28,7 @@ __copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
+import time
 import base64
 import datetime
 
@@ -89,11 +90,15 @@ class SMTPConnection(netius.Connection):
         self.sequence = ()
         self.capabilities = ()
         self.messages = []
+        self.greeting = None
+        self.queue_response = None
+        self.start_time = None
 
     def open(self, *args, **kwargs):
         netius.Connection.open(self, *args, **kwargs)
         if not self.is_open():
             return
+        self.start_time = time.time()
         self.parser = netius.common.SMTPParser(self)
         self.parser.bind("on_line", self.on_line)
         self.build()
@@ -263,10 +268,14 @@ class SMTPConnection(netius.Connection):
         self.call()
 
     def helo_t(self):
+        if self.greeting == None:
+            self.greeting = self.messages[0] if self.messages else None
         self.helo(self.host)
         self.next_sequence()
 
     def ehlo_t(self):
+        if self.greeting == None:
+            self.greeting = self.messages[0] if self.messages else None
         self.ehlo(self.host)
         self.next_sequence()
 
@@ -331,6 +340,7 @@ class SMTPConnection(netius.Connection):
         self.next_sequence()
 
     def quit_t(self):
+        self.queue_response = self.messages[0] if self.messages else None
         self.quit()
         self.next_sequence()
 
@@ -498,12 +508,19 @@ class SMTPClient(netius.StreamClient):
         if mark:
             contents = self.mark(contents)
 
+        # creates the shared sessions list that will accumulate
+        # deliverability information across all domain handlers
+        # for the current message relay operation
+        sessions = []
+
         # creates the method that is able to generate handler for a
         # certain sequence of to based (email) addresses
         def build_handler(tos, domain=None, tos_map=None):
 
             # creates the context object that will be used to pass
-            # contextual information to the callbacks
+            # contextual information to the callbacks, the sessions
+            # list is shared across all handlers for the same message
+            # and accumulates deliverability info per domain session
             context = dict(
                 froms=froms,
                 tos=tos,
@@ -513,11 +530,31 @@ class SMTPClient(netius.StreamClient):
                 ensure_loop=ensure_loop,
                 domain=domain,
                 tos_map=tos_map,
+                sessions=sessions,
             )
 
             def on_close(connection=None):
-                # verifies if the current handler has been build with a
-                # domain based clojure and if that's the case removes the
+                # captures the deliverability information from the
+                # SMTP session that has just completed, including the
+                # remote server greeting, queue response, session
+                # duration and the recipients for this session
+                if connection:
+                    end_time = time.time()
+                    start_time = getattr(connection, "start_time", None)
+                    duration = end_time - start_time if start_time else None
+                    session = dict(
+                        domain=domain,
+                        host=connection.address[0] if connection.address else None,
+                        port=connection.address[1] if connection.address else None,
+                        greeting=getattr(connection, "greeting", None),
+                        queue_response=getattr(connection, "queue_response", None),
+                        duration=duration,
+                        recipients=list(tos),
+                    )
+                    context["sessions"].append(session)
+
+                # verifies if the current handler has been built with a
+                # domain based closure and if that's the case removes the
                 # reference of it from the map of tos, then verifies if the
                 # map is still valid and if that's the case returns and this
                 # is not considered the last remaining SMTP session for the
@@ -527,11 +564,13 @@ class SMTPClient(netius.StreamClient):
                 if tos_map:
                     return
 
+                # stores the accumulated session information on the
+                # client instance so it can be accessed by the callback
                 # verifies if the callback method is defined and if that's
                 # the case calls the callback indicating the end of the send
                 # operation (note that this may represent multiple SMTP sessions)
                 if callback:
-                    callback(self)
+                    callback(self, context)
 
             def on_exception(connection=None, exception=None):
                 if callback_error:

--- a/src/netius/clients/smtp.py
+++ b/src/netius/clients/smtp.py
@@ -541,7 +541,7 @@ class SMTPClient(netius.StreamClient):
                 if connection:
                     end_time = time.time()
                     start_time = getattr(connection, "start_time", None)
-                    duration = end_time - start_time if start_time else None
+                    duration = end_time - start_time if not start_time == None else None
                     session = dict(
                         domain=domain,
                         host=connection.address[0] if connection.address else None,
@@ -564,8 +564,6 @@ class SMTPClient(netius.StreamClient):
                 if tos_map:
                     return
 
-                # stores the accumulated session information on the
-                # client instance so it can be accessed by the callback
                 # verifies if the callback method is defined and if that's
                 # the case calls the callback indicating the end of the send
                 # operation (note that this may represent multiple SMTP sessions)

--- a/src/netius/extra/smtp_a.py
+++ b/src/netius/extra/smtp_a.py
@@ -31,6 +31,8 @@ __license__ = "Apache License, Version 2.0"
 import json
 import time
 
+import email.header
+
 import netius.common
 import netius.clients
 
@@ -63,28 +65,31 @@ class ActivityRelaySMTPServer(smtp_r.RelaySMTPServer):
                 "Activity tracking enabled, posting to '%s' ...", self.activity_url
             )
 
-    def on_relay_smtp(self, smtp_client, connection, froms, tos, contents):
+    def on_relay_smtp(self, connection, context, smtp_client, froms, tos, contents):
         self.debug("Relay delivered from %s to %s", froms, tos)
-        self._post_activity(smtp_client, connection, froms, tos, contents, "delivered")
+        self._post_activity(
+            smtp_client, connection, context, froms, tos, contents, "delivered"
+        )
         smtp_r.RelaySMTPServer.on_relay_smtp(
-            self, smtp_client, connection, froms, tos, contents
+            self, connection, context, smtp_client, froms, tos, contents
         )
 
     def on_relay_error_smtp(
         self,
-        smtp_client,
         connection,
+        context,
+        exception,
+        smtp_client,
         froms,
         tos,
         contents,
         reply_to,
-        context,
-        exception,
     ):
         self.debug("Relay failed from %s to %s (%s)", froms, tos, str(exception))
         self._post_activity(
             smtp_client,
             connection,
+            context,
             froms,
             tos,
             contents,
@@ -93,18 +98,26 @@ class ActivityRelaySMTPServer(smtp_r.RelaySMTPServer):
         )
         smtp_r.RelaySMTPServer.on_relay_error_smtp(
             self,
-            smtp_client,
             connection,
+            context,
+            exception,
+            smtp_client,
             froms,
             tos,
             contents,
             reply_to,
-            context,
-            exception,
         )
 
     def _post_activity(
-        self, smtp_client, connection, froms, tos, contents, status, error=None
+        self,
+        smtp_client,
+        connection,
+        context,
+        froms,
+        tos,
+        contents,
+        status,
+        error=None,
     ):
         # in case no activity URL is defined the tracking is
         # disabled and the method returns immediately
@@ -135,6 +148,11 @@ class ActivityRelaySMTPServer(smtp_r.RelaySMTPServer):
         message_id = netius.legacy.str(message_id)
         username = getattr(connection, "username", None)
 
+        # decodes the subject value using the RFC 2047 encoded
+        # word format (eg: =?utf-8?q?Recupera=C3=A7=C3=A3o?=)
+        # so that the activity payload contains a clean string
+        subject = self._decode_header(subject)
+
         # converts the headers list of byte pairs into a dictionary
         # of string key-value pairs for JSON serialization and also
         # decodes the full contents as a string value
@@ -142,6 +160,11 @@ class ActivityRelaySMTPServer(smtp_r.RelaySMTPServer):
             (netius.legacy.str(key), netius.legacy.str(value)) for key, value in headers
         )
         contents_s = netius.legacy.str(contents)
+
+        # retrieves the accumulated session information from the
+        # relay context that contains deliverability details for each
+        # domain session (remote host, greeting, queue response, etc)
+        sessions = context.get("sessions", [])
 
         # builds the activity payload using the extracted values
         # and the relay context information
@@ -156,6 +179,7 @@ class ActivityRelaySMTPServer(smtp_r.RelaySMTPServer):
             status=status,
             server=self.host,
             username=username,
+            sessions=sessions,
         )
         if error:
             payload["error"] = error
@@ -203,6 +227,20 @@ class ActivityRelaySMTPServer(smtp_r.RelaySMTPServer):
                 self.activity_url,
                 str(exception),
             )
+
+    def _decode_header(self, value):
+        # decodes a MIME encoded word header value as defined
+        # in RFC 2047 into a plain unicode string, in case
+        # of any decoding error the original value is returned
+        try:
+            parts = email.header.decode_header(value)
+            decoded = "".join(
+                part.decode(encoding or "utf-8") if isinstance(part, bytes) else part
+                for part, encoding in parts
+            )
+            return decoded
+        except Exception:
+            return value
 
 
 if __name__ == "__main__":

--- a/src/netius/extra/smtp_r.py
+++ b/src/netius/extra/smtp_r.py
@@ -103,7 +103,7 @@ class RelaySMTPServer(netius.servers.SMTPServer):
         froms = self._emails(connection.from_l, prefix="from")
         self.relay(connection, froms, connection.remotes, data_s)
 
-    def on_relay_smtp(self, smtp_client, connection, froms, tos, contents):
+    def on_relay_smtp(self, connection, context, smtp_client, froms, tos, contents):
         # by default the relay operation is considered to be successful
         # and the client is closed once the message is sent to all the
         # recipients
@@ -111,14 +111,14 @@ class RelaySMTPServer(netius.servers.SMTPServer):
 
     def on_relay_error_smtp(
         self,
-        smtp_client,
         connection,
+        context,
+        exception,
+        smtp_client,
         froms,
         tos,
         contents,
         reply_to,
-        context,
-        exception,
     ):
         # in case of error a postmaster email is sent to the reply
         # to address with the details of the error, the client
@@ -181,8 +181,8 @@ class RelaySMTPServer(netius.servers.SMTPServer):
         # is sent to all the recipients (better auto close support), note
         # that multiple SMTP session may be created for the message so that
         # all the hosts associated with the recipients are notified
-        callback = lambda smtp_client: self.on_relay_smtp(
-            smtp_client, connection, froms, tos, contents
+        callback = lambda smtp_client, context: self.on_relay_smtp(
+            connection, context, smtp_client, froms, tos, contents
         )
 
         # creates the callback to the error as a function that sends a
@@ -191,14 +191,14 @@ class RelaySMTPServer(netius.servers.SMTPServer):
         # address defined as postmaster for this SMTP server
         callback_error = (
             lambda smtp_client, context, exception: self.on_relay_error_smtp(
-                smtp_client,
                 connection,
+                context,
+                exception,
+                smtp_client,
                 froms,
                 tos,
                 contents,
                 reply_to,
-                context,
-                exception,
             )
         )
 


### PR DESCRIPTION
## Summary

- Captures per-domain SMTP session deliverability data: remote host, port, server greeting (220 banner), queue response (250 confirmation), session duration, and per-session recipients
- Passes `context` (including `sessions` list) to the relay success callback so `ActivityRelaySMTPServer` can include it in the webhook payload without storing state on the client
- Decodes RFC 2047 MIME-encoded subjects (e.g. `=?utf-8?q?Recupera=C3=A7=C3=A3o?=`) into clean unicode strings before posting
- Reorders `on_relay_smtp` and `on_relay_error_smtp` arguments to lead with `connection`, `context` for consistency

## Test plan

- [x] Verify existing SMTP relay tests pass (`pytest -k "smtp or dns"`)
- [ ] Send an email with non-ASCII subject through the relay and verify decoded subject in mailog
- [ ] Send to recipients on multiple domains and verify separate session entries in the webhook payload
- [ ] Verify session data includes greeting, queue_response, duration, host, port, recipients

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity webhooks now include per-domain SMTP session deliverability details (session list).
  * Enhanced SMTP session tracking: connection greeting, server queue response, start time/duration, and recipient info are captured.
  * Improved RFC 2047 encoded-word decoding for email Subject headers.

* **Changed**
  * Relay event callback parameter ordering changed (callbacks now receive session context alongside connection info).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->