### PR TITLE
feat: add sequential mode for SMTP MX sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Sequential MX session mode for SMTP client (`sequential` parameter in `message()`), establishes one connection at a time per MX host to reduce pressure on remote servers that drop concurrent connections from the same source
 
 ### Changed
 

--- a/src/netius/clients/smtp.py
+++ b/src/netius/clients/smtp.py
@@ -931,6 +931,11 @@ class SMTPClient(netius.StreamClient):
             # each connection starting only after the previous completes
             mx_entries = netius.legacy.items(mx_map)
 
+            # in sequential mode the connections are established one
+            # at a time, each starting only after the previous one
+            # completes, reducing pressure on remote MX servers that
+            # may drop concurrent connections from the same source,
+            # in parallel mode all connections are started immediately
             if sequential:
                 _connect_next_mx(mx_entries, tos_map)
             else:

--- a/src/netius/clients/smtp.py
+++ b/src/netius/clients/smtp.py
@@ -926,26 +926,6 @@ class SMTPClient(netius.StreamClient):
                         )
                     return
 
-            def _connect_next_mx(pending, tos_map):
-                # in case there are no more pending MX entries returns
-                # immediately as all connections have been processed
-                if not pending:
-                    return
-
-                # retrieves the next MX entry from the pending list
-                # and establishes the connection for it
-                mx_key, (tos, _domains) = pending[0]
-                remaining = pending[1:]
-                connect_mx = build_handler(tos, domain=mx_key, tos_map=tos_map)
-                connection = connect_mx(mx_key, _tos=tos)
-
-                # binds an additional close handler that triggers the
-                # next connection once the current one completes
-                connection.bind(
-                    "close",
-                    lambda connection=None: _connect_next_mx(remaining, tos_map),
-                )
-
             # retrieves the list of MX entries to be processed, in
             # sequential mode these are processed one at a time with
             # each connection starting only after the previous completes
@@ -957,6 +937,26 @@ class SMTPClient(netius.StreamClient):
                 for mx_key, (tos, _domains) in mx_entries:
                     connect_mx = build_handler(tos, domain=mx_key, tos_map=tos_map)
                     connect_mx(mx_key, _tos=tos)
+
+        def _connect_next_mx(pending, tos_map):
+            # in case there are no more pending MX entries returns
+            # immediately as all connections have been processed
+            if not pending:
+                return
+
+            # retrieves the next MX entry from the pending list
+            # and establishes the connection for it
+            mx_key, (tos, _domains) = pending[0]
+            remaining = pending[1:]
+            connect_mx = build_handler(tos, domain=mx_key, tos_map=tos_map)
+            connection = connect_mx(mx_key, _tos=tos)
+
+            # binds an additional close handler that triggers the
+            # next connection once the current one completes
+            connection.bind(
+                "close",
+                lambda connection=None: _connect_next_mx(remaining, tos_map),
+            )
 
         # iterates over the complete set of domains to run the MX
         # based query operation collecting the results

--- a/src/netius/clients/smtp.py
+++ b/src/netius/clients/smtp.py
@@ -520,6 +520,7 @@ class SMTPClient(netius.StreamClient):
         mark=True,
         comply=False,
         ensure_loop=True,
+        sequential=True,
         callback=None,
         callback_error=None,
     ):
@@ -608,6 +609,12 @@ class SMTPClient(netius.StreamClient):
         required for standalone usage where no event loop is running
         yet. Should be disabled when the client is already running
         within an active event loop.
+        :type sequential: bool
+        :param sequential: If True the SMTP connections to different
+        MX hosts are established one at a time, waiting for each
+        session to complete before starting the next. This reduces
+        pressure on remote servers that may drop concurrent connections
+        from the same source IP. Defaults to False (parallel).
         :type callback: Callable
         :param callback: Optional callback invoked once all SMTP
         sessions for this message have completed. Called with
@@ -919,11 +926,37 @@ class SMTPClient(netius.StreamClient):
                         )
                     return
 
-            # iterates over the unique MX hosts establishing a single
-            # connection per host with all the associated recipients
-            for mx_key, (tos, _domains) in netius.legacy.items(mx_map):
+            def _connect_next_mx(pending, tos_map):
+                # in case there are no more pending MX entries returns
+                # immediately as all connections have been processed
+                if not pending:
+                    return
+
+                # retrieves the next MX entry from the pending list
+                # and establishes the connection for it
+                mx_key, (tos, _domains) = pending[0]
+                remaining = pending[1:]
                 connect_mx = build_handler(tos, domain=mx_key, tos_map=tos_map)
-                connect_mx(mx_key, _tos=tos)
+                connection = connect_mx(mx_key, _tos=tos)
+
+                # binds an additional close handler that triggers the
+                # next connection once the current one completes
+                connection.bind(
+                    "close",
+                    lambda connection=None: _connect_next_mx(remaining, tos_map),
+                )
+
+            # retrieves the list of MX entries to be processed, in
+            # sequential mode these are processed one at a time with
+            # each connection starting only after the previous completes
+            mx_entries = netius.legacy.items(mx_map)
+
+            if sequential:
+                _connect_next_mx(mx_entries, tos_map)
+            else:
+                for mx_key, (tos, _domains) in mx_entries:
+                    connect_mx = build_handler(tos, domain=mx_key, tos_map=tos_map)
+                    connect_mx(mx_key, _tos=tos)
 
         # iterates over the complete set of domains to run the MX
         # based query operation collecting the results

--- a/src/netius/clients/smtp.py
+++ b/src/netius/clients/smtp.py
@@ -614,7 +614,7 @@ class SMTPClient(netius.StreamClient):
         MX hosts are established one at a time, waiting for each
         session to complete before starting the next. This reduces
         pressure on remote servers that may drop concurrent connections
-        from the same source IP. Defaults to False (parallel).
+        from the same source IP. Defaults to True (sequential).
         :type callback: Callable
         :param callback: Optional callback invoked once all SMTP
         sessions for this message have completed. Called with

--- a/src/netius/test/clients/smtp.py
+++ b/src/netius/test/clients/smtp.py
@@ -221,6 +221,7 @@ class SMTPClientTest(unittest.TestCase):
             ],
             "test contents",
             mark=False,
+            sequential=False,
         )
 
         self.assertEqual(len(self.connections), 2)

--- a/src/netius/test/clients/smtp.py
+++ b/src/netius/test/clients/smtp.py
@@ -336,6 +336,71 @@ class SMTPClientTest(unittest.TestCase):
         self.assertEqual(len(self.connections), 1)
         self.assertEqual(len(self.connections[0].tos), 2)
 
+    def test_message_sequential_one_at_a_time(self):
+        self._build_mock_dns(unique=True)
+
+        client = self._build_client()
+        client.message(
+            ["sender@example.com"],
+            [
+                "user1@domain-a.com",
+                "user2@domain-b.com",
+                "user3@domain-c.com",
+            ],
+            "test contents",
+            mark=False,
+            sequential=True,
+        )
+
+        self.assertEqual(len(self.connections), 1)
+
+        self.connections[0].trigger("close", self.connections[0])
+        self.assertEqual(len(self.connections), 2)
+
+        self.connections[1].trigger("close", self.connections[1])
+        self.assertEqual(len(self.connections), 3)
+
+    def test_message_sequential_all_recipients(self):
+        self._build_mock_dns(unique=True)
+
+        client = self._build_client()
+        client.message(
+            ["sender@example.com"],
+            [
+                "user1@domain-a.com",
+                "user2@domain-b.com",
+            ],
+            "test contents",
+            mark=False,
+            sequential=True,
+        )
+
+        self.assertEqual(len(self.connections), 1)
+
+        self.connections[0].trigger("close", self.connections[0])
+        self.assertEqual(len(self.connections), 2)
+
+        hosts = set(netius.legacy.str(c.host) for c in self.connections)
+        self.assertEqual(hosts, {"mx.domain-a.com", "mx.domain-b.com"})
+
+    def test_message_parallel_all_at_once(self):
+        self._build_mock_dns(unique=True)
+
+        client = self._build_client()
+        client.message(
+            ["sender@example.com"],
+            [
+                "user1@domain-a.com",
+                "user2@domain-b.com",
+                "user3@domain-c.com",
+            ],
+            "test contents",
+            mark=False,
+            sequential=False,
+        )
+
+        self.assertEqual(len(self.connections), 3)
+
     def _build_client(self):
         client = netius.clients.SMTPClient()
         self.clients.append(client)
@@ -373,6 +438,14 @@ class _MockSMTPConnection(object):
         self.contents = None
         self.mx_host = None
         self.sequence = None
+        self.address = (host, port)
+        self.start_time = None
+        self.greeting = None
+        self.queue_response = None
+        self.capabilities = []
+        self.tls_version = None
+        self.tls_cipher = None
+        self.transcript = []
         self._bindings = {}
 
     def set_message_seq(self, ehlo=True):
@@ -387,4 +460,11 @@ class _MockSMTPConnection(object):
         self.contents = contents
 
     def bind(self, event, callback):
-        self._bindings[event] = callback
+        methods = self._bindings.get(event, [])
+        methods.append(callback)
+        self._bindings[event] = methods
+
+    def trigger(self, name, *args, **kwargs):
+        methods = self._bindings.get(name, [])
+        for method in methods:
+            method(*args, **kwargs)


### PR DESCRIPTION
## Summary

- Add `sequential` parameter to `SMTPClient.message()` controlling whether SMTP connections to different MX hosts are established in parallel or one at a time
- When `sequential=True` (default), each connection waits for the previous one to complete before starting the next, reducing pressure on remote servers
- Addresses Google MX servers silently dropping concurrent connections from the same source IP, which caused email loss

### How it works

In `initiate_mx()`, when sequential mode is enabled, a `_connect_next_mx` function processes MX entries one at a time. After the first connection is established, an additional `close` event handler is bound that triggers the next connection when the current one completes. The existing `on_close` handler from `build_handler` still fires normally for session tracking and completion.

### Changes

- **`SMTPClient.message()`** — new `sequential=True` parameter
- **`initiate_mx()`** — conditional parallel vs sequential connection initiation via `_connect_next_mx`
- **`_MockSMTPConnection`** — added missing connection attributes and proper `bind`/`trigger` methods matching the observer pattern

## Test plan

- [x] All 359 tests pass
- [x] `test_message_sequential_one_at_a_time` — verifies only one connection exists until close triggers the next
- [x] `test_message_sequential_all_recipients` — verifies all MX hosts are reached sequentially
- [x] `test_message_parallel_all_at_once` — verifies parallel mode still opens all connections immediately
- [ ] Deploy to production and verify multi-domain email delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * **Sequential MX Session Mode for SMTP Client** – Added a new option to SMTP message sending that controls whether MX host connections are established sequentially (one at a time, now the default) or in parallel, giving finer control over delivery behavior.

* **Tests**
  * Expanded tests to cover the new sequential MX behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->