### PR TITLE
fix: properly close diag server socket on cleanup and reload

### DIFF
--- a/src/netius/base/common.py
+++ b/src/netius/base/common.py
@@ -1884,6 +1884,10 @@ class AbstractBase(observer.Observable):
         return self.poll.unsub_error(socket)
 
     def cleanup(self, destroy=True):
+        # stops the diagnostics application if it's currently running
+        # releasing the bound socket and associated resources
+        self.unload_diag()
+
         # runs the unload operation for the current base container this should
         # unset/unload some of the components for this base infra-structure
         self.unload()
@@ -1900,10 +1904,6 @@ class AbstractBase(observer.Observable):
         del self._delayed[:]
         del self._delayed_o[:]
         del self._delayed_n[:]
-
-        # stops the diagnostics application if it's currently running
-        # releasing the bound socket and associated resources
-        self.unload_diag()
 
         # runs the expand destroy operation so that the complete set of expanded
         # values get their (temporary) files removed (garbage collection)

--- a/src/netius/base/common.py
+++ b/src/netius/base/common.py
@@ -1509,6 +1509,12 @@ class AbstractBase(observer.Observable):
         if not self.diag:
             return
 
+        # in case there's already a diagnostics application running
+        # stops it before creating a new one to avoid socket binding
+        # conflicts (address already in use)
+        if self.diag_app:
+            self.unload_diag()
+
         # runs the import operations for the diag module, note that
         # this must be performed locally no avoid any unwanted behavior
         # or collision with a runtime process (would pose issues)
@@ -1540,6 +1546,21 @@ class AbstractBase(observer.Observable):
         self.diag_app.serve(
             server=server, host=host, port=port, diag=False, threaded=True, conf=False
         )
+
+    def unload_diag(self):
+        # verifies if there's a valid diagnostics application
+        # currently running and if not returns immediately
+        if not self.diag_app:
+            return
+
+        # stops the diagnostics application by refraining its
+        # underlying server, this will release the bound socket
+        # allowing a new diagnostics app to bind to the same port
+        try:
+            self.diag_app.refrain()
+        except Exception:
+            pass
+        self.diag_app = None
 
     def load_middleware(self, suffix="Middleware"):
         # iterates over the complete set of string that define the middleware
@@ -1879,6 +1900,10 @@ class AbstractBase(observer.Observable):
         del self._delayed[:]
         del self._delayed_o[:]
         del self._delayed_n[:]
+
+        # stops the diagnostics application if it's currently running
+        # releasing the bound socket and associated resources
+        self.unload_diag()
 
         # runs the expand destroy operation so that the complete set of expanded
         # values get their (temporary) files removed (garbage collection)

--- a/src/netius/base/common.py
+++ b/src/netius/base/common.py
@@ -1558,8 +1558,8 @@ class AbstractBase(observer.Observable):
         # allowing a new diagnostics app to bind to the same port
         try:
             self.diag_app.refrain()
-        except Exception:
-            pass
+        except Exception as exception:
+            self.warning("Problem unloading diagnostics application: %s", exception)
         self.diag_app = None
 
     def load_middleware(self, suffix="Middleware"):


### PR DESCRIPTION
## Summary

- Fix diagnostics server socket leak that causes `OSError: [Errno 98] Address already in use` during rolling deploys and server restarts
- Add `unload_diag()` method for proper diag server lifecycle management
- Call it from both `load_diag()` (guard) and `cleanup()` (shutdown)

### Root cause

The diag server runs in a daemon thread via `appier.serve(threaded=True)`. Two scenarios leaked the socket:

1. **Shutdown**: `cleanup()` never stopped the diag app, so the socket remained bound until the process exited
2. **Reload guard**: `load_diag()` had no check for an existing `diag_app` — if called again, the old app's socket was leaked

This is particularly visible with Nomad rolling deploys on host networking, where old and new allocations briefly overlap and both try to bind port 5050.

### Changes

- **`unload_diag()`** — new method that stops the diag app via `refrain()`, releasing the bound socket, then clears the reference
- **`load_diag()`** — guard added to stop existing diag app before creating a new one
- **`cleanup()`** — calls `unload_diag()` matching the existing pattern for npool/tpool/fpool

## Test plan

- [x] All 362 tests pass
- [x] Verified diag server starts correctly after fix
- [ ] Deploy and verify no `Address already in use` errors during rolling deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)