### PR TITLE
fix: address proxy compat audit findings

### DIFF
--- a/src/netius/base/mixin.py
+++ b/src/netius/base/mixin.py
@@ -128,6 +128,31 @@ class ConnectionCompat(object):
             return
         connection.enable_read()
 
+    def bind(self, name, method, *args, **kwargs):
+        connection = self.connection
+        if not connection:
+            return
+        connection.bind(name, method, *args, **kwargs)
+
+    def unbind(self, name, method=None):
+        connection = self.connection
+        if not connection:
+            return
+        connection.unbind(name, method=method)
+
+    def trigger(self, name, *args, **kwargs):
+        connection = self.connection
+        if not connection:
+            return
+        connection.trigger(name, *args, **kwargs)
+
+    @property
+    def pending_s(self):
+        connection = self.connection
+        if connection:
+            return connection.pending_s
+        return 0
+
     @property
     def max_pending(self):
         connection = self.connection

--- a/src/netius/base/transport.py
+++ b/src/netius/base/transport.py
@@ -197,9 +197,7 @@ class Transport(observer.Observable):
             compression=lambda: _safe_socket_call("compression"),
             cipher=lambda: _safe_socket_call("cipher"),
             peercert=lambda: _safe_socket_call("getpeercert"),
-            sslcontext=lambda: (
-                getattr(_safe_socket(), "context", None)
-            ),
+            sslcontext=lambda: (getattr(_safe_socket(), "context", None)),
             ssl_object=_safe_socket,
         )
 

--- a/src/netius/base/transport.py
+++ b/src/netius/base/transport.py
@@ -173,19 +173,34 @@ class Transport(observer.Observable):
         self._connection.min_pending = low
 
     def set_extra_dict(self):
+        def _safe_socket():
+            if not self._connection:
+                return None
+            return self._connection.socket
+
+        def _safe_socket_call(method):
+            _socket = _safe_socket()
+            if not _socket:
+                return None
+            _method = getattr(_socket, method, None)
+            if not _method:
+                return None
+            try:
+                return _method()
+            except Exception:
+                return None
+
         self._extra_dict = dict(
-            socket=lambda: self._connection.socket,
-            peername=lambda: self._connection.socket.getpeername(),
-            sockname=lambda: self._connection.socket.getsockname(),
-            compression=lambda: self._connection.socket.compression(),
-            cipher=lambda: self._connection.socket.cipher(),
-            peercert=lambda: self._connection.socket.getpeercert(),
+            socket=_safe_socket,
+            peername=lambda: _safe_socket_call("getpeername"),
+            sockname=lambda: _safe_socket_call("getsockname"),
+            compression=lambda: _safe_socket_call("compression"),
+            cipher=lambda: _safe_socket_call("cipher"),
+            peercert=lambda: _safe_socket_call("getpeercert"),
             sslcontext=lambda: (
-                self._connection.socket.context
-                if hasattr(self._connection.socket, "context")
-                else None
+                getattr(_safe_socket(), "context", None)
             ),
-            ssl_object=lambda: self._connection.socket,
+            ssl_object=_safe_socket,
         )
 
     def get_protocol(self):

--- a/src/netius/servers/proxy.py
+++ b/src/netius/servers/proxy.py
@@ -386,8 +386,10 @@ class ProxyServer(http2.HTTP2Server):
         # and then uses the resolved value as the key, notice that
         # in case the connection is in a final closing flush state
         # (graceful closing) the connection mapping may have already
-        # been removed (requires early return)
-        _connection_key = getattr(_connection, "_protocol", _connection)
+        # been removed (requires early return), the lookup tries the
+        # protocol first (transport case) then the connection itself
+        _connection_key = getattr(_connection, "_protocol", None)
+        _connection_key = _connection_key or _connection
         if not _connection_key in self.conn_map:
             return
         connection = self.conn_map[_connection_key]

--- a/src/netius/test/base/mixin.py
+++ b/src/netius/test/base/mixin.py
@@ -117,6 +117,36 @@ class ConnectionCompatTest(unittest.TestCase):
         self.compat.enable_read()
         self.assertEqual(self.connection._read_disabled, False)
 
+    def test_bind(self):
+        results = []
+        self.compat.bind("test", lambda c: results.append(c))
+        self.connection.trigger("test", self.connection)
+        self.assertEqual(len(results), 1)
+
+    def test_bind_no_connection(self):
+        self.compat_none.bind("test", lambda c: None)
+
+    def test_unbind(self):
+        callback = lambda c: None
+        self.compat.bind("test", callback)
+        self.compat.unbind("test", callback)
+
+    def test_trigger(self):
+        results = []
+        self.connection.bind("test", lambda c: results.append(c))
+        self.compat.trigger("test", self.connection)
+        self.assertEqual(len(results), 1)
+
+    def test_trigger_no_connection(self):
+        self.compat_none.trigger("test")
+
+    def test_pending_s(self):
+        self.connection.pending_s = 1024
+        self.assertEqual(self.compat.pending_s, 1024)
+
+    def test_pending_s_no_connection(self):
+        self.assertEqual(self.compat_none.pending_s, 0)
+
     def test_max_pending(self):
         self.connection.max_pending = 65536
         self.assertEqual(self.compat.max_pending, 65536)
@@ -216,12 +246,14 @@ class _MockConnection(object):
         self.address = None
         self.status = 0
         self.renable = True
+        self.pending_s = 0
         self.max_pending = -1
         self.min_pending = -1
         self._throttleable = False
         self._exhausted = False
         self._restored = True
         self._read_disabled = False
+        self._events = {}
 
     def is_throttleable(self):
         return self._throttleable
@@ -237,6 +269,22 @@ class _MockConnection(object):
 
     def enable_read(self):
         self._read_disabled = False
+
+    def bind(self, name, method, *args, **kwargs):
+        methods = self._events.get(name, [])
+        methods.append(method)
+        self._events[name] = methods
+
+    def unbind(self, name, method=None):
+        if method:
+            methods = self._events.get(name, [])
+            methods.remove(method)
+        else:
+            self._events.pop(name, None)
+
+    def trigger(self, name, *args, **kwargs):
+        for method in self._events.get(name, []):
+            method(*args, **kwargs)
 
 
 class _MockCompat(ConnectionCompat):


### PR DESCRIPTION
## Summary

Fixes compatibility gaps found during a deep audit of Connection vs Protocol usage in the proxy codebase. Ref: #59

### Changes

**ConnectionCompat mixin (`mixin.py`):**
- Add `pending_s` property — delegates to `connection.pending_s`, required by `Transport.get_write_buffer_size()` for flow control
- Add `bind()`, `unbind()`, `trigger()` methods — delegate to the underlying connection's observer interface, required by `Transport.set_handlers()` for pend/unpend flow control events

**Transport (`transport.py`):**
- Safeguard `set_extra_dict()` lambdas against closed connections and missing socket attributes — prevents crashes when `get_extra_info()` is called after the connection has been closed

**Proxy (`proxy.py`):**
- Fix `_throttle()` getattr fallback — use `None` instead of `_connection` as the default for `_protocol` lookup, preventing self-reference as `conn_map` key when the attribute is not present

**Tests (`test/base/mixin.py`):**
- Add `bind`, `unbind`, `trigger`, `pending_s` tests to the mixin test suite (7 new tests)

## Test plan

- [x] All 411 tests pass
- [x] Zero orphan connections in production after prior fixes
- [ ] Deploy and verify flow control still works under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when handling missing or closed connections to prevent runtime errors.
  * Enhanced event handling system with reliable lifecycle management and callback registration.

* **Tests**
  * Added comprehensive test coverage for event binding, unbinding, and triggering mechanisms.
  * Expanded test scenarios for connection resilience and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->