### PR TITLE
fix(http2): sync HPACK encoder/decoder table sizes with SETTINGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * `HTTP2Parser.parse` now flushes zero-length payload frames (eg: SETTINGS with the ACK flag, DATA with END_STREAM and no body) instead of leaving the parser stuck in `PAYLOAD_STATE` until subsequent bytes arrive
+* `HTTP2Parser` now syncs the HPACK encoder / decoder dynamic table sizes with `SETTINGS_HEADER_TABLE_SIZE` — the encoder is bounded by the peer's advertised value and the decoder caps `max_allowed_table_size` at our own; `HTTP2Connection.set_settings` propagates peer-driven changes to the live encoder, fixing a latent interop bug where the encoder could emit indices outside the peer's table window
 
 ## [1.55.0] - 2026-04-29
 

--- a/src/netius/base/transport.py
+++ b/src/netius/base/transport.py
@@ -159,7 +159,7 @@ class Transport(observer.Observable):
         before the connection send buffer is unblocked.
         """
 
-        if high is None:
+        if high == None:
             if low == None:
                 high = 65536
             else:

--- a/src/netius/common/http2.py
+++ b/src/netius/common/http2.py
@@ -888,6 +888,9 @@ class HTTP2Parser(parser.Parser):
         import hpack
 
         self._encoder = hpack.hpack.Encoder()
+        self._encoder.header_table_size = self.owner.settings_r[
+            SETTINGS_HEADER_TABLE_SIZE
+        ]
         return self._encoder
 
     @property
@@ -897,6 +900,9 @@ class HTTP2Parser(parser.Parser):
         import hpack
 
         self._decoder = hpack.hpack.Decoder()
+        self._decoder.max_allowed_table_size = self.owner.settings[
+            SETTINGS_HEADER_TABLE_SIZE
+        ]
         return self._decoder
 
 

--- a/src/netius/servers/http2.py
+++ b/src/netius/servers/http2.py
@@ -727,6 +727,18 @@ class HTTP2Connection(http.HTTPConnection):
     def set_settings(self, settings):
         self.settings_r.update(settings)
 
+        # propagates a peer-driven `SETTINGS_HEADER_TABLE_SIZE` change
+        # to the HPACK encoder so the dynamic table stays bounded by
+        # the value the peer is willing to accept (RFC 7541 §6.3)
+        if (
+            netius.common.http2.SETTINGS_HEADER_TABLE_SIZE in settings
+            and self.parser
+            and not self.legacy
+        ):
+            self.parser.encoder.header_table_size = settings[
+                netius.common.http2.SETTINGS_HEADER_TABLE_SIZE
+            ]
+
     def close_stream(self, stream, final=False, flush=False, reset=False):
         if not self.parser._has_stream(stream):
             return

--- a/src/netius/servers/http2.py
+++ b/src/netius/servers/http2.py
@@ -729,13 +729,17 @@ class HTTP2Connection(http.HTTPConnection):
 
         # propagates a peer-driven `SETTINGS_HEADER_TABLE_SIZE` change
         # to the HPACK encoder so the dynamic table stays bounded by
-        # the value the peer is willing to accept (RFC 7541 §6.3)
+        # the value the peer is willing to accept (RFC 7541 §6.3); only
+        # touches an already-initialized encoder so connections that
+        # never send headers don't pay the lazy-init cost — the lazy
+        # property reads `settings_r` on first access anyway
         if (
             netius.common.http2.SETTINGS_HEADER_TABLE_SIZE in settings
             and self.parser
             and not self.legacy
+            and not self.parser._encoder == None
         ):
-            self.parser.encoder.header_table_size = settings[
+            self.parser._encoder.header_table_size = settings[
                 netius.common.http2.SETTINGS_HEADER_TABLE_SIZE
             ]
 

--- a/src/netius/test/common/http2.py
+++ b/src/netius/test/common/http2.py
@@ -33,6 +33,11 @@ import unittest
 
 import netius.common
 
+try:
+    import hpack
+except ImportError:
+    hpack = None
+
 
 def _pack_frame(type, flags=0x00, stream=0x00, payload=b""):
     size = len(payload)
@@ -396,6 +401,8 @@ class HTTP2ParserTest(unittest.TestCase):
             parser.clear(force=True)
 
     def test_encoder(self):
+        if hpack == None:
+            self.skipTest("Skipping test: hpack unavailable")
         self.settings_r[netius.common.http2.SETTINGS_HEADER_TABLE_SIZE] = 8192
         parser = netius.common.HTTP2Parser(self, store=True)
         try:
@@ -404,6 +411,8 @@ class HTTP2ParserTest(unittest.TestCase):
             parser.clear(force=True)
 
     def test_decoder(self):
+        if hpack == None:
+            self.skipTest("Skipping test: hpack unavailable")
         self.settings[netius.common.http2.SETTINGS_HEADER_TABLE_SIZE] = 16384
         parser = netius.common.HTTP2Parser(self, store=True)
         try:

--- a/src/netius/test/common/http2.py
+++ b/src/netius/test/common/http2.py
@@ -67,6 +67,7 @@ class HTTP2ParserTest(unittest.TestCase):
 
     def setUp(self):
         self.settings = dict(netius.common.HTTP2_SETTINGS_OPTIMAL)
+        self.settings_r = dict(netius.common.HTTP2_SETTINGS)
         self.window = netius.common.HTTP2_WINDOW
 
     def test_assert_header(self):
@@ -391,5 +392,21 @@ class HTTP2ParserTest(unittest.TestCase):
             stream, increment = events[0]
             self.assertEqual(stream, None)
             self.assertEqual(increment, 4096)
+        finally:
+            parser.clear(force=True)
+
+    def test_encoder(self):
+        self.settings_r[netius.common.http2.SETTINGS_HEADER_TABLE_SIZE] = 8192
+        parser = netius.common.HTTP2Parser(self, store=True)
+        try:
+            self.assertEqual(parser.encoder.header_table_size, 8192)
+        finally:
+            parser.clear(force=True)
+
+    def test_decoder(self):
+        self.settings[netius.common.http2.SETTINGS_HEADER_TABLE_SIZE] = 16384
+        parser = netius.common.HTTP2Parser(self, store=True)
+        try:
+            self.assertEqual(parser.decoder.max_allowed_table_size, 16384)
         finally:
             parser.clear(force=True)

--- a/src/netius/test/servers/http2.py
+++ b/src/netius/test/servers/http2.py
@@ -30,7 +30,14 @@ __license__ = "Apache License, Version 2.0"
 
 import unittest
 
+import netius.common
 import netius.servers
+import netius.servers.http2
+
+try:
+    import hpack
+except ImportError:
+    hpack = None
 
 
 class HTTP2ServerTest(unittest.TestCase):
@@ -74,3 +81,43 @@ class HTTP2ServerTest(unittest.TestCase):
             self.assertEqual(protocols, ["h2", "http/1.1", "http/1.0"])
         else:
             self.assertEqual(protocols, ["http/1.1", "http/1.0"])
+
+
+class HTTP2ConnectionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.settings = dict(netius.common.HTTP2_SETTINGS_OPTIMAL)
+        self.settings_r = dict(netius.common.HTTP2_SETTINGS)
+        self.window = netius.common.HTTP2_WINDOW
+
+    def test_set_settings(self):
+        if hpack == None:
+            self.skipTest("Skipping test: hpack unavailable")
+
+        connection = netius.servers.http2.HTTP2Connection.__new__(
+            netius.servers.http2.HTTP2Connection
+        )
+        connection.legacy = False
+        connection.settings_r = self.settings_r
+        connection.parser = netius.common.HTTP2Parser(self, store=True)
+
+        try:
+            self.assertEqual(connection.parser._encoder, None)
+
+            connection.set_settings(
+                {netius.common.http2.SETTINGS_HEADER_TABLE_SIZE: 8192}
+            )
+            self.assertEqual(connection.parser._encoder, None)
+            self.assertEqual(
+                connection.settings_r[netius.common.http2.SETTINGS_HEADER_TABLE_SIZE],
+                8192,
+            )
+
+            self.assertEqual(connection.parser.encoder.header_table_size, 8192)
+
+            connection.set_settings(
+                {netius.common.http2.SETTINGS_HEADER_TABLE_SIZE: 16384}
+            )
+            self.assertEqual(connection.parser._encoder.header_table_size, 16384)
+        finally:
+            connection.parser.clear(force=True)


### PR DESCRIPTION
## Summary

- **Encoder** (`HTTP2Parser.encoder`) caps `header_table_size` at the value the peer advertised in `SETTINGS_HEADER_TABLE_SIZE` (`owner.settings_r`) on first access. Previously the encoder ran at the hpack library default and could emit indices outside the peer's dynamic table window — a latent interop bug under RFC 7541 §6.3.
- **Decoder** (`HTTP2Parser.decoder`) caps `max_allowed_table_size` at the value we advertised in our SETTINGS (`owner.settings`) on first access, so any peer-driven size update beyond that is treated as a compression error per RFC 7541.
- **Live propagation** in `HTTP2Connection.set_settings`: a peer-driven `SETTINGS_HEADER_TABLE_SIZE` change is now pushed to the live HPACK encoder so already-initialized encoders stay bounded.
- Step 1 of the multi-step HTTP/2 audit-driven plan (Step 0 was the test scaffolding + zero-length payload flush merged in #63).

## Test plan

- [x] `pytest src/netius/test/common/http2.py src/netius/test/servers/http2.py` (19 passed)
- [x] New `test_encoder` and `test_decoder` exercise the lazy-init sync against `owner.settings_r` / `owner.settings`
- [ ] Reviewer sanity-checks the `set_settings` propagation guard (`legacy=False`, parser exists, setting present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)