### PR TITLE
fix(proxy_r): keep `x_forwarded_*` defined when serve(env=False)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `HTTP2Parser.parse` now flushes zero-length payload frames (eg: SETTINGS with the ACK flag, DATA with END_STREAM and no body) instead of leaving the parser stuck in `PAYLOAD_STATE` until subsequent bytes arrive
 * `HTTP2Parser` now syncs the HPACK encoder / decoder dynamic table sizes with `SETTINGS_HEADER_TABLE_SIZE` — the encoder is bounded by the peer's advertised value and the decoder caps `max_allowed_table_size` at our own; `HTTP2Connection.set_settings` propagates peer-driven changes to the live encoder, fixing a latent interop bug where the encoder could emit indices outside the peer's table window
+* `ReverseProxyServer` now initializes `x_forwarded_port` and `x_forwarded_proto` to `None` in `__init__`; previously they were only set inside `on_serve` under `if self.env`, so any embedded usage that called `serve(env=False)` raised `AttributeError` on the first inbound request
 
 ## [1.55.0] - 2026-04-29
 

--- a/src/netius/extra/proxy_r.py
+++ b/src/netius/extra/proxy_r.py
@@ -85,6 +85,8 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         forward=None,
         strategy="robin",
         reuse=True,
+        x_forwarded_port=None,
+        x_forwarded_proto=None,
         sts=0,
         resolve=True,
         resolve_t=120.0,
@@ -115,6 +117,8 @@ class ReverseProxyServer(netius.servers.ProxyServer):
             forward=forward,
             strategy=strategy,
             reuse=reuse,
+            x_forwarded_port=x_forwarded_port,
+            x_forwarded_proto=x_forwarded_proto,
             sts=sts,
             resolve=resolve,
             resolve_t=resolve_t,
@@ -160,9 +164,13 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         if self.env:
             self.strategy = self.get_env("STRATEGY", self.strategy)
         if self.env:
-            self.x_forwarded_port = self.get_env("X_FORWARDED_PORT", None)
+            self.x_forwarded_port = self.get_env(
+                "X_FORWARDED_PORT", self.x_forwarded_port
+            )
         if self.env:
-            self.x_forwarded_proto = self.get_env("X_FORWARDED_PROTO", None)
+            self.x_forwarded_proto = self.get_env(
+                "X_FORWARDED_PROTO", self.x_forwarded_proto
+            )
         if self.sts:
             self.info("Strict transport security set to %d seconds", self.sts)
         if self.resolve:

--- a/src/netius/test/extra/proxy_r.py
+++ b/src/netius/test/extra/proxy_r.py
@@ -58,8 +58,6 @@ class ReverseProxyServerTest(unittest.TestCase):
         self.server = netius.extra.ReverseProxyServer(
             hosts={"host.com": "http://localhost"}, alias={"alias.host.com": "host.com"}
         )
-        self.server.x_forwarded_proto = None
-        self.server.x_forwarded_port = None
 
     def tearDown(self):
         unittest.TestCase.tearDown(self)
@@ -355,6 +353,10 @@ class ReverseProxyServerTest(unittest.TestCase):
 
     def test_busy_conn_initial(self):
         self.assertEqual(self.server.busy_conn, 0)
+
+    def test_x_forwarded_initial(self):
+        self.assertEqual(self.server.x_forwarded_port, None)
+        self.assertEqual(self.server.x_forwarded_proto, None)
 
     def test_cleanup(self):
         server = netius.extra.ReverseProxyServer(hosts={"host.com": "http://localhost"})


### PR DESCRIPTION
## Summary

- `ReverseProxyServer.on_headers` reads `self.x_forwarded_proto` / `self.x_forwarded_port` on every inbound request, but those attributes were only set inside `on_serve` under `if self.env`. Any embedded usage that called `serve(env=False)` therefore raised `AttributeError` on the first inbound request — surfaced while testing `proxy_r` over HTTP/2.
- Promotes both to constructor parameters (default `None`) threaded through `load_config` so they always exist on the instance, and changes the `on_serve` env override to fall back to the constructor / `load_config` value instead of a hardcoded `None` (so callers can configure them via constructor _or_ env, with env winning).
- Drops the `setUp` workaround that was patching the attrs onto the test instance and adds `test_x_forwarded_initial` to lock in the new post-init defaults.

## Test plan

- [x] `pytest src/netius/test/extra/proxy_r.py::ReverseProxyServerTest` (70 passed)
- [x] Verified manually with `proxy_r` over TLS+ALPN(h2) — first inbound request no longer raises `AttributeError`
- [ ] Pre-existing `ReverseProxyIntegrationTest` failures on master are out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)