### PR TITLE
feat(proxy_c): support proxy.redirect and proxy.redirect-regex tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Test scaffolding for HTTP/2 (`HTTP2ParserTest` covering frame size, SETTINGS / PUSH_PROMISE / PING / GOAWAY / WINDOW_UPDATE assertions and parse round-trips for SETTINGS, PING, GOAWAY and WINDOW_UPDATE; `HTTP2ServerTest` covering `_has_hpack`, `_has_alpn`, `_has_npn`, `info_dict` and `get_protocols`)
+* `ConsulProxyServer` support for two new redirect tags: `proxy.redirect=<host>` (or `<host>;<protocol>` tuple form) registers a host redirect for the service domain and propagates it to tag aliases and host-suffix expansions, mirroring the existing `proxy.redirect-ssl=true` propagation; `proxy.redirect-regex=<pattern>;<target>,...` registers regex redirect rules in `self.redirect_regex`, mirroring the shape of `proxy.auth-regex`
 
 ### Changed
 
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `HTTP2Parser.parse` now flushes zero-length payload frames (eg: SETTINGS with the ACK flag, DATA with END_STREAM and no body) instead of leaving the parser stuck in `PAYLOAD_STATE` until subsequent bytes arrive
 * `HTTP2Parser` now syncs the HPACK encoder / decoder dynamic table sizes with `SETTINGS_HEADER_TABLE_SIZE` — the encoder is bounded by the peer's advertised value and the decoder caps `max_allowed_table_size` at our own; `HTTP2Connection.set_settings` propagates peer-driven changes to the live encoder, fixing a latent interop bug where the encoder could emit indices outside the peer's table window
 * `ReverseProxyServer` now initializes `x_forwarded_port` and `x_forwarded_proto` to `None` in `__init__`; previously they were only set inside `on_serve` under `if self.env`, so any embedded usage that called `serve(env=False)` raised `AttributeError` on the first inbound request
+* `ConsulProxyServer._build_hosts` now sweeps consul-managed alias keys from `self.redirect` on each rebuild cycle, so redirect entries created for tag aliases (eg: `api`) and host-suffix expansions (eg: `api.example.com`) no longer leak across rebuilds when the underlying service is removed; also incidentally fixes the same pre-existing leak for `proxy.redirect-ssl=true`
 
 ## [1.55.0] - 2026-04-29
 

--- a/src/netius/extra/proxy_c.py
+++ b/src/netius/extra/proxy_c.py
@@ -58,7 +58,8 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
     protection (`proxy.password=<secret>`), custom error pages
     (`proxy.error-url=<url>`), automatic HTTPS redirection
     (`proxy.redirect-ssl=true`), host redirection
-    (`proxy.redirect=<host>`), regex-based redirection
+    (`proxy.redirect=<host>` or `proxy.redirect=<host>;<protocol>`),
+    regex-based redirection
     (`proxy.redirect-regex=<pattern>;<target>,...`), port filtering
     (`proxy.port=<port1,port2,...>` or alias `proxy.ports`),
     address override (`proxy.address=<address>`), domain aliasing
@@ -458,6 +459,20 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
                 result.append((regex, tuple(auths)))
         return result if result else None
 
+    def _resolve_redirect(self, value):
+        if not value:
+            return None
+        if ";" not in value:
+            return str(value)
+        parts = value.split(";", 1)
+        host = parts[0].strip()
+        protocol = parts[1].strip()
+        if not host:
+            return None
+        if not protocol:
+            return None
+        return (str(host), str(protocol))
+
     def _resolve_redirect_regex(self, tags):
         value = None
         for tag in tags:
@@ -544,9 +559,9 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
                         self._consul_tag_aliases.add(alias)
                         self.debug("Registered proxy.alias '%s' -> '%s'", alias, domain)
             elif tag.startswith("proxy.redirect="):
-                redirect = tag[len("proxy.redirect=") :]
+                redirect = self._resolve_redirect(tag[len("proxy.redirect=") :])
                 if redirect:
-                    self.redirect[domain] = str(redirect)
+                    self.redirect[domain] = redirect
                     self.debug(
                         "Registered proxy.redirect '%s' for '%s'", redirect, domain
                     )

--- a/src/netius/extra/proxy_c.py
+++ b/src/netius/extra/proxy_c.py
@@ -57,7 +57,9 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
     Additional per-service tags are supported for password
     protection (`proxy.password=<secret>`), custom error pages
     (`proxy.error-url=<url>`), automatic HTTPS redirection
-    (`proxy.redirect-ssl=true`), port filtering
+    (`proxy.redirect-ssl=true`), host redirection
+    (`proxy.redirect=<host>`), regex-based redirection
+    (`proxy.redirect-regex=<pattern>;<target>,...`), port filtering
     (`proxy.port=<port1,port2,...>` or alias `proxy.ports`),
     address override (`proxy.address=<address>`), domain aliasing
     (`proxy.alias=<domain1>,<domain2>,...`), and regex-based auth
@@ -88,6 +90,7 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
         self._consul_aliases = set()
         self._consul_tag_aliases = set()
         self._consul_auth_regex = []
+        self._consul_redirect_regex = []
 
     def on_serve(self):
         proxy_r.ReverseProxyServer.on_serve(self)
@@ -137,9 +140,15 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
                 self.auth_regex.remove(entry)
             except ValueError:
                 pass
+        for entry in self._consul_redirect_regex:
+            try:
+                self.redirect_regex.remove(entry)
+            except ValueError:
+                pass
         self._consul_hosts = set()
         self._consul_tag_aliases = set()
         self._consul_auth_regex = []
+        self._consul_redirect_regex = []
 
         # iterates over the fetched entries registering each one
         # in the hosts map and applying per-service configuration
@@ -449,6 +458,31 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
                 result.append((regex, tuple(auths)))
         return result if result else None
 
+    def _resolve_redirect_regex(self, tags):
+        value = None
+        for tag in tags:
+            if tag.startswith("proxy.redirect-regex=") and value == None:
+                value = tag[len("proxy.redirect-regex=") :]
+        if not value:
+            return None
+        result = []
+        for part in value.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            if ";" not in part:
+                continue
+            pattern, target = part.split(";", 1)
+            pattern = pattern.strip()
+            target = target.strip()
+            if not pattern:
+                continue
+            if not target:
+                continue
+            regex = re.compile(pattern)
+            result.append((regex, str(target)))
+        return result if result else None
+
     def _resolve_auth_type(self, auth_type, tags):
         if auth_type == "none":
             return None
@@ -509,25 +543,48 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
                         self._consul_aliases.add(alias)
                         self._consul_tag_aliases.add(alias)
                         self.debug("Registered proxy.alias '%s' -> '%s'", alias, domain)
+            elif tag.startswith("proxy.redirect="):
+                redirect = tag[len("proxy.redirect=") :]
+                if redirect:
+                    self.redirect[domain] = str(redirect)
+                    self.debug(
+                        "Registered proxy.redirect '%s' for '%s'", redirect, domain
+                    )
             elif tag == "proxy.redirect-ssl=true":
                 self.redirect[domain] = (domain, "https")
                 self.debug("Registered proxy.redirect-ssl for '%s'", domain)
 
-        # in case the domain itself is registered for SSL redirection, also
+        # in case the domain itself is registered for redirection, also
         # registers the same redirection for any aliases of the domain to
         # ensure consistent behavior across all related hostnames
         if domain in self.redirect:
+            redirect = self.redirect[domain]
+            is_ssl = isinstance(redirect, tuple) and redirect == (domain, "https")
             for alias in self._consul_tag_aliases:
                 if not self.alias.get(alias) == domain:
                     continue
-                self.redirect[alias] = (alias, "https")
-                self.debug("Registered proxy.redirect-ssl for alias '%s'", alias)
+                if is_ssl:
+                    self.redirect[alias] = (alias, "https")
+                    self.debug("Registered proxy.redirect-ssl for alias '%s'", alias)
+                else:
+                    self.redirect[alias] = redirect
+                    self.debug(
+                        "Registered proxy.redirect '%s' for alias '%s'",
+                        redirect,
+                        alias,
+                    )
 
         auth_regex = self._resolve_auth_regex(tags)
         if auth_regex:
             self.auth_regex = list(self.auth_regex) + auth_regex
             self._consul_auth_regex.extend(auth_regex)
             self._debug_auth_regex(domain, auth_regex)
+
+        redirect_regex = self._resolve_redirect_regex(tags)
+        if redirect_regex:
+            self.redirect_regex = list(self.redirect_regex) + redirect_regex
+            self._consul_redirect_regex.extend(redirect_regex)
+            self._debug_redirect_regex(domain, redirect_regex)
 
     def _build_urls(self, instances, address=None, ports=None):
         urls = []
@@ -651,6 +708,15 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
                 regex.pattern,
                 domain,
                 auth_s,
+            )
+
+    def _debug_redirect_regex(self, domain, redirect_regex):
+        for regex, target in redirect_regex:
+            self.debug(
+                "Registered redirect regex '%s' for '%s' with target '%s'",
+                regex.pattern,
+                domain,
+                target,
             )
 
 

--- a/src/netius/extra/proxy_c.py
+++ b/src/netius/extra/proxy_c.py
@@ -146,6 +146,8 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
                 self.redirect_regex.remove(entry)
             except ValueError:
                 pass
+        for alias in self._consul_aliases:
+            self.redirect.pop(alias, None)
         self._consul_hosts = set()
         self._consul_tag_aliases = set()
         self._consul_auth_regex = []

--- a/src/netius/test/extra/proxy_c.py
+++ b/src/netius/test/extra/proxy_c.py
@@ -630,6 +630,49 @@ class ConsulProxyServerTest(unittest.TestCase):
         result = self.server._resolve_auth_regex(tags)
         self.assertEqual(result, None)
 
+    def test_resolve_redirect_regex(self):
+        tags = [
+            "proxy.enable=true",
+            "proxy.redirect-regex=^http://old\\.com/(.*)$;new.com,^http://other\\.com/(.*)$;https://other.com",
+        ]
+        result = self.server._resolve_redirect_regex(tags)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0][0].pattern, "^http://old\\.com/(.*)$")
+        self.assertEqual(result[0][1], "new.com")
+        self.assertEqual(result[1][0].pattern, "^http://other\\.com/(.*)$")
+        self.assertEqual(result[1][1], "https://other.com")
+
+    def test_resolve_redirect_regex_none(self):
+        tags = ["proxy.enable=true"]
+        result = self.server._resolve_redirect_regex(tags)
+        self.assertEqual(result, None)
+
+    def test_resolve_redirect_regex_empty(self):
+        tags = ["proxy.enable=true", "proxy.redirect-regex="]
+        result = self.server._resolve_redirect_regex(tags)
+        self.assertEqual(result, None)
+
+    def test_resolve_redirect_regex_priority(self):
+        tags = [
+            "proxy.enable=true",
+            "proxy.redirect-regex=/first;a.com",
+            "proxy.redirect-regex=/second;b.com",
+        ]
+        result = self.server._resolve_redirect_regex(tags)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0].pattern, "/first")
+        self.assertEqual(result[0][1], "a.com")
+
+    def test_resolve_redirect_regex_no_separator(self):
+        tags = ["proxy.enable=true", "proxy.redirect-regex=/api/*"]
+        result = self.server._resolve_redirect_regex(tags)
+        self.assertEqual(result, None)
+
+    def test_resolve_redirect_regex_empty_target(self):
+        tags = ["proxy.enable=true", "proxy.redirect-regex=/api/*;"]
+        result = self.server._resolve_redirect_regex(tags)
+        self.assertEqual(result, None)
+
     def test_resolve_auth_type_none(self):
         result = self.server._resolve_auth_type("none", [])
         self.assertEqual(result, None)
@@ -707,6 +750,81 @@ class ConsulProxyServerTest(unittest.TestCase):
         self.server._build_hosts(entries)
 
         self.assertTrue("myapp" not in self.server.error_urls)
+
+    def test_apply_tags_redirect(self):
+        tags = ["proxy.enable=true", "proxy.redirect=other.host.com"]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        self.server._build_hosts(entries)
+
+        self.assertEqual(self.server.redirect.get("myapp"), "other.host.com")
+
+    def test_apply_tags_redirect_empty(self):
+        tags = ["proxy.enable=true", "proxy.redirect="]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        self.server._build_hosts(entries)
+
+        self.assertTrue("myapp" not in self.server.redirect)
+
+    def test_apply_tags_redirect_custom_name(self):
+        tags = [
+            "proxy.enable=true",
+            "proxy.name=webapp",
+            "proxy.redirect=other.host.com",
+        ]
+        entries = [("myapp", "webapp", ["http://10.0.0.1:8080"], tags)]
+        self.server._build_hosts(entries)
+
+        self.assertEqual(self.server.redirect.get("webapp"), "other.host.com")
+        self.assertTrue("myapp" not in self.server.redirect)
+
+    def test_apply_tags_redirect_with_alias(self):
+        tags = [
+            "proxy.enable=true",
+            "proxy.alias=api,api-v2",
+            "proxy.redirect=other.host.com",
+        ]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        self.server._build_hosts(entries)
+
+        self.assertEqual(self.server.redirect.get("myapp"), "other.host.com")
+        self.assertEqual(self.server.redirect.get("api"), "other.host.com")
+        self.assertEqual(self.server.redirect.get("api-v2"), "other.host.com")
+
+    def test_apply_tags_redirect_with_alias_suffixes(self):
+        server = netius.extra.ConsulProxyServer(
+            host_suffixes=["example.com"],
+            hosts=dict(),
+            auth=dict(),
+            redirect=dict(),
+            error_urls=dict(),
+        )
+
+        tags = [
+            "proxy.enable=true",
+            "proxy.alias=api",
+            "proxy.redirect=other.host.com",
+        ]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        server._build_consul(entries)
+
+        self.assertEqual(server.redirect.get("myapp"), "other.host.com")
+        self.assertEqual(server.redirect.get("api"), "other.host.com")
+        self.assertEqual(server.redirect.get("myapp.example.com"), "other.host.com")
+        self.assertEqual(server.redirect.get("api.example.com"), "other.host.com")
+        server.cleanup()
+
+    def test_apply_tags_redirect_cleanup(self):
+        tags = ["proxy.enable=true", "proxy.redirect=other.host.com"]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        self.server._build_hosts(entries)
+
+        self.assertTrue("myapp" in self.server.redirect)
+
+        # simulates second rebuild with the service removed from
+        # consul, the redirect entry should be properly cleaned up
+        self.server._build_hosts([])
+
+        self.assertTrue("myapp" not in self.server.redirect)
 
     def test_apply_tags_redirect_ssl(self):
         tags = ["proxy.enable=true", "proxy.redirect-ssl=true"]
@@ -976,6 +1094,40 @@ class ConsulProxyServerTest(unittest.TestCase):
         self.server._build_hosts([])
 
         self.assertEqual(len(self.server.auth_regex), 0)
+
+    def test_apply_tags_redirect_regex(self):
+        tags = [
+            "proxy.enable=true",
+            "proxy.redirect-regex=^http://old\\.com/(.*)$;new.com,^http://other\\.com/(.*)$;https://other.com",
+        ]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        self.server._build_hosts(entries)
+
+        self.assertEqual(len(self.server.redirect_regex), 2)
+        self.assertEqual(
+            self.server.redirect_regex[0][0].pattern, "^http://old\\.com/(.*)$"
+        )
+        self.assertEqual(self.server.redirect_regex[0][1], "new.com")
+        self.assertEqual(
+            self.server.redirect_regex[1][0].pattern, "^http://other\\.com/(.*)$"
+        )
+        self.assertEqual(self.server.redirect_regex[1][1], "https://other.com")
+
+    def test_apply_tags_redirect_regex_cleanup(self):
+        tags = [
+            "proxy.enable=true",
+            "proxy.redirect-regex=^http://old\\.com/(.*)$;new.com",
+        ]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        self.server._build_hosts(entries)
+
+        self.assertEqual(len(self.server.redirect_regex), 1)
+
+        # simulates second rebuild with the service removed from
+        # consul, redirect regex entries should be properly cleaned up
+        self.server._build_hosts([])
+
+        self.assertEqual(len(self.server.redirect_regex), 0)
 
     def test_build_urls(self):
         instances = [

--- a/src/netius/test/extra/proxy_c.py
+++ b/src/netius/test/extra/proxy_c.py
@@ -630,6 +630,30 @@ class ConsulProxyServerTest(unittest.TestCase):
         result = self.server._resolve_auth_regex(tags)
         self.assertEqual(result, None)
 
+    def test_resolve_redirect(self):
+        result = self.server._resolve_redirect("other.host.com")
+        self.assertEqual(result, "other.host.com")
+
+    def test_resolve_redirect_tuple(self):
+        result = self.server._resolve_redirect("other.host.com;https")
+        self.assertEqual(result, ("other.host.com", "https"))
+
+    def test_resolve_redirect_none(self):
+        result = self.server._resolve_redirect("")
+        self.assertEqual(result, None)
+
+    def test_resolve_redirect_tuple_spaces(self):
+        result = self.server._resolve_redirect(" other.host.com ; https ")
+        self.assertEqual(result, ("other.host.com", "https"))
+
+    def test_resolve_redirect_tuple_empty_host(self):
+        result = self.server._resolve_redirect(";https")
+        self.assertEqual(result, None)
+
+    def test_resolve_redirect_tuple_empty_protocol(self):
+        result = self.server._resolve_redirect("other.host.com;")
+        self.assertEqual(result, None)
+
     def test_resolve_redirect_regex(self):
         tags = [
             "proxy.enable=true",
@@ -825,6 +849,29 @@ class ConsulProxyServerTest(unittest.TestCase):
         self.server._build_hosts([])
 
         self.assertTrue("myapp" not in self.server.redirect)
+
+    def test_apply_tags_redirect_tuple(self):
+        tags = ["proxy.enable=true", "proxy.redirect=other.host.com;https"]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        self.server._build_hosts(entries)
+
+        self.assertEqual(
+            self.server.redirect.get("myapp"), ("other.host.com", "https")
+        )
+
+    def test_apply_tags_redirect_tuple_with_alias(self):
+        tags = [
+            "proxy.enable=true",
+            "proxy.alias=api",
+            "proxy.redirect=other.host.com;https",
+        ]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        self.server._build_hosts(entries)
+
+        self.assertEqual(
+            self.server.redirect.get("myapp"), ("other.host.com", "https")
+        )
+        self.assertEqual(self.server.redirect.get("api"), ("other.host.com", "https"))
 
     def test_apply_tags_redirect_ssl(self):
         tags = ["proxy.enable=true", "proxy.redirect-ssl=true"]

--- a/src/netius/test/extra/proxy_c.py
+++ b/src/netius/test/extra/proxy_c.py
@@ -657,14 +657,14 @@ class ConsulProxyServerTest(unittest.TestCase):
     def test_resolve_redirect_regex(self):
         tags = [
             "proxy.enable=true",
-            "proxy.redirect-regex=^http://old\\.com/(.*)$;new.com,^http://other\\.com/(.*)$;https://other.com",
+            "proxy.redirect-regex=^http://old\\.com/(.*)$;new.com,^http://other\\.com/(.*)$;other.com",
         ]
         result = self.server._resolve_redirect_regex(tags)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0][0].pattern, "^http://old\\.com/(.*)$")
         self.assertEqual(result[0][1], "new.com")
         self.assertEqual(result[1][0].pattern, "^http://other\\.com/(.*)$")
-        self.assertEqual(result[1][1], "https://other.com")
+        self.assertEqual(result[1][1], "other.com")
 
     def test_resolve_redirect_regex_none(self):
         tags = ["proxy.enable=true"]
@@ -849,6 +849,59 @@ class ConsulProxyServerTest(unittest.TestCase):
         self.server._build_hosts([])
 
         self.assertTrue("myapp" not in self.server.redirect)
+
+    def test_apply_tags_redirect_with_alias_cleanup(self):
+        tags = [
+            "proxy.enable=true",
+            "proxy.alias=api,api-v2",
+            "proxy.redirect=other.host.com",
+        ]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        self.server._build_consul(entries)
+
+        self.assertTrue("myapp" in self.server.redirect)
+        self.assertTrue("api" in self.server.redirect)
+        self.assertTrue("api-v2" in self.server.redirect)
+
+        # simulates second rebuild with the service removed from
+        # consul, redirect entries for the domain and its tag aliases
+        # should be properly cleaned up
+        self.server._build_consul([])
+
+        self.assertTrue("myapp" not in self.server.redirect)
+        self.assertTrue("api" not in self.server.redirect)
+        self.assertTrue("api-v2" not in self.server.redirect)
+
+    def test_apply_tags_redirect_with_alias_suffixes_cleanup(self):
+        server = netius.extra.ConsulProxyServer(
+            host_suffixes=["example.com"],
+            hosts=dict(),
+            auth=dict(),
+            redirect=dict(),
+            error_urls=dict(),
+        )
+
+        tags = [
+            "proxy.enable=true",
+            "proxy.alias=api",
+            "proxy.redirect=other.host.com",
+        ]
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
+        server._build_consul(entries)
+
+        self.assertTrue("myapp.example.com" in server.redirect)
+        self.assertTrue("api.example.com" in server.redirect)
+
+        # simulates second rebuild with the service removed from
+        # consul, redirect entries for the suffix-expanded aliases
+        # should be properly cleaned up
+        server._build_consul([])
+
+        self.assertTrue("myapp" not in server.redirect)
+        self.assertTrue("api" not in server.redirect)
+        self.assertTrue("myapp.example.com" not in server.redirect)
+        self.assertTrue("api.example.com" not in server.redirect)
+        server.cleanup()
 
     def test_apply_tags_redirect_tuple(self):
         tags = ["proxy.enable=true", "proxy.redirect=other.host.com;https"]
@@ -1141,7 +1194,7 @@ class ConsulProxyServerTest(unittest.TestCase):
     def test_apply_tags_redirect_regex(self):
         tags = [
             "proxy.enable=true",
-            "proxy.redirect-regex=^http://old\\.com/(.*)$;new.com,^http://other\\.com/(.*)$;https://other.com",
+            "proxy.redirect-regex=^http://old\\.com/(.*)$;new.com,^http://other\\.com/(.*)$;other.com",
         ]
         entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
         self.server._build_hosts(entries)
@@ -1154,7 +1207,7 @@ class ConsulProxyServerTest(unittest.TestCase):
         self.assertEqual(
             self.server.redirect_regex[1][0].pattern, "^http://other\\.com/(.*)$"
         )
-        self.assertEqual(self.server.redirect_regex[1][1], "https://other.com")
+        self.assertEqual(self.server.redirect_regex[1][1], "other.com")
 
     def test_apply_tags_redirect_regex_cleanup(self):
         tags = [

--- a/src/netius/test/extra/proxy_c.py
+++ b/src/netius/test/extra/proxy_c.py
@@ -855,9 +855,7 @@ class ConsulProxyServerTest(unittest.TestCase):
         entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
         self.server._build_hosts(entries)
 
-        self.assertEqual(
-            self.server.redirect.get("myapp"), ("other.host.com", "https")
-        )
+        self.assertEqual(self.server.redirect.get("myapp"), ("other.host.com", "https"))
 
     def test_apply_tags_redirect_tuple_with_alias(self):
         tags = [
@@ -868,9 +866,7 @@ class ConsulProxyServerTest(unittest.TestCase):
         entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], tags)]
         self.server._build_hosts(entries)
 
-        self.assertEqual(
-            self.server.redirect.get("myapp"), ("other.host.com", "https")
-        )
+        self.assertEqual(self.server.redirect.get("myapp"), ("other.host.com", "https"))
         self.assertEqual(self.server.redirect.get("api"), ("other.host.com", "https"))
 
     def test_apply_tags_redirect_ssl(self):


### PR DESCRIPTION
## Summary

- Adds `proxy.redirect=<host>` Consul tag to `ConsulProxyServer`, registering a plain host redirect for the service domain and propagating it to tag aliases and host-suffix expansions (mirrors `proxy.redirect-ssl=true`).
- Adds `proxy.redirect-regex=<pattern>;<target>,...` Consul tag, registering regex redirect rules in `self.redirect_regex` (mirrors `proxy.auth-regex`).
- Tracks consul-managed regex entries via a new `_consul_redirect_regex` list with cleanup on each rebuild cycle, matching the pattern used for `_consul_auth_regex`.
- Tightens the alias-propagation block in `_apply_tags` to detect the SSL-tuple form vs. plain-string form, so a `proxy.redirect=...` without `proxy.redirect-ssl=true` no longer silently rewrites aliases to `(alias, "https")`.

Existing `proxy.redirect-ssl=true` semantics are preserved.

Closes #66

## Test plan

- [x] `python -m unittest netius.test.extra.proxy_c -v` — 126 tests pass (15 new).
- [x] 6 tests for `_resolve_redirect_regex` mirroring `test_resolve_auth_regex_*`.
- [x] 6 tests for `proxy.redirect` in `_apply_tags` mirroring the `redirect-ssl` set (basic, empty, custom name, with alias, with alias + suffixes, cleanup).
- [x] 2 tests for `proxy.redirect-regex` end-to-end (registration + cleanup on rebuild).
- [x] Existing `proxy.redirect-ssl` tests continue to pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced proxy redirect functionality with regex pattern matching for advanced routing rules
  * Added support for configurable host-based redirects alongside existing SSL redirect options
  * Improved redirect rule propagation to service aliases in distributed service discovery environments

* **Tests**
  * Added comprehensive test coverage for redirect configuration parsing and management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->