### PR TITLE
feat(proxy_r): support WebSocket upgrade requests via raw tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* `ReverseProxyServer` support for WebSocket (`Connection: Upgrade` + `Upgrade: websocket`) requests, which are now forwarded to the resolved back-end through a raw byte tunnel (the switching protocols response and subsequent frames flow back transparently); the back-end target honours the same regex / host / forward rule resolution and load balancing as regular HTTP requests
+* `ProxyServer.is_upgrade` and `ProxyServer.tunnel` helpers factoring out the raw tunnel establishment (back-end connection, connection mapping, optional initial request forwarding and acknowledge response) shared by the WebSocket upgrade and `CONNECT` code paths
 
 ### Changed
 
-*
+* `ForwardProxyServer` `CONNECT` handling now uses the shared `ProxyServer.tunnel` helper instead of an inline tunnel setup (behaviour preserved, the `200 Connection established` acknowledge is still sent on tunnel establishment)
 
 ### Fixed
 

--- a/src/netius/extra/proxy_f.py
+++ b/src/netius/extra/proxy_f.py
@@ -73,11 +73,12 @@ class ForwardProxyServer(netius.servers.ProxyServer):
         if method == "CONNECT":
             host, port = path.split(":")
             port = int(port)
-            _connection = self.raw_client.connect(host, port)
-            _connection.max_pending = self.max_pending
-            _connection.min_pending = self.min_pending
-            connection.tunnel_c = _connection
-            self.conn_map[_connection] = connection
+            self.tunnel(
+                connection,
+                host,
+                port,
+                response=(200, "Connection established"),
+            )
         else:
             proxy_c = hasattr(connection, "proxy_c") and connection.proxy_c
             proxy_c = proxy_c or None

--- a/src/netius/extra/proxy_r.py
+++ b/src/netius/extra/proxy_r.py
@@ -430,7 +430,7 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         # request, the switching protocols response (and any subsequent
         # frames) then flow back transparently through that tunnel
         if self.is_upgrade(parser):
-            return self._upgrade(connection, parser, prefix, path, headers)
+            return self._upgrade(connection, parser, prefix, path, headers, state=state)
 
         # verifies if the current connection already contains a valid
         # a proxy connection if that's the case that must be unset from
@@ -516,7 +516,24 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         connection.state = state
         self.conn_map[_connection] = connection
 
-    def _upgrade(self, connection, parser, prefix, path, headers):
+    def _upgrade(self, connection, parser, prefix, path, headers, state=None):
+        # the raw tunnel does not take part in the busy based balancing
+        # life-cycle (no message/close callbacks update the state) so the
+        # previously acquired state is released immediately, otherwise the
+        # selected back-end busy count would leak for the smart strategy
+        if not state == None:
+            self.releaser(state)
+
+        # verifies if the current connection already contains a valid proxy
+        # connection (eg: a previous request on a kept alive connection) and
+        # if that's the case unsets it from the connection map, avoiding a
+        # possible leak or the misrouting of late back-end callbacks
+        proxy_c = hasattr(connection, "proxy_c") and connection.proxy_c
+        proxy_c = proxy_c or None
+        connection.proxy_c = None
+        if proxy_c in self.conn_map:
+            del self.conn_map[proxy_c]
+
         # parses the resolved prefix value into its components so that the
         # back-end host, port and security mode may be extracted and used
         # for the raw tunnel connection (the prefix is the back-end URL)
@@ -525,12 +542,16 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         host = parsed.hostname
         port = parsed.port or (443 if ssl else 80)
 
-        # re-builds the original request line using the back-end path so
-        # that the upgrade request is forwarded transparently to the
-        # back-end, the version string is the one of the original request
+        # re-builds the original request line prepending the prefix path of
+        # the back-end (in case there's one) so that the upgrade request is
+        # forwarded to the same target as a regular request (prefix + path),
+        # the version string is the one of the original request
         method = parser.method_s
         version_s = parser.version_s
-        request = [netius.legacy.bytes("%s %s %s\r\n" % (method, path, version_s))]
+        request_path = parsed.path + path
+        request = [
+            netius.legacy.bytes("%s %s %s\r\n" % (method, request_path, version_s))
+        ]
 
         # forwards the original header block verbatim so that the casing of
         # the (case sensitive) WebSocket handshake headers is preserved, the

--- a/src/netius/extra/proxy_r.py
+++ b/src/netius/extra/proxy_r.py
@@ -530,16 +530,32 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         # back-end, the version string is the one of the original request
         method = parser.method_s
         version_s = parser.version_s
-        request = ["%s %s %s\r\n" % (method, path, version_s)]
+        request = [netius.legacy.bytes("%s %s %s\r\n" % (method, path, version_s))]
 
-        # appends the complete set of (possibly modified) headers to the
-        # request buffer so that the back-end receives the original upgrade
-        # headers together with the reverse proxy forwarding headers
-        for key, value in netius.legacy.items(headers):
-            key = netius.common.header_up(key)
-            request.append("%s: %s\r\n" % (key, value))
-        request.append("\r\n")
-        request = netius.legacy.bytes("".join(request))
+        # forwards the original header block verbatim so that the casing of
+        # the (case sensitive) WebSocket handshake headers is preserved, the
+        # leading separator of the raw headers string is stripped as the
+        # request line already provides it
+        request.append(parser.headers_s.lstrip(b"\r\n"))
+        request.append(b"\r\n")
+
+        # appends the reverse proxy forwarding headers that are not part of
+        # the original request, these are lower cased and do not interfere
+        # with the case sensitive handshake headers already forwarded
+        for key in (
+            "x-real-ip",
+            "x-client-ip",
+            "x-forwarded-for",
+            "x-forwarded-proto",
+            "x-forwarded-port",
+            "x-forwarded-host",
+        ):
+            value = headers.get(key, None)
+            if value == None:
+                continue
+            request.append(netius.legacy.bytes("%s: %s\r\n" % (key, value)))
+        request.append(b"\r\n")
+        request = b"".join(request)
 
         # establishes the raw tunnel towards the back-end forwarding the
         # original upgrade request, the switching protocols response and

--- a/src/netius/extra/proxy_r.py
+++ b/src/netius/extra/proxy_r.py
@@ -423,6 +423,15 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         )
         headers["x-forwarded-host"] = host_o
 
+        # in case the current request represents a WebSocket upgrade the
+        # normal HTTP client based forwarding is not possible (the back-end
+        # switches to a raw protocol) and so a raw tunnel must be established
+        # towards the resolved back-end forwarding the original upgrade
+        # request, the switching protocols response (and any subsequent
+        # frames) then flow back transparently through that tunnel
+        if self.is_upgrade(parser):
+            return self._upgrade(connection, parser, prefix, path, headers)
+
         # verifies if the current connection already contains a valid
         # a proxy connection if that's the case that must be unset from
         # the connection and from the connection map internal structures
@@ -506,6 +515,36 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         connection.prefix = prefix
         connection.state = state
         self.conn_map[_connection] = connection
+
+    def _upgrade(self, connection, parser, prefix, path, headers):
+        # parses the resolved prefix value into its components so that the
+        # back-end host, port and security mode may be extracted and used
+        # for the raw tunnel connection (the prefix is the back-end URL)
+        parsed = netius.legacy.urlparse(prefix)
+        ssl = parsed.scheme == "https"
+        host = parsed.hostname
+        port = parsed.port or (443 if ssl else 80)
+
+        # re-builds the original request line using the back-end path so
+        # that the upgrade request is forwarded transparently to the
+        # back-end, the version string is the one of the original request
+        method = parser.method_s
+        version_s = parser.version_s
+        request = ["%s %s %s\r\n" % (method, path, version_s)]
+
+        # appends the complete set of (possibly modified) headers to the
+        # request buffer so that the back-end receives the original upgrade
+        # headers together with the reverse proxy forwarding headers
+        for key, value in netius.legacy.items(headers):
+            key = netius.common.header_up(key)
+            request.append("%s: %s\r\n" % (key, value))
+        request.append("\r\n")
+        request = netius.legacy.bytes("".join(request))
+
+        # establishes the raw tunnel towards the back-end forwarding the
+        # original upgrade request, the switching protocols response and
+        # any subsequent frames flow back transparently through the tunnel
+        self.tunnel(connection, host, port, ssl=ssl, data=request)
 
     def rules(self, url, parser):
         resolved = self.rules_regex(url, parser)

--- a/src/netius/extra/proxy_r.py
+++ b/src/netius/extra/proxy_r.py
@@ -516,7 +516,6 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         connection.state = state
         self.conn_map[_connection] = connection
 
-
     def rules(self, url, parser):
         resolved = self.rules_regex(url, parser)
         if resolved[0]:

--- a/src/netius/extra/proxy_r.py
+++ b/src/netius/extra/proxy_r.py
@@ -516,72 +516,6 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         connection.state = state
         self.conn_map[_connection] = connection
 
-    def _upgrade(self, connection, parser, prefix, path, headers, state=None):
-        # the raw tunnel does not take part in the busy based balancing
-        # life-cycle (no message/close callbacks update the state) so the
-        # previously acquired state is released immediately, otherwise the
-        # selected back-end busy count would leak for the smart strategy
-        if not state == None:
-            self.releaser(state)
-
-        # verifies if the current connection already contains a valid proxy
-        # connection (eg: a previous request on a kept alive connection) and
-        # if that's the case unsets it from the connection map, avoiding a
-        # possible leak or the misrouting of late back-end callbacks
-        proxy_c = hasattr(connection, "proxy_c") and connection.proxy_c
-        proxy_c = proxy_c or None
-        connection.proxy_c = None
-        if proxy_c in self.conn_map:
-            del self.conn_map[proxy_c]
-
-        # parses the resolved prefix value into its components so that the
-        # back-end host, port and security mode may be extracted and used
-        # for the raw tunnel connection (the prefix is the back-end URL)
-        parsed = netius.legacy.urlparse(prefix)
-        ssl = parsed.scheme == "https"
-        host = parsed.hostname
-        port = parsed.port or (443 if ssl else 80)
-
-        # re-builds the original request line prepending the prefix path of
-        # the back-end (in case there's one) so that the upgrade request is
-        # forwarded to the same target as a regular request (prefix + path),
-        # the version string is the one of the original request
-        method = parser.method_s
-        version_s = parser.version_s
-        request_path = parsed.path + path
-        request = [
-            netius.legacy.bytes("%s %s %s\r\n" % (method, request_path, version_s))
-        ]
-
-        # forwards the original header block verbatim so that the casing of
-        # the (case sensitive) WebSocket handshake headers is preserved, the
-        # leading separator of the raw headers string is stripped as the
-        # request line already provides it
-        request.append(parser.headers_s.lstrip(b"\r\n"))
-        request.append(b"\r\n")
-
-        # appends the reverse proxy forwarding headers that are not part of
-        # the original request, these are lower cased and do not interfere
-        # with the case sensitive handshake headers already forwarded
-        for key in (
-            "x-real-ip",
-            "x-client-ip",
-            "x-forwarded-for",
-            "x-forwarded-proto",
-            "x-forwarded-port",
-            "x-forwarded-host",
-        ):
-            value = headers.get(key, None)
-            if value == None:
-                continue
-            request.append(netius.legacy.bytes("%s: %s\r\n" % (key, value)))
-        request.append(b"\r\n")
-        request = b"".join(request)
-
-        # establishes the raw tunnel towards the back-end forwarding the
-        # original upgrade request, the switching protocols response and
-        # any subsequent frames flow back transparently through the tunnel
-        self.tunnel(connection, host, port, ssl=ssl, data=request)
 
     def rules(self, url, parser):
         resolved = self.rules_regex(url, parser)
@@ -860,6 +794,73 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         if error_url:
             _connection.error_url = None
         netius.servers.ProxyServer._on_prx_close(self, client, _connection)
+
+    def _upgrade(self, connection, parser, prefix, path, headers, state=None):
+        # the raw tunnel does not take part in the busy based balancing
+        # life-cycle (no message/close callbacks update the state) so the
+        # previously acquired state is released immediately, otherwise the
+        # selected back-end busy count would leak for the smart strategy
+        if not state == None:
+            self.releaser(state)
+
+        # verifies if the current connection already contains a valid proxy
+        # connection (eg: a previous request on a kept alive connection) and
+        # if that's the case unsets it from the connection map, avoiding a
+        # possible leak or the misrouting of late back-end callbacks
+        proxy_c = hasattr(connection, "proxy_c") and connection.proxy_c
+        proxy_c = proxy_c or None
+        connection.proxy_c = None
+        if proxy_c in self.conn_map:
+            del self.conn_map[proxy_c]
+
+        # parses the resolved prefix value into its components so that the
+        # back-end host, port and security mode may be extracted and used
+        # for the raw tunnel connection (the prefix is the back-end URL)
+        parsed = netius.legacy.urlparse(prefix)
+        ssl = parsed.scheme == "https"
+        host = parsed.hostname
+        port = parsed.port or (443 if ssl else 80)
+
+        # re-builds the original request line prepending the prefix path of
+        # the back-end (in case there's one) so that the upgrade request is
+        # forwarded to the same target as a regular request (prefix + path),
+        # the version string is the one of the original request
+        method = parser.method_s
+        version_s = parser.version_s
+        request_path = parsed.path + path
+        request = [
+            netius.legacy.bytes("%s %s %s\r\n" % (method, request_path, version_s))
+        ]
+
+        # forwards the original header block verbatim so that the casing of
+        # the (case sensitive) WebSocket handshake headers is preserved, the
+        # leading separator of the raw headers string is stripped as the
+        # request line already provides it
+        request.append(parser.headers_s.lstrip(b"\r\n"))
+        request.append(b"\r\n")
+
+        # appends the reverse proxy forwarding headers that are not part of
+        # the original request, these are lower cased and do not interfere
+        # with the case sensitive handshake headers already forwarded
+        for key in (
+            "x-real-ip",
+            "x-client-ip",
+            "x-forwarded-for",
+            "x-forwarded-proto",
+            "x-forwarded-port",
+            "x-forwarded-host",
+        ):
+            value = headers.get(key, None)
+            if value == None:
+                continue
+            request.append(netius.legacy.bytes("%s: %s\r\n" % (key, value)))
+        request.append(b"\r\n")
+        request = b"".join(request)
+
+        # establishes the raw tunnel towards the back-end forwarding the
+        # original upgrade request, the switching protocols response and
+        # any subsequent frames flow back transparently through the tunnel
+        self.tunnel(connection, host, port, ssl=ssl, data=request)
 
     def _apply_all(
         self, parser, connection, headers, upper=True, normalize=False, replace=False

--- a/src/netius/servers/proxy.py
+++ b/src/netius/servers/proxy.py
@@ -246,63 +246,6 @@ class ProxyServer(http2.HTTP2Server):
     def connection_dict(self, id, full=False):
         return self.container.connection_dict(id, full=full)
 
-    def on_data(self, connection, data):
-        netius.StreamServer.on_data(self, connection, data)
-
-        # tries to retrieve the reference to the tunnel connection
-        # currently set in the connection in case it does not exists
-        # (initial handshake or HTTP client proxy) runs the parse
-        # step on the data and then returns immediately
-        tunnel_c = hasattr(connection, "tunnel_c") and connection.tunnel_c
-        if not tunnel_c:
-            connection.parse(data)
-            return
-
-        # verifies that the current size of the pending buffer is greater
-        # than the maximum size for the pending buffer the read operations
-        # if that the case the read operations must be disabled
-        should_throttle = self.throttle and connection.is_throttleable()
-        should_disable = should_throttle and tunnel_c.is_exhausted()
-        if should_disable:
-            connection.disable_read()
-
-        # performs the sending operation on the data but uses the throttle
-        # callback so that the connection read operations may be resumed if
-        # the buffer has reached certain (minimum) levels
-        tunnel_c.send(data, callback=self._throttle)
-
-    def is_upgrade(self, parser):
-        """
-        Determines if the request associated with the provided parser
-        represents a WebSocket upgrade request, this is the case when
-        the connection header contains the upgrade token and the upgrade
-        header is set to the websocket value.
-
-        :type parser: HTTPParser
-        :param parser: The parser of the request that is going to be
-        verified for the presence of a WebSocket upgrade.
-        :rtype: bool
-        :return: If the request represents a WebSocket upgrade request.
-        """
-
-        headers = parser.headers
-        connection = headers.get("connection", "")
-        upgrade = headers.get("upgrade", "")
-
-        # normalizes both values into a single string as the HTTP parser
-        # stores repeated headers as a list, using the last definition in
-        # such case (consistent with the regular header retrieval)
-        if isinstance(connection, (list, tuple)):
-            connection = connection[-1] if connection else ""
-        if isinstance(upgrade, (list, tuple)):
-            upgrade = upgrade[-1] if upgrade else ""
-
-        # matches the upgrade option as a complete (comma separated) token
-        # of the connection header instead of a substring, avoiding false
-        # positives for values such as 'notupgrade'
-        tokens = [value.strip() for value in connection.lower().split(",")]
-        return "upgrade" in tokens and upgrade.lower() == "websocket"
-
     def tunnel(self, connection, host, port, ssl=False, data=None, response=None):
         """
         Establishes a raw (byte oriented) tunnel between the provided
@@ -354,6 +297,63 @@ class ProxyServer(http2.HTTP2Server):
         connection.tunnel_c = _connection
         self.conn_map[_connection] = connection
         return _connection
+
+    def is_upgrade(self, parser):
+        """
+        Determines if the request associated with the provided parser
+        represents a WebSocket upgrade request, this is the case when
+        the connection header contains the upgrade token and the upgrade
+        header is set to the websocket value.
+
+        :type parser: HTTPParser
+        :param parser: The parser of the request that is going to be
+        verified for the presence of a WebSocket upgrade.
+        :rtype: bool
+        :return: If the request represents a WebSocket upgrade request.
+        """
+
+        headers = parser.headers
+        connection = headers.get("connection", "")
+        upgrade = headers.get("upgrade", "")
+
+        # normalizes both values into a single string as the HTTP parser
+        # stores repeated headers as a list, using the last definition in
+        # such case (consistent with the regular header retrieval)
+        if isinstance(connection, (list, tuple)):
+            connection = connection[-1] if connection else ""
+        if isinstance(upgrade, (list, tuple)):
+            upgrade = upgrade[-1] if upgrade else ""
+
+        # matches the upgrade option as a complete (comma separated) token
+        # of the connection header instead of a substring, avoiding false
+        # positives for values such as 'notupgrade'
+        tokens = [value.strip() for value in connection.lower().split(",")]
+        return "upgrade" in tokens and upgrade.lower() == "websocket"
+
+    def on_data(self, connection, data):
+        netius.StreamServer.on_data(self, connection, data)
+
+        # tries to retrieve the reference to the tunnel connection
+        # currently set in the connection in case it does not exists
+        # (initial handshake or HTTP client proxy) runs the parse
+        # step on the data and then returns immediately
+        tunnel_c = hasattr(connection, "tunnel_c") and connection.tunnel_c
+        if not tunnel_c:
+            connection.parse(data)
+            return
+
+        # verifies that the current size of the pending buffer is greater
+        # than the maximum size for the pending buffer the read operations
+        # if that the case the read operations must be disabled
+        should_throttle = self.throttle and connection.is_throttleable()
+        should_disable = should_throttle and tunnel_c.is_exhausted()
+        if should_disable:
+            connection.disable_read()
+
+        # performs the sending operation on the data but uses the throttle
+        # callback so that the connection read operations may be resumed if
+        # the buffer has reached certain (minimum) levels
+        tunnel_c.send(data, callback=self._throttle)
 
     def on_connection_d(self, connection):
         http2.HTTP2Server.on_connection_d(self, connection)

--- a/src/netius/servers/proxy.py
+++ b/src/netius/servers/proxy.py
@@ -288,7 +288,20 @@ class ProxyServer(http2.HTTP2Server):
         headers = parser.headers
         connection = headers.get("connection", "")
         upgrade = headers.get("upgrade", "")
-        return "upgrade" in connection.lower() and upgrade.lower() == "websocket"
+
+        # normalizes both values into a single string as the HTTP parser
+        # stores repeated headers as a list, using the last definition in
+        # such case (consistent with the regular header retrieval)
+        if isinstance(connection, (list, tuple)):
+            connection = connection[-1] if connection else ""
+        if isinstance(upgrade, (list, tuple)):
+            upgrade = upgrade[-1] if upgrade else ""
+
+        # matches the upgrade option as a complete (comma separated) token
+        # of the connection header instead of a substring, avoiding false
+        # positives for values such as 'notupgrade'
+        tokens = [value.strip() for value in connection.lower().split(",")]
+        return "upgrade" in tokens and upgrade.lower() == "websocket"
 
     def tunnel(self, connection, host, port, ssl=False, data=None, response=None):
         """

--- a/src/netius/servers/proxy.py
+++ b/src/netius/servers/proxy.py
@@ -271,6 +271,77 @@ class ProxyServer(http2.HTTP2Server):
         # the buffer has reached certain (minimum) levels
         tunnel_c.send(data, callback=self._throttle)
 
+    def is_upgrade(self, parser):
+        """
+        Determines if the request associated with the provided parser
+        represents a WebSocket upgrade request, this is the case when
+        the connection header contains the upgrade token and the upgrade
+        header is set to the websocket value.
+
+        :type parser: HTTPParser
+        :param parser: The parser of the request that is going to be
+        verified for the presence of a WebSocket upgrade.
+        :rtype: bool
+        :return: If the request represents a WebSocket upgrade request.
+        """
+
+        headers = parser.headers
+        connection = headers.get("connection", "")
+        upgrade = headers.get("upgrade", "")
+        return "upgrade" in connection.lower() and upgrade.lower() == "websocket"
+
+    def tunnel(self, connection, host, port, ssl=False, data=None, response=None):
+        """
+        Establishes a raw (byte oriented) tunnel between the provided
+        (front-end) connection and a newly created back-end connection
+        targeting the requested host and port.
+
+        After this call any data received from the front-end is relayed
+        verbatim to the back-end (and vice versa) using the raw pump,
+        meaning that no HTTP parsing is performed and protocols such as
+        WebSocket can be transparently proxied.
+
+        The optional data value is sent to the back-end as soon as the
+        connection is established, this is used to forward the original
+        upgrade request so that the back-end may reply with the proper
+        switching protocols response (flowing back through the tunnel).
+
+        The optional response value is the (code, code string) tuple to
+        be sent to the front-end once the back-end connection is
+        established, this is used by the CONNECT method to acknowledge
+        the tunnel, for transparent upgrades it should be unset so that
+        the back-end response is the one flowing back to the front-end.
+
+        :type connection: Connection
+        :param connection: The front-end connection that is going to be
+        tunneled to the back-end.
+        :type host: String
+        :param host: The host of the back-end endpoint to connect to.
+        :type port: int
+        :param port: The port of the back-end endpoint to connect to.
+        :type ssl: bool
+        :param ssl: If the back-end connection should be established
+        using a secure (SSL/TLS) transport.
+        :type data: bytes
+        :param data: The optional set of bytes to be sent to the back-end
+        immediately after the connection is established.
+        :type response: Tuple
+        :param response: The optional (code, code string) tuple to be
+        sent to the front-end on tunnel establishment.
+        :rtype: Connection
+        :return: The back-end (tunnel) connection that has just been
+        created and associated with the front-end connection.
+        """
+
+        _connection = self.raw_client.connect(host, port, ssl=ssl)
+        _connection.max_pending = self.max_pending
+        _connection.min_pending = self.min_pending
+        _connection.tunnel_d = data
+        _connection.tunnel_r = response
+        connection.tunnel_c = _connection
+        self.conn_map[_connection] = connection
+        return _connection
+
     def on_connection_d(self, connection):
         http2.HTTP2Server.on_connection_d(self, connection)
 
@@ -698,7 +769,31 @@ class ProxyServer(http2.HTTP2Server):
 
     def _on_raw_connect(self, client, _connection):
         connection = self.conn_map[_connection]
-        connection.send_response(code=200, code_s="Connection established", apply=True)
+
+        # retrieves the optional response and data values that may have
+        # been associated with the tunnel connection, the response is
+        # sent to the front-end to acknowledge the tunnel and the data
+        # is forwarded to the back-end (eg: the original upgrade request)
+        response = hasattr(_connection, "tunnel_r") and _connection.tunnel_r
+        data = hasattr(_connection, "tunnel_d") and _connection.tunnel_d
+
+        # in case a response tuple is defined sends the proper acknowledge
+        # response to the front-end connection (eg: CONNECT method), note
+        # that for transparent upgrades no response is sent as the back-end
+        # one is the one that should flow back to the front-end
+        if response:
+            code, code_s = response
+            connection.send_response(code=code, code_s=code_s, apply=True)
+
+        # in case there's data to be sent to the back-end forwards it as
+        # soon as the connection is established, this is required so that
+        # the back-end may reply with the proper switching protocols
+        # response that is going to flow back through the raw tunnel, the
+        # reference is unset afterwards as it's no longer required (avoids
+        # retaining the request buffer for the lifetime of the tunnel)
+        if data:
+            _connection.send(data)
+            _connection.tunnel_d = None
 
     def _on_raw_data(self, client, _connection, data):
         connection = self.conn_map[_connection]

--- a/src/netius/test/extra/proxy_f.py
+++ b/src/netius/test/extra/proxy_f.py
@@ -1,0 +1,150 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius.extra
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+
+class ForwardProxyServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.server = netius.extra.ForwardProxyServer()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+
+    def test_on_headers_connect_tunnels(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        frontend = self._make_frontend()
+        request_parser = self._make_request_parser(
+            method="CONNECT", path="host.com:443"
+        )
+        backend = self._make_backend()
+
+        with mock.patch.object(
+            self.server.raw_client, "connect", return_value=backend
+        ) as connect:
+            with mock.patch.object(self.server.http_client, "method") as method:
+                self.server.on_headers(frontend, request_parser)
+
+        # the CONNECT request must establish a raw tunnel through the raw
+        # client and never reach the (HTTP) client based forwarding path
+        self.assertEqual(method.call_count, 0)
+        self.assertEqual(connect.call_args[0], ("host.com", 443))
+
+        # the back-end connection must be set as the tunnel connection and
+        # the proper reverse mapping must exist in the connection map
+        self.assertEqual(frontend.tunnel_c, backend)
+        self.assertIn(backend, self.server.conn_map)
+        self.assertEqual(self.server.conn_map[backend], frontend)
+
+        # the acknowledge response must be stored so that it may be sent to
+        # the front-end once the tunnel connection is established
+        self.assertEqual(backend.tunnel_r, (200, "Connection established"))
+        self.assertIsNone(backend.tunnel_d)
+
+    def test_on_headers_method_routes_to_backend(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        frontend = self._make_frontend()
+        request_parser = self._make_request_parser(
+            method="GET", path="http://host.com/"
+        )
+        backend = self._make_backend()
+
+        with mock.patch.object(self.server.raw_client, "connect") as connect:
+            with mock.patch.object(
+                self.server.http_client, "method", return_value=backend
+            ) as method:
+                self.server.on_headers(frontend, request_parser)
+
+        # a regular method must be forwarded through the (HTTP) client and
+        # no raw tunnel must be established for the connection
+        self.assertEqual(connect.call_count, 0)
+        self.assertEqual(method.call_count, 1)
+        self.assertEqual(frontend.proxy_c, backend)
+        self.assertIn(backend, self.server.conn_map)
+
+    def test_on_headers_rejected_sends_403(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        server = netius.extra.ForwardProxyServer(rules=dict(deny=".*host.com.*"))
+
+        frontend = self._make_frontend()
+        request_parser = self._make_request_parser(
+            method="CONNECT", path="host.com:443"
+        )
+
+        try:
+            with mock.patch.object(server.raw_client, "connect") as connect:
+                server.on_headers(frontend, request_parser)
+        finally:
+            server.cleanup()
+
+        # a rejected connection must be answered with a forbidden response
+        # and must never establish a raw tunnel towards the back-end
+        self.assertEqual(connect.call_count, 0)
+        self.assertEqual(frontend.send_response.call_count, 1)
+        self.assertEqual(frontend.send_response.call_args[1]["code"], 403)
+
+    def _make_frontend(self):
+        frontend = mock.MagicMock()
+        frontend.ssl = False
+        frontend.address = ("127.0.0.1", 12345)
+        # removes dynamic attributes that on_headers checks via hasattr
+        del frontend.proxy_c
+        del frontend.tunnel_c
+        return frontend
+
+    def _make_backend(self):
+        backend = mock.MagicMock()
+        backend.address = ("10.0.0.1", 8080)
+        backend.waiting = False
+        return backend
+
+    def _make_request_parser(self, method="GET", path="/test"):
+        parser = mock.MagicMock()
+        parser.method = method
+        parser.path_s = path
+        parser.version_s = "HTTP/1.1"
+        parser.headers = {}
+        return parser

--- a/src/netius/test/extra/proxy_r.py
+++ b/src/netius/test/extra/proxy_r.py
@@ -637,6 +637,64 @@ class ReverseProxyServerTest(unittest.TestCase):
         self.assertEqual(frontend.proxy_c, backend)
         self.assertEqual(frontend.prefix, "http://localhost")
 
+    def test_on_headers_upgrade_tunnels_to_backend(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        frontend = self._make_frontend()
+        request_parser = self._make_upgrade_parser()
+        backend = self._make_backend()
+
+        with mock.patch.object(
+            self.server.raw_client, "connect", return_value=backend
+        ) as connect:
+            with mock.patch.object(self.server.http_client, "method") as method:
+                self.server.on_headers(frontend, request_parser)
+
+        # the upgrade request must be tunneled through the raw client and
+        # never reach the (HTTP) client based forwarding code path
+        self.assertEqual(method.call_count, 0)
+        self.assertEqual(connect.call_count, 1)
+        self.assertEqual(connect.call_args[0], ("localhost", 80))
+        self.assertEqual(connect.call_args[1], dict(ssl=False))
+
+        # the back-end connection must be set as the tunnel connection and
+        # the proper reverse mapping must exist in the connection map
+        self.assertEqual(frontend.tunnel_c, backend)
+        self.assertIn(backend, self.server.conn_map)
+        self.assertEqual(self.server.conn_map[backend], frontend)
+
+        # the original upgrade request must have been stored for forwarding
+        # to the back-end once the tunnel connection is established
+        self.assertTrue(backend.tunnel_d.startswith(b"GET /socket HTTP/1.1\r\n"))
+        self.assertIn(b"Upgrade: websocket\r\n", backend.tunnel_d)
+        self.assertIsNone(backend.tunnel_r)
+
+    def test_on_headers_upgrade_secure_backend(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        server = netius.extra.ReverseProxyServer(
+            hosts={"host.com": "https://localhost"}
+        )
+
+        frontend = self._make_frontend()
+        request_parser = self._make_upgrade_parser()
+        backend = self._make_backend()
+
+        try:
+            with mock.patch.object(
+                server.raw_client, "connect", return_value=backend
+            ) as connect:
+                server.on_headers(frontend, request_parser)
+        finally:
+            server.cleanup()
+
+        # the secure scheme of the back-end must be reflected both in the
+        # default port resolution and in the secure transport flag
+        self.assertEqual(connect.call_args[0], ("localhost", 443))
+        self.assertEqual(connect.call_args[1], dict(ssl=True))
+
     def test_on_headers_no_match_sends_404(self):
         if mock == None:
             self.skipTest("Skipping test: mock unavailable")
@@ -964,9 +1022,19 @@ class ReverseProxyServerTest(unittest.TestCase):
     def _make_request_parser(self, host="host.com", method="GET", path="/test"):
         parser = mock.MagicMock()
         parser.method = method
+        parser.method_s = method
         parser.path_s = path
         parser.version_s = "HTTP/1.1"
         parser.headers = {"host": host}
+        return parser
+
+    def _make_upgrade_parser(self, host="host.com", path="/socket"):
+        parser = self._make_request_parser(host=host, method="GET", path=path)
+        parser.headers = {
+            "host": host,
+            "connection": "Upgrade",
+            "upgrade": "websocket",
+        }
         return parser
 
     def _make_response_parser(self, backend, code="200", status="OK"):

--- a/src/netius/test/extra/proxy_r.py
+++ b/src/netius/test/extra/proxy_r.py
@@ -708,6 +708,32 @@ class ReverseProxyServerTest(unittest.TestCase):
         self.assertEqual(connect.call_args[0], ("localhost", 443))
         self.assertEqual(connect.call_args[1], dict(ssl=True))
 
+    def test_on_headers_upgrade_prefix_path(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        server = netius.extra.ReverseProxyServer(
+            hosts={"host.com": "http://localhost/base"}
+        )
+
+        frontend = self._make_frontend()
+        request_parser = self._make_upgrade_parser()
+        backend = self._make_backend()
+
+        try:
+            with mock.patch.object(
+                server.raw_client, "connect", return_value=backend
+            ) as connect:
+                server.on_headers(frontend, request_parser)
+        finally:
+            server.cleanup()
+
+        # the back-end prefix path must be prepended to the original path in
+        # the forwarded request line (prefix + path), matching the routing of
+        # a regular (non upgrade) request to the same prefixed back-end
+        self.assertEqual(connect.call_args[0], ("localhost", 80))
+        self.assertTrue(backend.tunnel_d.startswith(b"GET /base/socket HTTP/1.1\r\n"))
+
     def test_on_headers_no_match_sends_404(self):
         if mock == None:
             self.skipTest("Skipping test: mock unavailable")

--- a/src/netius/test/extra/proxy_r.py
+++ b/src/netius/test/extra/proxy_r.py
@@ -670,6 +670,19 @@ class ReverseProxyServerTest(unittest.TestCase):
         self.assertIn(b"Upgrade: websocket\r\n", backend.tunnel_d)
         self.assertIsNone(backend.tunnel_r)
 
+        # the (case sensitive) WebSocket handshake headers must be forwarded
+        # with their original casing preserved, the proxy must not normalize
+        # them (some back-ends match these headers in a case sensitive way)
+        self.assertIn(
+            b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n", backend.tunnel_d
+        )
+        self.assertIn(b"Sec-WebSocket-Version: 13\r\n", backend.tunnel_d)
+
+        # the reverse proxy forwarding headers must be appended to the request
+        # so that the back-end is aware of the original client and protocol
+        self.assertIn(b"x-forwarded-for: ", backend.tunnel_d)
+        self.assertIn(b"x-forwarded-host: ", backend.tunnel_d)
+
     def test_on_headers_upgrade_secure_backend(self):
         if mock == None:
             self.skipTest("Skipping test: mock unavailable")
@@ -1034,7 +1047,17 @@ class ReverseProxyServerTest(unittest.TestCase):
             "host": host,
             "connection": "Upgrade",
             "upgrade": "websocket",
+            "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "sec-websocket-version": "13",
         }
+        # the raw header block preserves the original (case sensitive) header
+        # names exactly as received, the leading separator follows the format
+        # produced by the HTTP parser
+        parser.headers_s = netius.legacy.bytes(
+            "\r\nHost: %s\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n"
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+            "Sec-WebSocket-Version: 13" % host
+        )
         return parser
 
     def _make_response_parser(self, backend, code="200", status="OK"):

--- a/src/netius/test/servers/proxy.py
+++ b/src/netius/test/servers/proxy.py
@@ -66,6 +66,17 @@ class ProxyServerTest(unittest.TestCase):
         parser = Parser(headers={"connection": "Upgrade", "upgrade": "h2c"})
         self.assertEqual(self.server.is_upgrade(parser), False)
 
+        parser = Parser(headers={"connection": "notupgrade", "upgrade": "websocket"})
+        self.assertEqual(self.server.is_upgrade(parser), False)
+
+        parser = Parser(
+            headers={
+                "connection": ["keep-alive", "Upgrade"],
+                "upgrade": ["websocket"],
+            }
+        )
+        self.assertEqual(self.server.is_upgrade(parser), True)
+
         parser = Parser(headers={})
         self.assertEqual(self.server.is_upgrade(parser), False)
 

--- a/src/netius/test/servers/proxy.py
+++ b/src/netius/test/servers/proxy.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import collections
+import unittest
+
+import netius.servers
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+
+class ProxyServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.server = netius.servers.ProxyServer()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+
+    def test_is_upgrade(self):
+        Parser = collections.namedtuple("Parser", "headers")
+
+        parser = Parser(headers={"connection": "Upgrade", "upgrade": "websocket"})
+        self.assertEqual(self.server.is_upgrade(parser), True)
+
+        parser = Parser(
+            headers={"connection": "keep-alive, Upgrade", "upgrade": "WebSocket"}
+        )
+        self.assertEqual(self.server.is_upgrade(parser), True)
+
+        parser = Parser(headers={"connection": "keep-alive"})
+        self.assertEqual(self.server.is_upgrade(parser), False)
+
+        parser = Parser(headers={"connection": "Upgrade", "upgrade": "h2c"})
+        self.assertEqual(self.server.is_upgrade(parser), False)
+
+        parser = Parser(headers={})
+        self.assertEqual(self.server.is_upgrade(parser), False)
+
+    def test_tunnel(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = mock.MagicMock()
+        backend = mock.MagicMock()
+
+        with mock.patch.object(
+            self.server.raw_client, "connect", return_value=backend
+        ) as connect:
+            result = self.server.tunnel(
+                connection, "host.com", 9090, ssl=True, data=b"data"
+            )
+
+        # the back-end connection must be created through the raw client
+        # using the requested host, port and secure transport flag
+        self.assertEqual(result, backend)
+        self.assertEqual(connect.call_args[0], ("host.com", 9090))
+        self.assertEqual(connect.call_args[1], dict(ssl=True))
+
+        # the back-end connection must be set as the tunnel connection of
+        # the front-end and the reverse mapping must exist in the conn map
+        self.assertEqual(connection.tunnel_c, backend)
+        self.assertIn(backend, self.server.conn_map)
+        self.assertEqual(self.server.conn_map[backend], connection)
+
+        # the data and response values must be stored in the back-end so
+        # that they may be used once the connection is established
+        self.assertEqual(backend.tunnel_d, b"data")
+        self.assertEqual(backend.tunnel_r, None)
+
+    def test_on_raw_connect_data(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = mock.MagicMock()
+        backend = mock.MagicMock()
+        backend.tunnel_d = b"data"
+        backend.tunnel_r = None
+        self.server.conn_map[backend] = connection
+
+        self.server._on_raw_connect(self.server.raw_client, backend)
+
+        # the buffered data must be forwarded to the back-end and no
+        # acknowledge response must be sent to the front-end connection
+        self.assertEqual(backend.send.call_args[0], (b"data",))
+        self.assertEqual(connection.send_response.call_count, 0)
+
+        # the data reference must be unset after being sent so that the
+        # request buffer is not retained for the lifetime of the tunnel
+        self.assertEqual(backend.tunnel_d, None)
+
+    def test_on_raw_connect_response(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = mock.MagicMock()
+        backend = mock.MagicMock()
+        backend.tunnel_d = None
+        backend.tunnel_r = (200, "Connection established")
+        self.server.conn_map[backend] = connection
+
+        self.server._on_raw_connect(self.server.raw_client, backend)
+
+        # the acknowledge response must be sent to the front-end connection
+        # and no data must be forwarded to the back-end connection
+        self.assertEqual(connection.send_response.call_count, 1)
+        self.assertEqual(connection.send_response.call_args[1]["code"], 200)
+        self.assertEqual(backend.send.call_count, 0)


### PR DESCRIPTION
## Summary

Adds WebSocket support to the netius reverse proxy. Until now `ReverseProxyServer` forwarded every request through the HTTP client, so a `Connection: Upgrade` / `Upgrade: websocket` request was relayed as a plain HTTP request and the back-end's `101 Switching Protocols` (plus the subsequent binary frames) could not be carried back — WebSocket connections through the reverse proxy were impossible.

This change detects the upgrade and forwards it to the resolved back-end through a **raw byte tunnel**, reusing the exact mechanism already used by the forward proxy `CONNECT` path. The switching-protocols response and all frames then flow back transparently.

Closes #19.

## Approach

- `ProxyServer.is_upgrade(parser)` — detects `Connection: upgrade` + `Upgrade: websocket` (case-insensitive, websocket-specific).
- `ProxyServer.tunnel(connection, host, port, ssl=, data=, response=)` — factors out the raw tunnel setup (back-end connection, `tunnel_c`, `conn_map` mapping). On connect it optionally forwards `data` (the original upgrade request) and/or sends a `response` acknowledge tuple to the front-end. The `CONNECT` `200 Connection established` is now sent here via `_on_raw_connect`.
- `ReverseProxyServer.on_headers` — when `is_upgrade`, resolves the back-end via the **same `rules()`** path (regex / host / forward rules + load balancing all apply), `urlparse`s the prefix for host/port/ssl, rebuilds the original request bytes (including the reverse-proxy forwarding headers) and establishes the tunnel.
- `ForwardProxyServer` `CONNECT` now uses the shared `tunnel()` helper (behaviour preserved).

## Performance / leak safety

This targets a long-running proxy, so the implementation reuses the existing leak-safe machinery rather than adding a new path:

- **No connection / `conn_map` leak** — `tunnel_c` + `conn_map` are set symmetrically; teardown is already handled on both sides by `on_connection_d` / `on_stream_d` (front-end close) and `_on_raw_close` (back-end close, which also `del`s the `conn_map` entry).
- **No retained buffers** — the forwarded request bytes are stored only until the tunnel connects and then unset (`tunnel_d = None`); no per-connection closures retain the parser/connection.
- **Backpressure preserved** — the raw pump (`on_data` / `_on_raw_data`) is already throttle-aware; WebSocket frames are pumped as opaque bytes with no per-frame Python work.

## Tests

- `test/servers/proxy.py` (new) — `is_upgrade`, `tunnel`, and `_on_raw_connect` (data vs response paths).
- `test/extra/proxy_r.py` — WebSocket upgrade routed to a raw tunnel (plain and secure back-end); non-upgrade requests still use the HTTP client.
- `test/extra/proxy_f.py` (new) — `CONNECT` regression: tunnels via the shared helper with the `200` acknowledge; regular methods still use the HTTP client; rejected rules still `403`.

Full suite green locally (the only failure is the pre-existing network-dependent `test_404_no_match`), `black --check` clean.
