### PR TITLE
fix(http): flow control conformance and chunked trailer handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* HTTP/2 responses no longer stall when the client offers a small flow control window - [#74](https://github.com/hivesolutions/netius/issues/74)
+* HTTP/2 window size changes requested after a request has started are now honoured - [#74](https://github.com/hivesolutions/netius/issues/74)
+* An oversized HTTP/2 window update now resets only the affected stream instead of the connection - [#74](https://github.com/hivesolutions/netius/issues/74)
 
 ## [1.60.0] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Bound for the size that a single chunk of a chunked request may announce - [#74](https://github.com/hivesolutions/netius/issues/74)
 
 ### Changed
 
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * HTTP/2 responses no longer stall when the client offers a small flow control window - [#74](https://github.com/hivesolutions/netius/issues/74)
 * HTTP/2 window size changes requested after a request has started are now honoured - [#74](https://github.com/hivesolutions/netius/issues/74)
 * An oversized HTTP/2 window update now resets only the affected stream instead of the connection - [#74](https://github.com/hivesolutions/netius/issues/74)
+* A chunked request that carries a trailer section is now handled instead of being answered twice - [#74](https://github.com/hivesolutions/netius/issues/74)
 
 ## [1.60.0] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * HTTP/2 responses no longer stall when the client offers a small flow control window - [#74](https://github.com/hivesolutions/netius/issues/74)
 * HTTP/2 window size changes requested after a request has started are now honoured - [#74](https://github.com/hivesolutions/netius/issues/74)
-* An oversized HTTP/2 window update now resets only the affected stream instead of the connection - [#74](https://github.com/hivesolutions/netius/issues/74)
+* An HTTP/2 flow control error on a stream now resets only that stream instead of closing the connection - [#74](https://github.com/hivesolutions/netius/issues/74)
 * A chunked request that carries a trailer section is now handled instead of being answered twice - [#74](https://github.com/hivesolutions/netius/issues/74)
 
 ## [1.60.0] - 2026-08-25

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -89,6 +89,7 @@
 | **LINE_LIMIT**     | `int` | `8192`  | The maximum size (in bytes) of the initial line of a request, a larger one is rejected with a `414` status code.                             |
 | **HEADERS_LIMIT**  | `int` | `65536` | The maximum size (in bytes) of the headers section of a request, a larger one is rejected with a `431` status code.                          |
 | **HEADERS_COUNT**  | `int` | `128`   | The maximum number of header lines of a request, a larger number is rejected with a `431` status code.                                       |
+| **CHUNK_LIMIT**    | `int` | `1073741824` | The maximum size (in bytes) that a single chunk of a chunked request may announce, a larger one is rejected with a `400` status code.   |
 | **REQUESTS_LIMIT** | `int` | `1000`  | The maximum number of requests served by a single connection before it stops being a persistent one, set it to `0` to remove the bound.      |
 | **IDLE_TIMEOUT**   | `int` | `75`    | The maximum amount of time (in seconds) that a connection may wait for a new request before being closed, set it to `0` to remove the bound. |
 

--- a/src/netius/common/__init__.py
+++ b/src/netius/common/__init__.py
@@ -103,6 +103,7 @@ from .http import (
     LINE_LIMIT,
     HEADERS_LIMIT,
     HEADERS_COUNT,
+    CHUNK_LIMIT,
     REQUEST,
     RESPONSE,
     PLAIN_ENCODING,

--- a/src/netius/common/http.py
+++ b/src/netius/common/http.py
@@ -76,6 +76,13 @@ number of small headers is sent, this is a default value for the
 parser and may be overridden using the dedicated parameter value
 in the constructor """
 
+CHUNK_LIMIT = 1073741824
+""" The maximum size (in bytes) that a single chunk of a chunked
+message may announce, an unbounded value would otherwise be taken
+by each implementation in a different way, desynchronizing the
+message stream, this is a default value for the parser and may be
+overridden using the dedicated parameter value in the constructor """
+
 REQUEST = 1
 """ The HTTP request message indicator, should be
 used when identifying the HTTP request messages """
@@ -264,6 +271,7 @@ class HTTPParser(parser.Parser):
         "line_limit",
         "headers_limit",
         "headers_count",
+        "chunk_limit",
         "state",
         "buffer",
         "headers",
@@ -291,6 +299,7 @@ class HTTPParser(parser.Parser):
         "chunk_l",
         "chunk_s",
         "chunk_e",
+        "chunk_t",
     )
 
     def __init__(
@@ -302,6 +311,7 @@ class HTTPParser(parser.Parser):
         line_limit=LINE_LIMIT,
         headers_limit=HEADERS_LIMIT,
         headers_count=HEADERS_COUNT,
+        chunk_limit=CHUNK_LIMIT,
     ):
         parser.Parser.__init__(self, owner)
 
@@ -313,6 +323,7 @@ class HTTPParser(parser.Parser):
             line_limit=line_limit,
             headers_limit=headers_limit,
             headers_count=headers_count,
+            chunk_limit=chunk_limit,
         )
 
     def build(self):
@@ -353,6 +364,7 @@ class HTTPParser(parser.Parser):
         line_limit=LINE_LIMIT,
         headers_limit=HEADERS_LIMIT,
         headers_count=HEADERS_COUNT,
+        chunk_limit=CHUNK_LIMIT,
     ):
         """
         Initializes the state of the parser setting the values
@@ -379,6 +391,9 @@ class HTTPParser(parser.Parser):
         :type headers_count: int
         :param headers_count: The maximum number of header lines that the
         message may contain.
+        :type chunk_limit: int
+        :param chunk_limit: The maximum size (in bytes) that a single chunk
+        of a chunked message may announce.
         """
 
         self.close()
@@ -388,6 +403,7 @@ class HTTPParser(parser.Parser):
         self.line_limit = line_limit
         self.headers_limit = headers_limit
         self.headers_count = headers_count
+        self.chunk_limit = chunk_limit
         self.state = LINE_STATE
         self.buffer = []
         self.headers = {}
@@ -415,6 +431,7 @@ class HTTPParser(parser.Parser):
         self.chunk_l = 0
         self.chunk_s = 0
         self.chunk_e = 0
+        self.chunk_t = False
 
     def clear(self, force=False):
         if not force and self.state == LINE_STATE:
@@ -426,6 +443,7 @@ class HTTPParser(parser.Parser):
             line_limit=self.line_limit,
             headers_limit=self.headers_limit,
             headers_count=self.headers_count,
+            chunk_limit=self.chunk_limit,
         )
 
     def close(self):
@@ -1032,6 +1050,12 @@ class HTTPParser(parser.Parser):
         # value this will be increment as bytes are parsed
         count = 0
 
+        # in case the trailer section is the one pending to be parsed
+        # delegates the operation to the proper method, as such section
+        # must be consumed before the message may be considered complete
+        if self.chunk_t:
+            return self._parse_trailer(data)
+
         # verifies if the end of chunk state has been reached
         # that happens when only the last two characters remain
         # to be parsed from the chunk
@@ -1056,20 +1080,12 @@ class HTTPParser(parser.Parser):
             count += self.chunk_l
             self.chunk_l = 0
 
-            # in case the current chunk dimension (size) is
-            # zero this is the last chunk and so the state
-            # must be set to the finish and the on data event
-            # must be triggered to indicate the end of message
-            if self.chunk_d == 0:
-                self.state = FINISH_STATE
-                self.trigger("on_data")
-
-            # otherwise this is the end of a "normal" chunk and
-            # and so the end of chunk index must be calculated
-            # and the chunk event must be triggered
-            else:
-                self.chunk_e = len(self.message)
-                self.trigger("on_chunk", (self.chunk_s, self.chunk_e))
+            # this is the end of a "normal" chunk and so the end of
+            # chunk index must be calculated and the chunk event must
+            # be triggered, note that the last chunk never reaches this
+            # state as it's the one that starts the trailer section
+            self.chunk_e = len(self.message)
+            self.trigger("on_chunk", (self.chunk_s, self.chunk_e))
 
             # in case the message is not meant to be stored or in
             # case the file storage mode is active (spares memory),
@@ -1127,6 +1143,13 @@ class HTTPParser(parser.Parser):
             if not CHUNK_REGEX.match(netius.legacy.str(size)):
                 raise netius.ParserError("Invalid chunk size")
             self.chunk_d = int(size, base=16)
+
+            # verifies that the announced size of the chunk is within the
+            # allowed bounds, as a value that no implementation is able to
+            # honour would otherwise desynchronize the message stream
+            if self.chunk_d > self.chunk_limit:
+                raise netius.ParserError("Chunk size too large")
+
             self.chunk_l = self.chunk_d + 2
             self.chunk_s = len(self.message)
 
@@ -1134,6 +1157,15 @@ class HTTPParser(parser.Parser):
             # provided data by the index of the newline character position
             # plus one byte respecting to the newline character
             count += index + 1
+
+            # in case this is the last chunk the trailer section becomes the
+            # one to be parsed, note that the end of line sequence is restored
+            # to the buffer so that an empty section is detected the same way
+            # as a populated one (required for compliance)
+            if self.chunk_d == 0:
+                self.chunk_t = True
+                self.buffer.append(b"\r\n")
+                return count + self._parse_trailer(data)
 
         # retrieves the partial data that is valid according to the
         # calculated chunk length and then calculates the size of
@@ -1162,6 +1194,74 @@ class HTTPParser(parser.Parser):
         # and then returns the same counter to the caller method
         count += data_s
         return count
+
+    def _parse_trailer(self, data):
+        # creates a temporary buffer with the contents of the current
+        # buffer plus the current data and then joins it to retrieve
+        # the current complete buffer string to be used in the finding
+        # of the end of trailer sequence (required for complete parsing)
+        buffer_t = self.buffer + [data]
+        buffer_s = b"".join(buffer_t)
+
+        # tries to find the end of trailer sequence in case it's not
+        # found returns the zero value meaning that no bytes have been
+        # processed (delays parsing), note that the bounds of the section
+        # are verified so that a peer may not exhaust the memory with it
+        index = buffer_s.find(b"\r\n\r\n")
+        if index == -1:
+            if len(buffer_s) > self.headers_limit:
+                raise netius.ParserError("Trailer too long", code=431)
+            return 0
+
+        # retrieves the partial trailer string from the buffer string
+        # and then deletes the current buffer so that it may be reused
+        # for other partial parsings, note that the fields of the section
+        # are discarded as no handling exists for any of them
+        trailer_s = buffer_s[:index]
+        del self.buffer[:]
+
+        # calculates the base length as the difference between the buffer
+        # string and the length of the currently provided data value and
+        # then uses this value to calculate the base index for the process
+        # data count value
+        base_length = len(buffer_s) - len(data)
+        base_index = index - base_length
+
+        # verifies that the trailer section respects the allowed bounds,
+        # this is the verification for the situation where the complete
+        # section is received at once (the partial one is done above)
+        if len(trailer_s) > self.headers_limit:
+            raise netius.ParserError("Trailer too long", code=431)
+
+        # ensures that no bare carriage return or line feed is present in
+        # the trailer section, either of them would allow the injection of
+        # an extra field, note that each separator accounts for exactly one
+        # of each of these characters so any extra one is a bare (invalid) one
+        lines = trailer_s.split(b"\r\n")
+        separators = len(lines) - 1
+        if (
+            not trailer_s.count(b"\r") == separators
+            or not trailer_s.count(b"\n") == separators
+        ):
+            raise netius.ParserError("Invalid trailer line")
+
+        # the complete trailer section has been received meaning that the
+        # message is now complete, so the state is set to the finish one
+        # and the data event triggered to indicate the end of message
+        self.chunk_t = False
+        self.state = FINISH_STATE
+        self.trigger("on_data")
+
+        # in case the message is not meant to be stored or in case the
+        # file storage mode is active (spares memory), deletes the contents
+        # of the message buffer as they're not going to be used to access
+        # request's data as a whole
+        if not self.store or self.message_f:
+            del self.message[:]
+
+        # returns the number of bytes that have been parsed from the provided
+        # data, note that the end of trailer sequence is consumed by it
+        return base_index + 4
 
     def _store_data(self, data, memory=True):
         if not self.store:

--- a/src/netius/common/http2.py
+++ b/src/netius/common/http2.py
@@ -116,6 +116,11 @@ HTTP2_PSEUDO = (":method", ":scheme", ":path", ":authority", ":status")
 """ The complete set of HTTP 2 based pseudo-header values
 this list should be inclusive and limited """
 
+HTTP2_STREAM_ERRORS = (FLOW_CONTROL_ERROR,)
+""" The sequence of error codes that must remain scoped to the stream
+that has originated them, meaning that only such stream is reset while
+the connection stays usable, as defined by RFC 9113 """
+
 HTTP2_CONNECTION = (
     "connection",
     "keep-alive",
@@ -996,7 +1001,7 @@ class HTTP2Stream(netius.Stream):
         self.store = store
         self.file_limit = file_limit
         self.window = window
-        self.window_m = min(self.window, frame_size - HEADER_SIZE)
+        self.window_m = frame_size - HEADER_SIZE
         self.window_o = self.connection.window_o
         self.window_l = self.window_o
         self.window_t = self.window_o // 2
@@ -1432,9 +1437,14 @@ class HTTP2Stream(netius.Stream):
         return self.encodings
 
     def fragment(self, data):
-        reference = min(self.connection.window, self.window, self.window_m)
-        yield data[:reference]
-        data = data[reference:]
+        # the window of the stream may be a negative value (eg: a reduction of
+        # the initial window size) so the reference is clamped, note that a
+        # zero reference implies no initial fragment as an empty data frame
+        # would otherwise be sent for it
+        reference = max(min(self.connection.window, self.window, self.window_m), 0)
+        if reference:
+            yield data[:reference]
+            data = data[reference:]
         while data:
             yield data[: self.window_m]
             data = data[self.window_m :]

--- a/src/netius/common/http2.py
+++ b/src/netius/common/http2.py
@@ -545,16 +545,20 @@ class HTTP2Parser(parser.Parser):
     def assert_window_update(self, stream, increment):
         if increment == 0:
             raise netius.ParserError(
-                "WINDOW_UPDATE increment must not be zero", error_code=PROTOCOL_ERROR
+                "WINDOW_UPDATE increment must not be zero",
+                stream=self.stream,
+                error_code=PROTOCOL_ERROR,
             )
-        if self.owner.window + increment > 2147483647:
+        if self.stream == 0x00 and self.owner.window + increment > 2147483647:
             raise netius.ParserError(
                 "Window value for the connection too large",
                 error_code=FLOW_CONTROL_ERROR,
             )
         if stream and stream.window + increment > 2147483647:
             raise netius.ParserError(
-                "Window value for the stream too large", error_code=FLOW_CONTROL_ERROR
+                "Window value for the stream too large",
+                stream=self.stream,
+                error_code=FLOW_CONTROL_ERROR,
             )
 
     def assert_continuation(self, stream):

--- a/src/netius/servers/http.py
+++ b/src/netius/servers/http.py
@@ -52,6 +52,7 @@ from netius.common import (
     LINE_LIMIT,
     HEADERS_LIMIT,
     HEADERS_COUNT,
+    CHUNK_LIMIT,
     PLAIN_ENCODING,
     CHUNKED_ENCODING,
     GZIP_ENCODING,
@@ -218,6 +219,7 @@ class HTTPConnection(netius.Connection):
             line_limit=self.owner.line_limit,
             headers_limit=self.owner.headers_limit,
             headers_count=self.owner.headers_count,
+            chunk_limit=self.owner.chunk_limit,
         )
         self.parser.bind("on_data", self.on_data)
         self.set_idle()
@@ -899,6 +901,7 @@ class HTTPServer(netius.StreamServer):
         line_limit=LINE_LIMIT,
         headers_limit=HEADERS_LIMIT,
         headers_count=HEADERS_COUNT,
+        chunk_limit=CHUNK_LIMIT,
         requests_limit=REQUESTS_LIMIT,
         idle_timeout=IDLE_TIMEOUT,
         *args,
@@ -918,6 +921,7 @@ class HTTPServer(netius.StreamServer):
         self.line_limit = line_limit
         self.headers_limit = headers_limit
         self.headers_count = headers_count
+        self.chunk_limit = chunk_limit
         self.requests_limit = requests_limit
         self.idle_timeout = idle_timeout
         self.dynamic = False
@@ -1084,6 +1088,8 @@ class HTTPServer(netius.StreamServer):
             self.headers_count = self.get_env(
                 "HEADERS_COUNT", self.headers_count, cast=int
             )
+        if self.env:
+            self.chunk_limit = self.get_env("CHUNK_LIMIT", self.chunk_limit, cast=int)
         if self.env:
             self.requests_limit = self.get_env(
                 "REQUESTS_LIMIT", self.requests_limit, cast=int

--- a/src/netius/servers/http2.py
+++ b/src/netius/servers/http2.py
@@ -619,6 +619,51 @@ class HTTP2Connection(http.HTTPConnection):
         # "immediately" by this method
         return 0
 
+    def split_frame(self, frame, size):
+        """
+        Splits the provided (delayed) frame so that only the first size
+        bytes of its payload are sent immediately, keeping the remaining
+        payload in the frame for a latter flush operation.
+
+        This operation is required whenever the flow control window that
+        is available for a stream is smaller than the payload pending to
+        be sent, as the sender must still make partial progress on it.
+
+        :type frame: Tuple
+        :param frame: The tuple describing the delayed frame that is going
+        to be split, note that its payload is changed in place.
+        :type size: int
+        :param size: The number of bytes of the payload that are going to
+        be sent by the current (partial) send operation.
+        :rtype: int
+        :return: The final number of bytes that have been sent by the
+        current partial send operation.
+        """
+
+        # retrieves the keyword arguments of the frame and uses them to
+        # obtain both the payload and the stream for which the frame is
+        # meant to be sent, then keeps only the remaining payload delayed
+        kwargs = frame[1]
+        payload = kwargs["payload"]
+        stream = kwargs["stream"]
+        kwargs["payload"] = payload[size:]
+
+        # builds the flags value to be used in the partial frame, unsetting
+        # the end stream flag as the stream is not going to be closed by it
+        flags = kwargs["flags"] & 0xFE
+
+        # decrements both the connection and the stream windows by the size
+        # of the part that is going to be sent and then sends such part, note
+        # that the callback is not registered as the frame is not yet complete
+        self.increment_remote(stream, size * -1, all=True)
+        return self.send_frame(
+            type=kwargs["type"],
+            flags=flags,
+            payload=payload[:size],
+            stream=stream,
+            delay=kwargs["delay"],
+        )
+
     def flush_frames(self, all=True):
         """
         Runs the flush operation on the delayed/pending frames, meaning
@@ -697,9 +742,18 @@ class HTTP2Connection(http.HTTPConnection):
             # as starved and the current iteration is skipped trying to
             # flush frames from different streams
             available = self.available_stream(stream, payload_l, strict=False)
-            if not available and not all:
-                return False
-            if not available and all:
+            if not available:
+                # tries to determine if at least a part of the payload may be
+                # sent and if that's the case splits the frame sending such
+                # part and keeping the remaining one delayed, this is required
+                # so that a peer announcing a window smaller than the payload
+                # is still able to receive the data
+                partial = self.partial_stream(stream, payload_l)
+                if partial:
+                    self.split_frame(frame, partial)
+                    continue
+                if not all:
+                    return False
                 starved[stream] = True
                 offset += 1
                 continue
@@ -735,6 +789,16 @@ class HTTP2Connection(http.HTTPConnection):
             self.try_available(stream)
 
     def set_settings(self, settings):
+        # determines the delta to be applied to the (remote) window of the
+        # streams that are already open, as a change to the initial window
+        # size must be applied to them as well (as per RFC 9113)
+        delta = 0
+        if netius.common.http2.SETTINGS_INITIAL_WINDOW_SIZE in settings:
+            delta = (
+                settings[netius.common.http2.SETTINGS_INITIAL_WINDOW_SIZE]
+                - self.settings_r[netius.common.http2.SETTINGS_INITIAL_WINDOW_SIZE]
+            )
+
         self.settings_r.update(settings)
 
         # propagates a peer-driven `SETTINGS_HEADER_TABLE_SIZE` change
@@ -753,6 +817,16 @@ class HTTP2Connection(http.HTTPConnection):
                 netius.common.http2.SETTINGS_HEADER_TABLE_SIZE
             ]
 
+        # applies the initial window size delta to the complete set of open
+        # streams and then flushes the frames that may have become sendable,
+        # note that the resulting window value may become negative, in which
+        # case no data is sent for the stream until it's positive again
+        if delta and self.parser and not self.legacy:
+            for stream in netius.legacy.values(self.parser.streams):
+                stream.remote_update(delta)
+            self.flush_frames()
+            self.flush_available()
+
     def close_stream(self, stream, final=False, flush=False, reset=False):
         if not self.parser._has_stream(stream):
             return
@@ -763,20 +837,45 @@ class HTTP2Connection(http.HTTPConnection):
         stream.close(flush=flush, reset=reset)
 
     def available_stream(self, stream, length, strict=True):
-        if self.window == 0:
-            return False
-        if self.window < length:
+        # a zero length payload does not consume any of the flow control
+        # windows and as such is always considered to be available, note
+        # that the ordering constraints are still going to be verified
+        if length > 0 and self.window < length:
             return False
         stream = self.parser._get_stream(stream)
         if not stream:
             return True
-        if stream.window == 0:
-            return False
-        if stream.window < length:
+        if length > 0 and stream.window < length:
             return False
         if strict and stream.frames:
             return False
         return True
+
+    def partial_stream(self, stream, length):
+        """
+        Determines the amount of bytes of the provided length that may be
+        immediately sent for the stream with the provided identifier, taking
+        into account both the connection and the stream windows.
+
+        This value is used to split a delayed data frame whenever the window
+        available is smaller than the payload pending to be sent.
+
+        :type stream: int
+        :param stream: The identifier of the stream that is going to be
+        tested for the amount of bytes available for sending.
+        :type length: int
+        :param length: The length (in bytes) of the payload that is currently
+        pending to be sent for the stream.
+        :rtype: int
+        :return: The number of bytes that may be immediately sent, note that
+        this value may be zero meaning that nothing may be sent.
+        """
+
+        length = min(length, self.window)
+        stream = self.parser._get_stream(stream)
+        if stream:
+            length = min(length, stream.window)
+        return max(length, 0)
 
     def fragment_stream(self, stream, data):
         stream = self.parser._get_stream(stream)

--- a/src/netius/servers/http2.py
+++ b/src/netius/servers/http2.py
@@ -822,7 +822,19 @@ class HTTP2Connection(http.HTTPConnection):
         # note that the resulting window value may become negative, in which
         # case no data is sent for the stream until it's positive again
         if delta and self.parser and not self.legacy:
-            for stream in netius.legacy.values(self.parser.streams):
+            streams = netius.legacy.values(self.parser.streams)
+
+            # verifies that the resulting window of every open stream is still
+            # within the allowed bounds, as a change that makes any of them too
+            # large is a connection level error (as per RFC 9113)
+            for stream in streams:
+                if stream.window + delta > 2147483647:
+                    raise netius.ParserError(
+                        "Value of SETTINGS_INITIAL_WINDOW_SIZE makes a window too large",
+                        error_code=netius.common.http2.FLOW_CONTROL_ERROR,
+                    )
+
+            for stream in streams:
                 stream.remote_update(delta)
             self.flush_frames()
             self.flush_available()
@@ -858,7 +870,8 @@ class HTTP2Connection(http.HTTPConnection):
         into account both the connection and the stream windows.
 
         This value is used to split a delayed data frame whenever the window
-        available is smaller than the payload pending to be sent.
+        available is smaller than the payload pending to be sent, and is also
+        bound by the maximum payload that a frame is allowed to carry.
 
         :type stream: int
         :param stream: The identifier of the stream that is going to be
@@ -874,7 +887,7 @@ class HTTP2Connection(http.HTTPConnection):
         length = min(length, self.window)
         stream = self.parser._get_stream(stream)
         if stream:
-            length = min(length, stream.window)
+            length = min(length, stream.window, stream.window_m)
         return max(length, 0)
 
     def fragment_stream(self, stream, data):
@@ -1041,6 +1054,14 @@ class HTTP2Connection(http.HTTPConnection):
         close=True,
         callback=None,
     ):
+        # an error that is meant to be scoped to the stream resets only such
+        # stream, so that the connection (and the remaining streams) stays
+        # usable, otherwise the connection is terminated right after the reset
+        if error_code in netius.common.http2.HTTP2_STREAM_ERRORS:
+            return self.send_rst_stream(
+                error_code=error_code, stream=stream, callback=callback
+            )
+
         self.send_rst_stream(
             error_code=error_code,
             stream=stream,

--- a/src/netius/test/clients/http.py
+++ b/src/netius/test/clients/http.py
@@ -164,6 +164,34 @@ class HTTPProtocolTest(unittest.TestCase):
         result = protocol.send_request()
         self.assertEqual(result, None)
 
+    def test_on_data_chunked_trailer(self):
+        protocol = netius.clients.HTTPProtocol(
+            "GET", "http://example.com/", asynchronous=True
+        )
+        protocol.parser = netius.common.HTTPParser(
+            protocol, type=netius.common.RESPONSE, store=True
+        )
+
+        messages = []
+        protocol.parser.bind(
+            "on_data",
+            lambda: messages.append(
+                (protocol.parser.code, protocol.parser.get_message())
+            ),
+        )
+
+        # a chunked response that ends with a trailer section must be parsed
+        # as a single message, with the fields of the section discarded, and
+        # the connection left ready for the response that follows it, otherwise
+        # the reuse of a keep alive connection would be desynchronized
+        protocol.on_data(
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+            b"\r\nb\r\nHello World\r\n0\r\nX-Checksum: abc\r\n\r\n"
+            b"HTTP/1.1 201 Created\r\nContent-Length: 6\r\n\r\nsecond"
+        )
+
+        self.assertEqual(messages, [(200, b"Hello World"), (201, b"second")])
+
     def test_apply_dynamic(self):
         protocol = netius.clients.HTTPProtocol(
             "GET", "http://example.com/", asynchronous=True

--- a/src/netius/test/common/http.py
+++ b/src/netius/test/common/http.py
@@ -575,6 +575,79 @@ class HTTPParserTest(unittest.TestCase):
         )
         self.assertEqual(parser.get_message(), b"Hello World")
 
+        # the announced size of a chunk must be within the allowed bounds, as
+        # a value that no implementation is able to honour would desynchronize
+        # the message stream of a more permissive peer
+        self._assert_error(
+            b"GET / HTTP/1.1\r\nHost: localhost\r\n"
+            b"Transfer-Encoding: chunked\r\n\r\nffffffffffffffff\r\n"
+        )
+
+        # the bound of the size is a configurable one, a chunk that announces
+        # exactly the limit is accepted while a larger one is rejected
+        parser = self._parse(
+            b"GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n"
+            b"\r\n10\r\n",
+            chunk_limit=16,
+        )
+        self.assertEqual(parser.chunk_d, 16)
+        self._assert_error(
+            b"GET / HTTP/1.1\r\nHost: localhost\r\n"
+            b"Transfer-Encoding: chunked\r\n\r\n11\r\n",
+            chunk_limit=16,
+        )
+
+    def test_chunked_trailer(self):
+        # the trailer section that follows the last chunk must be explicitly
+        # consumed, otherwise its fields would be taken as the initial line
+        # of an extra (smuggled) request
+        parser = self._parse(
+            b"GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n"
+            b"\r\nb\r\nHello World\r\n0\r\nX-Checksum: abc\r\n\r\n"
+        )
+        self.assertEqual(parser.state, netius.common.http.FINISH_STATE)
+        self.assertEqual(parser.get_message(), b"Hello World")
+
+        # a message carrying a trailer section may still be followed by another
+        # one under the same connection, meaning that pipelining is preserved
+        parser = self._parse(
+            b"GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n"
+            b"\r\nb\r\nHello World\r\n0\r\nX-Checksum: abc\r\n\r\n"
+            b"GET /next HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        )
+        self.assertEqual(parser.state, netius.common.http.FINISH_STATE)
+        self.assertEqual(parser.path_s, "/next")
+
+        # the trailer section may be received in multiple parts, in which case
+        # it must be buffered until the end of the section is found
+        parser = netius.common.HTTPParser(self, type=netius.common.REQUEST, store=True)
+        try:
+            data = (
+                b"GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n"
+                b"\r\nb\r\nHello World\r\n0\r\nX-A: 1\r\nX-B: 2\r\n\r\n"
+            )
+            for index in range(len(data)):
+                parser.parse(data[index : index + 1])
+            self.assertEqual(parser.state, netius.common.http.FINISH_STATE)
+            self.assertEqual(parser.get_message(), b"Hello World")
+        finally:
+            parser.clear()
+
+        # a bare carriage return or line feed in the trailer section must be
+        # rejected as either of them would allow the injection of an extra field
+        self._assert_error(
+            b"GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n"
+            b"\r\n0\r\nX-A: 1\nX-B: 2\r\n\r\n"
+        )
+
+        # the size of the trailer section is bound by the same value that bounds
+        # the headers section, avoiding the unbounded buffering of data
+        self._assert_error(
+            b"GET / HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n"
+            b"\r\n0\r\nX-Pad: " + b"a" * 70000 + b"\r\n\r\n",
+            code=431,
+        )
+
     def test_file(self):
         parser = netius.common.HTTPParser(
             self, type=netius.common.REQUEST, store=True, file_limit=-1

--- a/src/netius/test/common/http.py
+++ b/src/netius/test/common/http.py
@@ -648,6 +648,37 @@ class HTTPParserTest(unittest.TestCase):
             code=431,
         )
 
+    def test_chunked_trailer_response(self):
+        # a response carries the trailer section under the same rules as a
+        # request, this is the direction used by both the client and the proxy
+        parser = self._parse(
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nTrailer: X-Checksum\r\n"
+            b"\r\nb\r\nHello World\r\n0\r\nX-Checksum: abc\r\n\r\n",
+            type=netius.common.RESPONSE,
+        )
+        self.assertEqual(parser.state, netius.common.http.FINISH_STATE)
+        self.assertEqual(parser.code, 200)
+        self.assertEqual(parser.get_message(), b"Hello World")
+
+        # a connection that is kept alive may carry another response right
+        # after one that ends with a trailer section, so the section must not
+        # be left in the stream to be taken as the status line of the next one
+        messages = []
+        parser = netius.common.HTTPParser(self, type=netius.common.RESPONSE, store=True)
+        try:
+            parser.bind(
+                "on_data",
+                lambda: messages.append((parser.code, parser.get_message())),
+            )
+            parser.parse(
+                b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n"
+                b"\r\nb\r\nHello World\r\n0\r\nX-Checksum: abc\r\n\r\n"
+                b"HTTP/1.1 201 Created\r\nContent-Length: 6\r\n\r\nsecond"
+            )
+            self.assertEqual(messages, [(200, b"Hello World"), (201, b"second")])
+        finally:
+            parser.clear()
+
     def test_file(self):
         parser = netius.common.HTTPParser(
             self, type=netius.common.REQUEST, store=True, file_limit=-1

--- a/src/netius/test/common/http2.py
+++ b/src/netius/test/common/http2.py
@@ -311,6 +311,41 @@ class HTTP2ParserTest(unittest.TestCase):
                 )
 
             parser.assert_window_update(None, 4096)
+
+            # the connection window may only be changed by an update sent
+            # for the zero stream, so an update sent for a "normal" stream
+            # must not be verified against the value of such window
+            parser.stream = 0x01
+            parser.assert_window_update(None, 2147483647)
+
+            # an update that overflows the window of the stream is a stream
+            # level error, meaning that only such stream is reset by it
+            stream = netius.common.http2.HTTP2Stream.__new__(
+                netius.common.http2.HTTP2Stream
+            )
+            stream.window = 1
+
+            if hasattr(self, "assertRaisesRegexp"):
+                self.assertRaisesRegexp(
+                    netius.ParserError,
+                    "Window value for the stream too large",
+                    lambda: parser.assert_window_update(stream, 2147483647),
+                )
+            else:
+                self.assertRaisesRegex(
+                    netius.ParserError,
+                    "Window value for the stream too large",
+                    lambda: parser.assert_window_update(stream, 2147483647),
+                )
+
+            try:
+                parser.assert_window_update(stream, 2147483647)
+            except netius.ParserError as error:
+                self.assertEqual(error.get_kwarg("stream"), 0x01)
+                self.assertEqual(
+                    error.get_kwarg("error_code"),
+                    netius.common.http2.FLOW_CONTROL_ERROR,
+                )
         finally:
             parser.clear(force=True)
 

--- a/src/netius/test/common/http2.py
+++ b/src/netius/test/common/http2.py
@@ -600,6 +600,41 @@ class HTTP2StreamTest(unittest.TestCase):
         finally:
             parser.clear(force=True)
 
+    def test_fragment(self):
+        connection = self._make_connection()
+        parser = connection.parser
+        try:
+            # the maximum payload of a frame is bound by the maximum frame size
+            # of the peer and not by the window, so that a stream opened under
+            # an exhausted window is still able to fragment its payload
+            stream = netius.common.http2.HTTP2Stream(
+                identifier=1, owner=parser, window=0, frame_size=16384
+            )
+
+            self.assertEqual(stream.window_m, 16384 - netius.common.http2.HEADER_SIZE)
+            self.assertEqual(stream.fragmentable(b"x" * 20000), True)
+
+            # with an exhausted window no initial fragment is produced, as an
+            # empty data frame would otherwise be sent for it
+            fragments = list(stream.fragment(b"x" * 20000))
+            self.assertEqual([len(fragment) for fragment in fragments], [16375, 3625])
+
+            # the initial fragment is the one that fits the current window while
+            # the remaining ones are bound by the maximum payload of a frame
+            stream.remote_update(1000)
+            fragments = list(stream.fragment(b"x" * 20000))
+            self.assertEqual(
+                [len(fragment) for fragment in fragments], [1000, 16375, 2625]
+            )
+
+            # a negative window (eg: a reduction of the initial window size)
+            # must not produce an initial fragment either
+            stream.remote_update(-1001)
+            fragments = list(stream.fragment(b"x" * 20000))
+            self.assertEqual([len(fragment) for fragment in fragments], [16375, 3625])
+        finally:
+            parser.clear(force=True)
+
     def test_assert_headers(self):
         connection = self._make_connection()
         parser = connection.parser
@@ -703,6 +738,7 @@ class HTTP2StreamTest(unittest.TestCase):
         connection.encoding_c = None
         connection.encodings_a = None
         connection.dynamic = None
+        connection.window = netius.common.HTTP2_WINDOW
         connection.window_o = netius.common.HTTP2_WINDOW
         connection.parser = netius.common.HTTP2Parser(connection, store=True)
         return connection

--- a/src/netius/test/servers/http2.py
+++ b/src/netius/test/servers/http2.py
@@ -90,6 +90,70 @@ class HTTP2ConnectionTest(unittest.TestCase):
         self.settings_r = dict(netius.common.HTTP2_SETTINGS)
         self.window = netius.common.HTTP2_WINDOW
 
+    def test_split_frame(self):
+        connection = self._make_connection()
+        try:
+            stream = self._make_stream(connection, window=1)
+
+            # the payload is larger than the window of the stream so the
+            # frame must be delayed instead of being sent immediately
+            connection.send_data(b"hello", stream=stream.identifier)
+
+            self.assertEqual(len(connection.sent), 0)
+            self.assertEqual(len(connection.frames), 1)
+            self.assertEqual(connection.frames[0][1]["payload"], b"hello")
+
+            connection.split_frame(connection.frames[0], 1)
+
+            # only the first byte of the payload should have been sent, with
+            # the end stream flag unset, as the frame is not yet complete
+            self.assertEqual(len(connection.sent), 1)
+            self.assertEqual(connection.sent[0][4:5], b"\x00")
+            self.assertEqual(connection.sent[0][9:], b"h")
+
+            # the remaining payload must be kept in the delayed frame and
+            # both of the windows decremented by the amount that was sent
+            self.assertEqual(connection.frames[0][1]["payload"], b"ello")
+            self.assertEqual(stream.window, 0)
+            self.assertEqual(connection.window, self.window - 1)
+        finally:
+            connection.parser.clear(force=True)
+
+    def test_flush_frames(self):
+        connection = self._make_connection()
+        try:
+            stream = self._make_stream(connection, window=0)
+
+            connection.send_data(b"hello", stream=stream.identifier)
+
+            self.assertEqual(len(connection.sent), 0)
+            self.assertEqual(len(connection.frames), 1)
+            self.assertEqual(connection.unavailable, {stream.identifier: True})
+
+            # a window that only accommodates part of the payload must still
+            # make progress, sending such part and delaying the remaining one
+            stream.remote_update(2)
+            connection.flush_frames()
+
+            self.assertEqual(len(connection.sent), 1)
+            self.assertEqual(connection.sent[0][4:5], b"\x00")
+            self.assertEqual(connection.sent[0][9:], b"he")
+            self.assertEqual(connection.frames[0][1]["payload"], b"llo")
+            self.assertEqual(stream.window, 0)
+
+            # as soon as the window becomes large enough the remaining payload
+            # is sent as a whole, this time carrying the end stream flag
+            stream.remote_update(3)
+            connection.flush_frames()
+
+            self.assertEqual(len(connection.sent), 2)
+            self.assertEqual(connection.sent[1][4:5], b"\x01")
+            self.assertEqual(connection.sent[1][9:], b"llo")
+            self.assertEqual(len(connection.frames), 0)
+            self.assertEqual(stream.frames, 0)
+        finally:
+            connection.parser.clear(force=True)
+
     def test_set_settings(self):
         if hpack == None:
             self.skipTest("Skipping test: hpack unavailable")
@@ -121,3 +185,122 @@ class HTTP2ConnectionTest(unittest.TestCase):
             self.assertEqual(connection.parser._encoder.header_table_size, 16384)
         finally:
             connection.parser.clear(force=True)
+
+    def test_set_settings_window(self):
+        connection = self._make_connection()
+        connection.settings_r[netius.common.http2.SETTINGS_INITIAL_WINDOW_SIZE] = 3
+        try:
+            stream = self._make_stream(connection, window=3)
+
+            connection.send_data(b"hello", stream=stream.identifier)
+
+            self.assertEqual(len(connection.sent), 0)
+            self.assertEqual(len(connection.frames), 1)
+
+            # a change to the initial window size must be applied to the
+            # streams that are already open, unblocking the delayed frame
+            connection.set_settings(
+                {netius.common.http2.SETTINGS_INITIAL_WINDOW_SIZE: 4}
+            )
+
+            self.assertEqual(stream.window, 0)
+            self.assertEqual(len(connection.sent), 1)
+            self.assertEqual(connection.sent[0][9:], b"hell")
+            self.assertEqual(connection.frames[0][1]["payload"], b"o")
+
+            # a reduction of the initial window size must be applied as well,
+            # even if that makes the window of the stream a negative value
+            connection.set_settings(
+                {netius.common.http2.SETTINGS_INITIAL_WINDOW_SIZE: 3}
+            )
+
+            self.assertEqual(stream.window, -1)
+            self.assertEqual(len(connection.sent), 1)
+        finally:
+            connection.parser.clear(force=True)
+
+    def test_available_stream(self):
+        connection = self._make_connection()
+        try:
+            stream = self._make_stream(connection, window=4)
+
+            self.assertEqual(connection.available_stream(stream.identifier, 4), True)
+            self.assertEqual(connection.available_stream(stream.identifier, 5), False)
+
+            # a zero length payload does not consume any of the windows so
+            # it remains available even for an exhausted stream window
+            stream.remote_update(-4)
+
+            self.assertEqual(connection.available_stream(stream.identifier, 1), False)
+            self.assertEqual(connection.available_stream(stream.identifier, 0), True)
+
+            # the ordering constraint must still be verified, so that a frame
+            # is never sent ahead of the ones that are already delayed
+            stream.frames += 1
+
+            self.assertEqual(connection.available_stream(stream.identifier, 0), False)
+            self.assertEqual(
+                connection.available_stream(stream.identifier, 0, strict=False), True
+            )
+        finally:
+            connection.parser.clear(force=True)
+
+    def test_partial_stream(self):
+        connection = self._make_connection()
+        try:
+            stream = self._make_stream(connection, window=2)
+
+            self.assertEqual(connection.partial_stream(stream.identifier, 5), 2)
+            self.assertEqual(connection.partial_stream(stream.identifier, 1), 1)
+
+            # a negative window (eg: a reduction of the initial window size)
+            # must never produce a negative amount of bytes to be sent
+            stream.remote_update(-3)
+
+            self.assertEqual(connection.partial_stream(stream.identifier, 5), 0)
+
+            # the window of the connection is an upper bound for the value,
+            # even when the window of the stream is larger than it
+            stream.remote_update(1024)
+            connection.window = 4
+
+            self.assertEqual(connection.partial_stream(stream.identifier, 5), 4)
+        finally:
+            connection.parser.clear(force=True)
+
+    def _make_connection(self):
+        # builds a minimal HTTP/2 connection (and parser) that satisfies the
+        # window probes performed by the flow control operations, replacing
+        # the send operation by a simple collector of the sent messages
+        connection = netius.servers.http2.HTTP2Connection.__new__(
+            netius.servers.http2.HTTP2Connection
+        )
+        connection.legacy = False
+        connection.owner = netius.servers.HTTP2Server()
+        connection.encoding = netius.common.PLAIN_ENCODING
+        connection.current = connection.base_encoding()
+        connection.encoding_c = None
+        connection.encodings_a = None
+        connection.dynamic = None
+        connection.settings = dict(self.settings)
+        connection.settings_r = dict(self.settings_r)
+        connection.window = self.window
+        connection.window_o = self.settings[
+            netius.common.http2.SETTINGS_INITIAL_WINDOW_SIZE
+        ]
+        connection.frames = []
+        connection.unavailable = {}
+        connection.sent = []
+        connection.send = lambda data, **kwargs: connection.sent.append(data)
+        connection.parser = netius.common.HTTP2Parser(connection, store=True)
+        return connection
+
+    def _make_stream(self, connection, window=netius.common.HTTP2_WINDOW):
+        # builds an open stream with the requested (remote) window, registering
+        # it in the parser so that the flow control operations may reach it
+        stream = netius.common.http2.HTTP2Stream(
+            identifier=1, owner=connection.parser, window=window
+        )
+        stream.open()
+        connection.parser._set_stream(stream)
+        return stream

--- a/src/netius/test/servers/http2.py
+++ b/src/netius/test/servers/http2.py
@@ -216,6 +216,18 @@ class HTTP2ConnectionTest(unittest.TestCase):
 
             self.assertEqual(stream.window, -1)
             self.assertEqual(len(connection.sent), 1)
+
+            # a change that takes the window of an open stream above the maximum
+            # allowed value is a connection level error (as per RFC 9113)
+            connection.increment_remote(stream.identifier, 2147483647 - stream.window)
+            self.assertEqual(stream.window, 2147483647)
+            self.assertRaises(
+                netius.ParserError,
+                lambda: connection.set_settings(
+                    {netius.common.http2.SETTINGS_INITIAL_WINDOW_SIZE: 4}
+                ),
+            )
+            self.assertEqual(stream.window, 2147483647)
         finally:
             connection.parser.clear(force=True)
 
@@ -265,6 +277,45 @@ class HTTP2ConnectionTest(unittest.TestCase):
             connection.window = 4
 
             self.assertEqual(connection.partial_stream(stream.identifier, 5), 4)
+
+            # the maximum payload that a frame may carry is also an upper bound
+            # for the value, so that no oversized frame is ever produced
+            stream.remote_update(1024 * 1024)
+            connection.window = 1024 * 1024
+
+            self.assertEqual(
+                connection.partial_stream(stream.identifier, 1024 * 1024),
+                stream.window_m,
+            )
+        finally:
+            connection.parser.clear(force=True)
+
+    def test_error_stream(self):
+        connection = self._make_connection()
+        try:
+            stream = self._make_stream(connection)
+
+            # an error that is scoped to the stream resets only such stream,
+            # keeping the connection usable for the remaining ones
+            connection.error_stream(
+                stream.identifier, error_code=netius.common.http2.FLOW_CONTROL_ERROR
+            )
+
+            self.assertEqual(len(connection.sent), 1)
+            self.assertEqual(connection.sent[0][3:4], b"\x03")
+
+            # an error that is not scoped to the stream terminates the
+            # connection right after the reset of the stream
+            del connection.sent[:]
+            connection.error_stream(
+                stream.identifier,
+                error_code=netius.common.http2.PROTOCOL_ERROR,
+                close=False,
+            )
+
+            self.assertEqual(len(connection.sent), 2)
+            self.assertEqual(connection.sent[0][3:4], b"\x03")
+            self.assertEqual(connection.sent[1][3:4], b"\x07")
         finally:
             connection.parser.clear(force=True)
 
@@ -291,7 +342,14 @@ class HTTP2ConnectionTest(unittest.TestCase):
         connection.frames = []
         connection.unavailable = {}
         connection.sent = []
-        connection.send = lambda data, **kwargs: connection.sent.append(data)
+
+        def send(data, callback=None, **kwargs):
+            connection.sent.append(data)
+            if callback:
+                callback(connection)
+            return len(data)
+
+        connection.send = send
         connection.parser = netius.common.HTTP2Parser(connection, store=True)
         return connection
 


### PR DESCRIPTION
Closes the remaining HTTP/2 and chunked items of #74, which completes the checklist.

## Part 1: HTTP/2 flow control

`h2spec 2.6.0` reported 6 failures against the TLS server. Two of them were recorded on the issue as missing rejections, but a fresh run shows the opposite: they are `MUST accept` tests, and what actually happens is that the response stalls.

| Test | Requirement | Actual on `master` |
| --- | --- | --- |
| generic 2.2 | MUST accept `WINDOW_UPDATE` on half-closed (remote) | `HEADERS` sent, `DATA` never follows |
| generic 2.3 | MUST accept `PRIORITY` on half-closed (remote) | same stall |
| 4.2.3 | oversized `HEADERS` → `FRAME_SIZE_ERROR` | not a defect, see below |
| 6.9.1.3 | stream window above 2^31-1 → `RST_STREAM` | connection reset by peer |
| 6.9.2.1 | `SETTINGS_INITIAL_WINDOW_SIZE` must adjust open streams | only a `SETTINGS` ACK |
| 6.9.2.2 | must track a negative window | timeout |

All four real failures share one root cause. `h2spec` announces a `SETTINGS_INITIAL_WINDOW_SIZE` of `0` (or `3`), sends the request, and only then grants a window of a single byte. The response body is queued as one `DATA` frame and `flush_frames` only ever sent a delayed frame when the *whole* payload fitted, so a window smaller than the payload meant the frame was never sent at all.

* `split_frame` sends the part of a delayed `DATA` frame that fits the current window and keeps the remainder queued, clearing `END_STREAM` on the partial frame so the stream is not closed early. `flush_frames` uses it whenever the stream is starved but a positive window remains.
* `partial_stream` reports how many bytes of a payload may be sent right now, bounded by both windows and never negative.
* `set_settings` applies a `SETTINGS_INITIAL_WINDOW_SIZE` change to the streams that are already open, as RFC 9113 section 6.9.2 requires, and then flushes. The resulting window may go negative, which is what 6.9.2.2 exercises.
* `assert_window_update` only verifies the connection window when the update targets stream `0`. A stream update cannot change the connection window, so checking it there turned a stream level overflow into a `GOAWAY`; it is now the `RST_STREAM` with `FLOW_CONTROL_ERROR` that RFC 9113 section 6.9.1 asks for. The zero increment case is likewise scoped to the stream that carried it.
* `available_stream` no longer treats a zero length payload as window consuming. An empty `DATA` frame carries no flow control cost, so an exhausted window was leaving the final empty frame of a stream queued forever.

`h2spec -t -k` goes from **140** to **145** of 146 passed, stable across runs.

The one remaining failure is 4.2.3, which the issue already records as not a defect and this run confirms. The server advertises a `SETTINGS_MAX_FRAME_SIZE` of `131072` (the optimal profile, allowed up to `16777215` by RFC 9113 section 6.5.2) while `h2spec` sends the oversized `HEADERS` frame at a fixed `17575` bytes instead of scaling it to the advertised value, so accepting it is correct. Enforcement itself is present in `assert_header` and was verified.

## Part 2: chunked trailer section and chunk size bound

The last chunk of a chunked message is followed by a trailer section, which the parser was not consuming. It read the `0` line and then took the next two bytes as the terminator, so the first trailer field was left in the stream and parsed as the initial line of a new request.

The effect is a response queue desynchronization, reproduced end to end against a real server and a reverse proxy in front of a WSGI back end:

| Case | before | after |
| --- | --- | --- |
| direct request carrying a trailer | **2 responses** (`200` then `400`) | 1 response, body intact |
| the same request through the proxy | `400`, back end never saw it | 1 response, body intact |
| `GET /admin` smuggled as a trailer field | 1 back end request | 1 back end request |

Emitting a second, unsolicited response to a single request is exactly the desynchronization primitive this issue is about, so a peer that pipelines would read the `400` as the answer to its next request.

* `_parse_trailer` consumes the section and discards its fields, mirroring `_parse_headers`: it is bounded by `headers_limit` and rejected with `431` when exceeded, and a bare carriage return or line feed inside it is rejected, since either would allow an extra field to be injected. The end of line sequence of the last chunk is restored to the buffer so an empty section is detected exactly like a populated one, which is the same idiom `_parse_line` already uses.
* The zero chunk no longer reaches the end of chunk state, so the branch that handled it there was removed rather than left dead.
* `CHUNK_LIMIT` bounds the size a single chunk may announce, defaulting to `1073741824`. `ffffffffffffffff` was previously accepted, and a value no implementation can honour is a framing disagreement waiting to happen. It is exposed as a server option and an environment variable alongside the sibling limits and documented in `doc/configuration.md`.

## Client side impact

The parser is shared, so the same change applies to the client and to the proxy relaying a back end response. Verified in both directions.

A single request is unaffected: on `master` the body of a chunked response is already complete by the time the trailer is reached and the connection is then torn down, so the residual bytes are never observed. The defect surfaces only when the connection is **reused**, which is exactly what the reverse proxy does with its back ends. Three sequential requests through a proxy whose back end answers with a chunked body followed by a trailer:

| | master | branch |
| --- | --- | --- |
| request 0 | `200`, body intact | `200`, body intact |
| request 1 | **`ConnectionResetError`** | `200`, body intact |
| request 2 | not reached | `200`, body intact |
| back end requests served | 1 | 3 |

On `master` the trailer left in the stream is parsed as the status line of the next response, which desynchronizes the back end connection and kills it. A chunked response with no trailer behaves identically on both sides, as does a plain one delimited by `Content-Length`.

The new `CHUNK_LIMIT` default also applies to the client, since it builds its parser without overriding the limits, exactly as it already does for `LINE_LIMIT` and `HEADERS_LIMIT`. A response announcing an absurd chunk size now fails fast instead of waiting for bytes that will never arrive; both end up reported as a closed connection, so there is no visible change in the result.

## Part 3: review fixes

Four issues raised in review, all reproduced and fixed in `bf57b9be`.

* **A stream error still closed the connection.** `error_stream` registered `error_connection` as the reset callback unconditionally, so scoping the window update errors to the stream changed the error code path without changing the outcome. Removing the escalation outright was measured and drops `h2spec` from 145 to **134**, because several raise sites that genuinely need a connection error (idle stream frames, the CONTINUATION violations, a numerically smaller stream identifier, an invalid pad length) also carry `stream=`. The escalation is now skipped only for the codes in the new `HTTP2_STREAM_ERRORS`, currently `FLOW_CONTROL_ERROR`, which holds `h2spec` at 145.
* **A settings delta could overflow a stream window.** A `WINDOW_UPDATE` to exactly 2147483647 followed by an increase of `SETTINGS_INITIAL_WINDOW_SIZE` left the window at 2147483648 and usable. `set_settings` now verifies every open stream before applying the delta and raises a connection level `FLOW_CONTROL_ERROR`, as RFC 9113 section 6.9.2 requires.
* **An oversized `DATA` frame could be emitted.** `HTTP2Stream.reset` fixed `window_m` at `min(window, frame_size - HEADER_SIZE)`, so a stream opened under a zero window had `window_m` of zero, `fragmentable` always returned false, and a 20000 byte body was queued as a single frame against a 16384 maximum. Since the split now actually delivers queued frames, this became reachable. `window_m` is the maximum frame payload, so it is now the frame size alone and the body fragments to 16375 + 3625 before reaching the queue. `partial_stream` is additionally bounded by it as defence in depth.
* **`fragment` could slice from the end.** Its reference is now clamped, since a stream window may legitimately be negative once an initial window size reduction is applied, and a zero reference no longer yields an empty leading frame.

## Performance

`h2load`, 8 connections, 32 concurrent streams, median of 5 runs, `master` served from a separate worktree so both sides run on the same interpreter and machine state.

| Case | master | branch | Delta |
| --- | --- | --- | --- |
| HTTP/2, 1 KB body | 13745 req/s | 13810 req/s | +0.5% |
| HTTP/2, 64 KB body | 8332 req/s | 8617 req/s | +3.4% |
| HTTP/2, 1023 byte window, 64 KB body | 120 req/s | 306 req/s | **+155%** |
| HTTP/1.1 control, 1 KB body | 33590 req/s | 32765 req/s | -2.5% |

The HTTP/1.1 row is a control: it exercises no changed code and still moved by 2.5%, which sets the noise floor for this machine. The two ordinary HTTP/2 rows sit inside it, so the accumulated cost is not measurable.

The small window row is a real improvement rather than noise, and it is a consequence of the `window_m` fix. On `master` a peer announcing a 1023 byte window forced every `DATA` frame down to 1023 bytes for the lifetime of the stream; the branch fragments at the frame size and lets flow control split what it must, so the same payload costs a fraction of the frames and writes. An earlier revision of this branch measured roughly -4% on this case, which the `window_m` fix reversed.

Only `available_stream` is on the HTTP/2 hot path and it went from four comparisons to four. Everything else (`split_frame`, `partial_stream`, the initial window size delta) runs solely once a window is exhausted. On the HTTP/1.1 side the chunked path gains one comparison per chunk for the size bound, and the trailer parsing runs once per message.

## Tests

601 pass, 10 new, `black` clean.

* `test_split_frame`, `test_flush_frames`, `test_set_settings_window`, `test_available_stream` and `test_partial_stream` in `src/netius/test/servers/http2.py`
* `test_assert_window_update` in `src/netius/test/common/http2.py` extended for the connection versus stream scoping and the error code carried
* `test_chunked_trailer` in `src/netius/test/common/http.py`, covering a trailer present, pipelining after one, a section split across parse calls, a bare line feed inside it and an oversized one
* `test_chunked_malformed` extended for the announced size bound, both the default and a configured one
* `test_chunked_trailer_response` in `src/netius/test/common/http.py`, covering the response direction and a kept alive connection carrying a second response after a trailer
* `test_on_data_chunked_trailer` in `src/netius/test/clients/http.py`, driving the same case through the client protocol
* `test_error_stream` in `src/netius/test/servers/http2.py`, asserting a lone `RST_STREAM` for a scoped error and `RST_STREAM` plus `GOAWAY` for an unscoped one
* `test_fragment` in `src/netius/test/common/http2.py`, covering the frame bound under a zero, a small and a negative window
* `test_set_settings_window` and `test_partial_stream` extended for the window overflow and the frame size bound

## Notes

Two things found along the way and deliberately left out of scope:

* `ReverseProxyCompressionTest::test_compress_deferred` is flaky under the full suite. It failed on 2 of 3 runs of unmodified `master` and passed on 3 of 3 with this branch, so it is pre-existing and timing sensitive, not a regression, but it will intermittently redden CI.
* The two bytes that terminate a chunk's data are consumed without being verified as `CRLF`, so a peer may place arbitrary bytes there. It is the same family as the trailer defect above but is not one of the checklist items, so it is flagged rather than changed.
