### PR TITLE
feat(diag): track recently closed connections and their close reasons

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container: python:${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: python --version
       - run: |
           pip install -r requirements.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     container: python:${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: python --version
       - run: |
           pip install -r requirements.txt
@@ -43,11 +43,11 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.9, "3.10"]
+        python-version: [2.7, 3.6, 3.9, "3.10", "3.11"]
     runs-on: ubuntu-latest
     container: pypy:${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: pypy --version
       - run: |
           pip install -r requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Inspection of the recently closed connections and of the reason for their closing under the diagnostics - [#55](https://github.com/hivesolutions/netius/issues/55)
 
 ### Changed
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -42,6 +42,7 @@
 | **DIAG_SERVER** | `str`  | `netius`    | The server that is going to be used for serving the diagnostics system infrastructure.                                                                      |
 | **DIAG_HOST**   | `str`  | `127.0.0.1` | The hostname that is going to be used when launching the diagnostics system.                                                                                |
 | **DIAG_PORT**   | `int`  | `5050`      | The TCP port that is going to be used when launching the diagnostics system.                                                                                |
+| **DIAG_CLOSED_MAX** | `int` | `512`   | The maximum number of recently closed connections kept for inspection under the diagnostics, exposed by the `/connections/closed` endpoint.                 |
 
 #### SSL
 

--- a/extra.txt
+++ b/extra.txt
@@ -1,1 +1,2 @@
+appier
 hpack

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,11 +3,17 @@ python_files = *.py
 testpaths = src/netius/test
 
 # the deprecations below are deliberate, either because the replacement is
-# not available under the oldest supported runtime or because adopting it
-# would change the TLS behaviour, so they are silenced only for the tests
+# not available under the oldest supported runtime, because adopting it
+# would change the TLS behaviour, or because they are raised by the test
+# tooling itself, so they are silenced only for the tests, note that the
+# ones raised from the library are ordered alphabetically by module and
+# the ones raised from the test tooling are kept last
 filterwarnings =
+    ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning
+    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning
+    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning
+    ignore:ssl.match_hostname\(\) is deprecated:DeprecationWarning
     ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning
     ignore:ssl.TLSVersion.TLSv1 is deprecated:DeprecationWarning
-    ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning
-    ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning
-    ignore:datetime.datetime.utcnow:DeprecationWarning
+    ignore:the imp module is deprecated:DeprecationWarning
+    ignore:Please use assertRaisesRegex instead:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,5 @@ filterwarnings =
     ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning
     ignore:ssl.TLSVersion.TLSv1 is deprecated:DeprecationWarning
     ignore:'asyncio.get_event_loop_policy' is deprecated:DeprecationWarning
+    ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning
+    ignore:datetime.datetime.utcnow:DeprecationWarning

--- a/src/netius/base/__init__.py
+++ b/src/netius/base/__init__.py
@@ -124,7 +124,19 @@ from .config import (
     conf_ctx,
     conf_override,
 )
-from .conn import OPEN, CLOSED, PENDING, CHUNK_SIZE, Connection
+from .conn import (
+    OPEN,
+    CLOSED,
+    PENDING,
+    CHUNK_SIZE,
+    REASON_TIMEOUT,
+    REASON_CLIENT_EOF,
+    REASON_UPSTREAM_ERROR,
+    REASON_ERROR,
+    REASON_EXPLICIT,
+    REASON_UNKNOWN,
+    Connection,
+)
 from .container import Container, ContainerServer
 from .errors import (
     NetiusError,

--- a/src/netius/base/client.py
+++ b/src/netius/base/client.py
@@ -677,20 +677,20 @@ class StreamClient(Client):
                 if error_v in SSL_VALID_ERRORS:
                     break
                 if close:
-                    connection.close()
+                    connection.close(reason=REASON_ERROR, error=str(error))
                 valid = False
             except socket.error as error:
                 error_v = error.args[0] if error.args else None
                 if error_v in VALID_ERRORS:
                     break
                 if close:
-                    connection.close()
+                    connection.close(reason=REASON_ERROR, error=str(error))
                 valid = False
             except (KeyboardInterrupt, SystemExit):
                 raise
             except:
                 if close:
-                    connection.close()
+                    connection.close(reason=REASON_ERROR)
                 valid = False
 
         # returns the final value on the connection validity test
@@ -869,7 +869,7 @@ class StreamClient(Client):
                 if data:
                     self.on_data(connection, data)
                 else:
-                    connection.close()
+                    connection.close(reason=REASON_CLIENT_EOF)
                     break
                 if not connection.status == OPEN:
                     break
@@ -968,17 +968,17 @@ class StreamClient(Client):
         if not connection.status == OPEN:
             return
 
-        connection.close()
+        connection.close(reason=REASON_ERROR)
 
     def on_exception(self, exception, connection):
         self.warning(exception, stack=True)
         self.log_stack()
         connection.set_exception(exception)
-        connection.close()
+        connection.close(reason=REASON_ERROR, error=str(exception))
 
     def on_expected(self, exception, connection):
         self.debug(exception)
-        connection.close()
+        connection.close(reason=REASON_ERROR, error=str(exception))
 
     def on_connect(self, connection):
         self.debug(
@@ -1105,7 +1105,7 @@ class StreamClient(Client):
                 self.warning(error, stack=True)
                 self.log_stack()
                 self.trigger("error", self, connection, error)
-                connection.close()
+                connection.close(reason=REASON_ERROR, error=str(error))
                 return
         except socket.error as error:
             error_v = error.args[0] if error.args else None
@@ -1113,7 +1113,7 @@ class StreamClient(Client):
                 self.warning(error, stack=True)
                 self.log_stack()
                 self.trigger("error", self, connection, error)
-                connection.close()
+                connection.close(reason=REASON_ERROR, error=str(error))
                 return
         except (KeyboardInterrupt, SystemExit):
             raise
@@ -1121,7 +1121,7 @@ class StreamClient(Client):
             self.warning(exception, stack=True)
             self.log_stack()
             self.trigger("error", self, connection, exception)
-            connection.close()
+            connection.close(reason=REASON_ERROR, error=str(exception))
             raise
 
         # otherwise the connect operation has finished correctly

--- a/src/netius/base/common.py
+++ b/src/netius/base/common.py
@@ -3486,7 +3486,10 @@ class AbstractBase(observer.Observable):
         that is going to be recorded in the ring buffer.
         """
 
-        info = connection.info_dict(full=True)
+        # the snapshot is a shallow one so that no reference to the internal
+        # structures of the connection (eg: the parser and its buffers) is
+        # retained by the ring buffer for the lifetime of the entry
+        info = connection.info_dict()
 
         # calculates the total duration of the connection, note that such
         # value is only available for the connections that keep track of

--- a/src/netius/base/common.py
+++ b/src/netius/base/common.py
@@ -2085,6 +2085,7 @@ class AbstractBase(observer.Observable):
         # registered in the base structure and closes them so that
         # can no longer be used and are gracefully disconnected
         for connection in connections:
+            connection.close_reason = REASON_EXPLICIT
             connection.close()
 
         # iterates over the complete set of sockets in the connections
@@ -3237,6 +3238,7 @@ class AbstractBase(observer.Observable):
                 if data:
                     self.on_data_base(connection, data)
                 else:
+                    connection.close_reason = REASON_CLIENT_EOF
                     connection.close()
                     break
                 if not connection.status == OPEN:
@@ -3336,6 +3338,7 @@ class AbstractBase(observer.Observable):
         if not connection.status == OPEN:
             return
 
+        connection.close_reason = REASON_ERROR
         connection.close()
 
     def on_read_s(self, _socket, service):
@@ -3376,6 +3379,8 @@ class AbstractBase(observer.Observable):
     def on_exception(self, exception, connection):
         self.warning(exception, stack=True)
         self.log_stack()
+        connection.close_reason = REASON_ERROR
+        connection.close_error = str(exception)
         connection.close()
 
     def on_exception_s(self, exception):
@@ -3384,6 +3389,8 @@ class AbstractBase(observer.Observable):
 
     def on_expected(self, exception, connection):
         self.debug(exception)
+        connection.close_reason = REASON_ERROR
+        connection.close_error = str(exception)
         connection.close()
 
     def on_expected_s(self, exception):
@@ -3600,7 +3607,9 @@ class AbstractBase(observer.Observable):
         # is raises the connection is closed (avoids possible errors)
         try:
             connection.run_starter()
-        except Exception:
+        except Exception as exception:
+            connection.close_reason = REASON_ERROR
+            connection.close_error = str(exception)
             connection.close()
             raise
 
@@ -4393,6 +4402,8 @@ class AbstractBase(observer.Observable):
                 self.warning(error, stack=True)
                 self.log_stack()
                 self.trigger("error", self, connection, error)
+                connection.close_reason = REASON_ERROR
+                connection.close_error = str(error)
                 connection.close()
                 return
         except socket.error as error:
@@ -4401,6 +4412,8 @@ class AbstractBase(observer.Observable):
                 self.warning(error, stack=True)
                 self.log_stack()
                 self.trigger("error", self, connection, error)
+                connection.close_reason = REASON_ERROR
+                connection.close_error = str(error)
                 connection.close()
                 return
         except (KeyboardInterrupt, SystemExit):
@@ -4409,6 +4422,8 @@ class AbstractBase(observer.Observable):
             self.warning(exception, stack=True)
             self.log_stack()
             self.trigger("error", self, connection, exception)
+            connection.close_reason = REASON_ERROR
+            connection.close_error = str(exception)
             connection.close()
             raise
 

--- a/src/netius/base/common.py
+++ b/src/netius/base/common.py
@@ -291,10 +291,11 @@ COMPACT_MIN = 64
 the compaction of the delayed queues may be triggered, avoiding the
 cost of such operation for a small number of them """
 
-DIAG_CLOSED_MAX = config.conf("DIAG_CLOSED_MAX", 512, cast=int)
+DIAG_CLOSED_MAX = max(config.conf("DIAG_CLOSED_MAX", 512, cast=int), 0)
 """ The maximum number of closed connections that are kept by the
 diagnostics ring buffer, once such value is reached the oldest of
-the entries are dropped so that the memory usage remains bound """
+the entries are dropped so that the memory usage remains bound, note
+that a negative value is clamped as it's not a valid bound """
 
 KEEPALIVE_TIMEOUT = 300
 """ The amount of time in seconds that a connection is set as
@@ -3110,8 +3111,9 @@ class AbstractBase(observer.Observable):
 
         # records the connection in the ring buffer of closed connections
         # so that it may still be inspected after its destruction, note that
-        # this is only performed while running under diagnostics
-        if is_diag:
+        # this is only performed while running under diagnostics, either the
+        # ones set by configuration or the ones started by an instance
+        if is_diag or AbstractBase._DIAG_INSTANCE:
             self.record_closed(connection)
 
         # triggers the event notifying any listener about the
@@ -3523,7 +3525,12 @@ class AbstractBase(observer.Observable):
         return connection.info_dict(full=full)
 
     def connections_closed_dict(self):
-        return list(reversed(AbstractBase._DIAG_CLOSED))
+        # the snapshot is taken through a list conversion instead of a
+        # reversed iteration, as the latter is not safe against the append
+        # of a new entry from one of the event loop threads
+        closed = list(AbstractBase._DIAG_CLOSED)
+        closed.reverse()
+        return closed
 
     def build_connection(self, socket, address=None, datagram=False, ssl=False):
         """

--- a/src/netius/base/common.py
+++ b/src/netius/base/common.py
@@ -291,6 +291,11 @@ COMPACT_MIN = 64
 the compaction of the delayed queues may be triggered, avoiding the
 cost of such operation for a small number of them """
 
+DIAG_CLOSED_MAX = config.conf("DIAG_CLOSED_MAX", 512, cast=int)
+""" The maximum number of closed connections that are kept by the
+diagnostics ring buffer, once such value is reached the oldest of
+the entries are dropped so that the memory usage remains bound """
+
 KEEPALIVE_TIMEOUT = 300
 """ The amount of time in seconds that a connection is set as
 idle until a new refresh token is sent to it to make sure that
@@ -364,6 +369,11 @@ class AbstractBase(observer.Observable):
     """ Reference to the instance currently holding the diagnostics
     server for the process, ensures only one diag server binds per
     process even when multiple base instances coexist """
+
+    _DIAG_CLOSED = collections.deque(maxlen=DIAG_CLOSED_MAX)
+    """ Ring buffer with the snapshots of the connections that have
+    been recently closed, shared by every instance of the process so
+    that both sides of a proxied exchange are kept together """
 
     def __init__(self, name=None, handlers=None, *args, **kwargs):
         observer.Observable.__init__(self, *args, **kwargs)
@@ -3098,6 +3108,12 @@ class AbstractBase(observer.Observable):
             connection.owner.name,
         )
 
+        # records the connection in the ring buffer of closed connections
+        # so that it may still be inspected after its destruction, note that
+        # this is only performed while running under diagnostics
+        if is_diag:
+            self.record_closed(connection)
+
         # triggers the event notifying any listener about the
         # deletion/destruction f the connection
         self.trigger("connection_d", self, connection)
@@ -3448,6 +3464,43 @@ class AbstractBase(observer.Observable):
         )
         return info_s
 
+    def record_closed(self, connection):
+        """
+        Records the provided (already closed) connection in the ring buffer
+        of closed connections, taking a snapshot of its information together
+        with the metadata that describes the closing of it.
+
+        The buffer is shared by the complete set of instances running under
+        the process, so that the two sides of a proxied exchange may be
+        correlated through the paired connection identifier.
+
+        :type connection: BaseConnection
+        :param connection: The connection that has just been closed and
+        that is going to be recorded in the ring buffer.
+        """
+
+        info = connection.info_dict(full=True)
+
+        # calculates the total duration of the connection, note that such
+        # value is only available for the connections that keep track of
+        # their creation time (the diagnostics oriented ones)
+        creation = getattr(connection, "creation", None)
+        duration = (
+            connection.close_timestamp - creation
+            if creation and connection.close_timestamp
+            else None
+        )
+
+        # adds the metadata that is only meaningful once the connection has
+        # been closed, the paired identifier allows the correlation of the
+        # front-end and the back-end sides of a proxied exchange
+        info.update(
+            duration=duration,
+            close_paired=getattr(connection, "close_paired", None),
+        )
+
+        AbstractBase._DIAG_CLOSED.append(info)
+
     def connections_dict(self, full=False):
         connections = []
         for connection in self.connections:
@@ -3465,6 +3518,9 @@ class AbstractBase(observer.Observable):
         if not connection:
             return None
         return connection.info_dict(full=full)
+
+    def connections_closed_dict(self):
+        return list(reversed(AbstractBase._DIAG_CLOSED))
 
     def build_connection(self, socket, address=None, datagram=False, ssl=False):
         """

--- a/src/netius/base/common.py
+++ b/src/netius/base/common.py
@@ -2085,8 +2085,7 @@ class AbstractBase(observer.Observable):
         # registered in the base structure and closes them so that
         # can no longer be used and are gracefully disconnected
         for connection in connections:
-            connection.close_reason = REASON_EXPLICIT
-            connection.close()
+            connection.close(reason=REASON_EXPLICIT)
 
         # iterates over the complete set of sockets in the connections
         # map to properly close them (avoids any leak of resources)
@@ -3238,8 +3237,7 @@ class AbstractBase(observer.Observable):
                 if data:
                     self.on_data_base(connection, data)
                 else:
-                    connection.close_reason = REASON_CLIENT_EOF
-                    connection.close()
+                    connection.close(reason=REASON_CLIENT_EOF)
                     break
                 if not connection.status == OPEN:
                     break
@@ -3338,8 +3336,7 @@ class AbstractBase(observer.Observable):
         if not connection.status == OPEN:
             return
 
-        connection.close_reason = REASON_ERROR
-        connection.close()
+        connection.close(reason=REASON_ERROR)
 
     def on_read_s(self, _socket, service):
         try:
@@ -3379,9 +3376,7 @@ class AbstractBase(observer.Observable):
     def on_exception(self, exception, connection):
         self.warning(exception, stack=True)
         self.log_stack()
-        connection.close_reason = REASON_ERROR
-        connection.close_error = str(exception)
-        connection.close()
+        connection.close(reason=REASON_ERROR, error=str(exception))
 
     def on_exception_s(self, exception):
         self.warning(exception)
@@ -3389,9 +3384,7 @@ class AbstractBase(observer.Observable):
 
     def on_expected(self, exception, connection):
         self.debug(exception)
-        connection.close_reason = REASON_ERROR
-        connection.close_error = str(exception)
-        connection.close()
+        connection.close(reason=REASON_ERROR, error=str(exception))
 
     def on_expected_s(self, exception):
         self.debug(exception)
@@ -3611,9 +3604,7 @@ class AbstractBase(observer.Observable):
         try:
             connection.run_starter()
         except Exception as exception:
-            connection.close_reason = REASON_ERROR
-            connection.close_error = str(exception)
-            connection.close()
+            connection.close(reason=REASON_ERROR, error=str(exception))
             raise
 
         # in case there's extraneous data pending to be read from the
@@ -4405,9 +4396,7 @@ class AbstractBase(observer.Observable):
                 self.warning(error, stack=True)
                 self.log_stack()
                 self.trigger("error", self, connection, error)
-                connection.close_reason = REASON_ERROR
-                connection.close_error = str(error)
-                connection.close()
+                connection.close(reason=REASON_ERROR, error=str(error))
                 return
         except socket.error as error:
             error_v = error.args[0] if error.args else None
@@ -4415,9 +4404,7 @@ class AbstractBase(observer.Observable):
                 self.warning(error, stack=True)
                 self.log_stack()
                 self.trigger("error", self, connection, error)
-                connection.close_reason = REASON_ERROR
-                connection.close_error = str(error)
-                connection.close()
+                connection.close(reason=REASON_ERROR, error=str(error))
                 return
         except (KeyboardInterrupt, SystemExit):
             raise
@@ -4425,9 +4412,7 @@ class AbstractBase(observer.Observable):
             self.warning(exception, stack=True)
             self.log_stack()
             self.trigger("error", self, connection, exception)
-            connection.close_reason = REASON_ERROR
-            connection.close_error = str(exception)
-            connection.close()
+            connection.close(reason=REASON_ERROR, error=str(exception))
             raise
 
         # otherwise the connect operation has finished correctly

--- a/src/netius/base/conn.py
+++ b/src/netius/base/conn.py
@@ -1113,9 +1113,13 @@ class DiagConnection(BaseConnection):
             last_send_ts=self.last_send_ts,
             last_activity_timestamp=self._last_activity(),
         )
-        geo = self._resolve(self.address)
-        if geo:
-            info["geo"] = geo
+        # the geographical resolution of the address is an expensive
+        # operation, so it's only performed for the full version of the
+        # information, sparing the uses that are run per connection
+        if full:
+            geo = self._resolve(self.address)
+            if geo:
+                info["geo"] = geo
         return info
 
     def _last_activity(self):

--- a/src/netius/base/conn.py
+++ b/src/netius/base/conn.py
@@ -68,6 +68,30 @@ CHUNK_SIZE = 16384
 """ The size of the chunk to be used while received
 data from the service socket """
 
+REASON_TIMEOUT = "timeout"
+""" Close reason for a connection that has been closed because
+it remained idle for longer than the allowed period of time """
+
+REASON_CLIENT_EOF = "client_eof"
+""" Close reason for the situation where the other peer has closed
+the connection gracefully, meaning that no more data is available """
+
+REASON_UPSTREAM_ERROR = "upstream_error"
+""" Close reason for a connection closed as a consequence of a
+failure in the upstream (back-end) connection associated with it """
+
+REASON_ERROR = "error"
+""" Close reason for a connection that has been closed because of
+an error raised while handling either its data or its socket """
+
+REASON_EXPLICIT = "explicit"
+""" Close reason for a connection closed by an explicit request of
+the upper layers, meaning that the closing was protocol driven """
+
+REASON_UNKNOWN = "unknown"
+""" Fallback close reason set whenever no other one has been
+associated with the connection before it has been closed """
+
 
 class BaseConnection(observer.Observable):
     """
@@ -112,6 +136,9 @@ class BaseConnection(observer.Observable):
         self.wready = False
         self.pending_s = 0
         self.restored_s = 0
+        self.close_reason = None
+        self.close_error = None
+        self.close_timestamp = None
         self.starters = collections.deque()
         self.pending = collections.deque()
         self.restored = collections.deque()
@@ -187,6 +214,13 @@ class BaseConnection(observer.Observable):
         # so that no one else changes the current connection status
         # this is relevant to avoid any erroneous situation
         self.status = CLOSED
+
+        # marks the timestamp for the closing of the connection and makes
+        # sure that a reason is associated with it, so that a connection
+        # closed with no explicit reason is still properly identified
+        self.close_timestamp = time.time()
+        if not self.close_reason:
+            self.close_reason = REASON_UNKNOWN
 
         # unsets the connecting flag this is for connections that
         # are under the connecting state, and that must be reverted
@@ -685,6 +719,9 @@ class BaseConnection(observer.Observable):
             owner=getattr(self.owner, "name", None) if self.owner else None,
             waiting=getattr(self, "waiting", None),
             busy=getattr(self, "busy", None),
+            close_reason=self.close_reason,
+            close_error=self.close_error,
+            close_timestamp=self.close_timestamp,
         )
         return info
 
@@ -1074,11 +1111,20 @@ class DiagConnection(BaseConnection):
             out_bytes=self.out_bytes,
             last_recv_ts=self.last_recv_ts,
             last_send_ts=self.last_send_ts,
+            last_activity_timestamp=self._last_activity(),
         )
         geo = self._resolve(self.address)
         if geo:
             info["geo"] = geo
         return info
+
+    def _last_activity(self):
+        timestamps = [
+            timestamp
+            for timestamp in (self.last_recv_ts, self.last_send_ts)
+            if timestamp
+        ]
+        return max(timestamps) if timestamps else None
 
     def _uptime(self):
         creation_d = datetime.datetime.utcfromtimestamp(self.creation)

--- a/src/netius/base/conn.py
+++ b/src/netius/base/conn.py
@@ -196,12 +196,20 @@ class BaseConnection(observer.Observable):
         # the current netius specification and strategy
         self.trigger("open", self)
 
-    def close(self, flush=False, destroy=True):
+    def close(self, flush=False, destroy=True, reason=None, error=None):
         # in case the current status of the connection is closed it does
         # nor make sense to proceed with the closing as the connection
         # is already in the closed state (nothing to be done)
         if self.status == CLOSED:
             return
+
+        # associates the provided reason (and error) with the connection,
+        # note that this is done before the flushing so that the values
+        # survive a closing that is deferred until the buffer is empty
+        if reason:
+            self.close_reason = reason
+        if error:
+            self.close_error = error
 
         # in case the flush flag is set, a different approach is taken
         # where all the pending data is flushed (as possible) before

--- a/src/netius/base/diag.py
+++ b/src/netius/base/diag.py
@@ -100,6 +100,11 @@ class DiagApp(appier.APIApp):
         info = self.system.connections_dict(full=full)
         return self.json(info, sort_keys=True, cls=DiagEncoder)
 
+    @appier.route("/connections/closed", "GET")
+    def list_connections_closed(self):
+        info = self.system.connections_closed_dict()
+        return self.json(info, sort_keys=True, cls=DiagEncoder)
+
     @appier.route("/connections/<str:id>", "GET")
     def show_connection(self, id):
         full = self.field("full", True, cast=bool)

--- a/src/netius/base/server.py
+++ b/src/netius/base/server.py
@@ -852,8 +852,7 @@ class StreamServer(Server):
                 if data:
                     self.on_data(connection, data)
                 else:
-                    connection.close_reason = REASON_CLIENT_EOF
-                    connection.close()
+                    connection.close(reason=REASON_CLIENT_EOF)
                     break
                 if not connection.status == OPEN:
                     break
@@ -953,15 +952,12 @@ class StreamServer(Server):
         if not connection.status == OPEN:
             return
 
-        connection.close_reason = REASON_ERROR
-        connection.close()
+        connection.close(reason=REASON_ERROR)
 
     def on_exception(self, exception, connection):
         self.warning(exception, stack=True)
         self.log_stack()
-        connection.close_reason = REASON_ERROR
-        connection.close_error = str(exception)
-        connection.close()
+        connection.close(reason=REASON_ERROR, error=str(exception))
 
     def on_exception_s(self, exception):
         self.warning(exception, stack=True)
@@ -969,9 +965,7 @@ class StreamServer(Server):
 
     def on_expected(self, exception, connection):
         self.debug(exception)
-        connection.close_reason = REASON_ERROR
-        connection.close_error = str(exception)
-        connection.close()
+        connection.close(reason=REASON_ERROR, error=str(exception))
 
     def on_expected_s(self, exception):
         self.debug(exception)
@@ -1077,9 +1071,7 @@ class StreamServer(Server):
         try:
             connection.run_starter()
         except Exception as exception:
-            connection.close_reason = REASON_ERROR
-            connection.close_error = str(exception)
-            connection.close()
+            connection.close(reason=REASON_ERROR, error=str(exception))
             raise
 
         # in case there's extraneous data pending to be read from the

--- a/src/netius/base/server.py
+++ b/src/netius/base/server.py
@@ -852,6 +852,7 @@ class StreamServer(Server):
                 if data:
                     self.on_data(connection, data)
                 else:
+                    connection.close_reason = REASON_CLIENT_EOF
                     connection.close()
                     break
                 if not connection.status == OPEN:
@@ -952,11 +953,14 @@ class StreamServer(Server):
         if not connection.status == OPEN:
             return
 
+        connection.close_reason = REASON_ERROR
         connection.close()
 
     def on_exception(self, exception, connection):
         self.warning(exception, stack=True)
         self.log_stack()
+        connection.close_reason = REASON_ERROR
+        connection.close_error = str(exception)
         connection.close()
 
     def on_exception_s(self, exception):
@@ -965,6 +969,8 @@ class StreamServer(Server):
 
     def on_expected(self, exception, connection):
         self.debug(exception)
+        connection.close_reason = REASON_ERROR
+        connection.close_error = str(exception)
         connection.close()
 
     def on_expected_s(self, exception):
@@ -1070,7 +1076,9 @@ class StreamServer(Server):
         # is raises the connection is closed (avoids possible errors)
         try:
             connection.run_starter()
-        except Exception:
+        except Exception as exception:
+            connection.close_reason = REASON_ERROR
+            connection.close_error = str(exception)
             connection.close()
             raise
 

--- a/src/netius/clients/http.py
+++ b/src/netius/clients/http.py
@@ -699,6 +699,8 @@ class HTTPProtocol(netius.StreamProtocol):
                 cls.set_error(
                     "timeout", message="Timeout on connect", request=self.request
                 )
+            if self.connection:
+                self.connection.close_reason = netius.REASON_TIMEOUT
             self.close()
 
         # schedules a delay operation to run the timeout handler for
@@ -772,7 +774,11 @@ class HTTPProtocol(netius.StreamProtocol):
             cls.set_error("timeout", message=message, request=self.request)
 
             # closes the protocol (it's no longer considered valid)
-            # and then verifies the various auto closing values
+            # and then verifies the various auto closing values, note
+            # that the reason is set in the underlying connection as
+            # it's the one that is going to be recorded
+            if self.connection:
+                self.connection.close_reason = netius.REASON_TIMEOUT
             self.close()
 
         # sends the request effectively triggering a chain of event

--- a/src/netius/extra/proxy_f.py
+++ b/src/netius/extra/proxy_f.py
@@ -139,7 +139,7 @@ class ForwardProxyServer(netius.servers.ProxyServer):
             _connection.max_pending = self.max_pending
             _connection.min_pending = self.min_pending
             connection.proxy_c = _connection
-            self.map_connection(_connection, connection)
+            self.conn_map[_connection] = connection
 
     def compile(self):
         for key, rule in netius.legacy.items(self.rules):

--- a/src/netius/extra/proxy_f.py
+++ b/src/netius/extra/proxy_f.py
@@ -139,7 +139,7 @@ class ForwardProxyServer(netius.servers.ProxyServer):
             _connection.max_pending = self.max_pending
             _connection.min_pending = self.min_pending
             connection.proxy_c = _connection
-            self.conn_map[_connection] = connection
+            self.map_connection(_connection, connection)
 
     def compile(self):
         for key, rule in netius.legacy.items(self.rules):

--- a/src/netius/extra/proxy_r.py
+++ b/src/netius/extra/proxy_r.py
@@ -540,7 +540,7 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         connection.proxy_c = _connection
         connection.prefix = prefix
         connection.state = state
-        self.conn_map[_connection] = connection
+        self.map_connection(_connection, connection)
 
     def rules(self, url, parser):
         resolved = self.rules_regex(url, parser)

--- a/src/netius/extra/proxy_r.py
+++ b/src/netius/extra/proxy_r.py
@@ -540,7 +540,7 @@ class ReverseProxyServer(netius.servers.ProxyServer):
         connection.proxy_c = _connection
         connection.prefix = prefix
         connection.state = state
-        self.map_connection(_connection, connection)
+        self.conn_map[_connection] = connection
 
     def rules(self, url, parser):
         resolved = self.rules_regex(url, parser)

--- a/src/netius/middleware/proxy.py
+++ b/src/netius/middleware/proxy.py
@@ -138,7 +138,7 @@ class ProxyMiddleware(Middleware):
         self.owner.debug(
             "PROXY handshake timeout for '%s', closing connection" % connection.id
         )
-        connection.close()
+        connection.close(reason=netius.REASON_TIMEOUT)
 
     def _proxy_handshake_v1(self, connection):
         cls = self.__class__

--- a/src/netius/servers/http.py
+++ b/src/netius/servers/http.py
@@ -285,7 +285,7 @@ class HTTPConnection(netius.Connection):
             self.idle_h = self.owner.delay(self.close_idle, timeout=remaining)
             return
 
-        self.close(flush=True)
+        self.close(flush=True, reason=netius.REASON_TIMEOUT)
 
     def info_dict(self, full=False):
         info = netius.Connection.info_dict(self, full=full)

--- a/src/netius/servers/proxy.py
+++ b/src/netius/servers/proxy.py
@@ -364,27 +364,56 @@ class ProxyServer(http2.HTTP2Server):
         _connection.tunnel_d = data
         _connection.tunnel_r = response
         connection.tunnel_c = _connection
-        self.map_connection(_connection, connection)
+        self.conn_map[_connection] = connection
         return _connection
 
-    def map_connection(self, _connection, connection):
+    def reason_connection(self, _connection, reason):
         """
-        Associates the back-end connection with the front-end one, so that
-        the relation between both of them may be resolved latter on.
+        Sets the provided close reason in the back-end connection, taking
+        into account that the value may be a protocol instead of a proper
+        connection, in which case the underlying connection is the one to
+        be marked, as that's the object known by the diagnostics.
 
-        The identifier of each of the connections is kept in the other one
+        :type _connection: Connection/HTTPProtocol
+        :param _connection: The back-end connection (or protocol) that is
+        going to have its close reason set.
+        :type reason: String
+        :param reason: The reason to be associated with the closing of the
+        connection, should be one of the close reason constants.
+        """
+
+        _connection = getattr(_connection, "connection", _connection)
+        if not _connection:
+            return
+        _connection.close_reason = reason
+
+    def pair_connection(self, _connection):
+        """
+        Associates the identifier of the back-end connection with the one
+        of the front-end connection mapped to it (and the other way around)
         so that the two sides of the exchange may be correlated even after
-        they have been closed (as required by the diagnostics).
+        both of them have been closed.
 
-        :type _connection: Connection
-        :param _connection: The back-end connection that is going to be
-        associated with the front-end one.
-        :type connection: Connection
-        :param connection: The front-end connection that is going to be
-        associated with the back-end one.
+        Note that the back-end value may be a protocol instead of a proper
+        connection, in which case the underlying connection is the one to
+        be used, as that's the object known by the diagnostics.
+
+        :type _connection: Connection/HTTPProtocol
+        :param _connection: The back-end connection (or protocol) that is
+        going to be associated with its front-end counterpart.
         """
 
-        self.conn_map[_connection] = connection
+        connection = self.conn_map.get(_connection, None)
+        if not connection:
+            return
+
+        # resolves the back-end value into the underlying connection, note
+        # that a plain connection has no such attribute and so it's the
+        # value itself that is used for the association
+        _connection = getattr(_connection, "connection", _connection)
+        if not _connection:
+            return
+
         _connection.close_paired = connection.id
         connection.close_paired = _connection.id
 
@@ -452,10 +481,10 @@ class ProxyServer(http2.HTTP2Server):
         proxy_c = hasattr(connection, "proxy_c") and connection.proxy_c
 
         if tunnel_c:
-            tunnel_c.close_reason = netius.REASON_EXPLICIT
+            self.reason_connection(tunnel_c, netius.REASON_EXPLICIT)
             tunnel_c.close()
         if proxy_c:
-            proxy_c.close_reason = netius.REASON_EXPLICIT
+            self.reason_connection(proxy_c, netius.REASON_EXPLICIT)
             proxy_c.close()
 
         setattr(connection, "tunnel_c", None)
@@ -469,10 +498,10 @@ class ProxyServer(http2.HTTP2Server):
         proxy_c = hasattr(stream, "proxy_c") and stream.proxy_c
 
         if tunnel_c:
-            tunnel_c.close_reason = netius.REASON_EXPLICIT
+            self.reason_connection(tunnel_c, netius.REASON_EXPLICIT)
             tunnel_c.close()
         if proxy_c:
-            proxy_c.close_reason = netius.REASON_EXPLICIT
+            self.reason_connection(proxy_c, netius.REASON_EXPLICIT)
             proxy_c.close()
 
         setattr(stream, "tunnel_c", None)
@@ -1219,9 +1248,11 @@ class ProxyServer(http2.HTTP2Server):
 
     def _on_prx_connect(self, client, _connection):
         _connection.waiting = False
+        self.pair_connection(_connection)
 
     def _on_prx_acquire(self, client, _connection):
         _connection.waiting = False
+        self.pair_connection(_connection)
 
     def _on_prx_close(self, client, _connection):
         """
@@ -1351,6 +1382,7 @@ class ProxyServer(http2.HTTP2Server):
 
     def _on_raw_connect(self, client, _connection):
         connection = self.conn_map[_connection]
+        self.pair_connection(_connection)
 
         # retrieves the optional response and data values that may have
         # been associated with the tunnel connection, the response is

--- a/src/netius/servers/proxy.py
+++ b/src/netius/servers/proxy.py
@@ -1187,8 +1187,7 @@ class ProxyServer(http2.HTTP2Server):
         # current client connection and that may or may not close the
         # corresponding back-end connection (as defined in specification)
         def close(connection):
-            connection.close_reason = netius.REASON_EXPLICIT
-            connection.close(flush=True)
+            connection.close(flush=True, reason=netius.REASON_EXPLICIT)
 
         # verifies that the connection is meant to be kept alive, the
         # connection is meant to be kept alive when both the client and
@@ -1419,8 +1418,7 @@ class ProxyServer(http2.HTTP2Server):
 
     def _on_raw_close(self, client, _connection):
         connection = self.conn_map[_connection]
-        connection.close_reason = netius.REASON_UPSTREAM_ERROR
-        connection.close(flush=True)
+        connection.close(flush=True, reason=netius.REASON_UPSTREAM_ERROR)
         del self.conn_map[_connection]
 
     def _apply_headers(self, parser, connection, parser_prx, headers, upper=True):

--- a/src/netius/servers/proxy.py
+++ b/src/netius/servers/proxy.py
@@ -364,8 +364,29 @@ class ProxyServer(http2.HTTP2Server):
         _connection.tunnel_d = data
         _connection.tunnel_r = response
         connection.tunnel_c = _connection
-        self.conn_map[_connection] = connection
+        self.map_connection(_connection, connection)
         return _connection
+
+    def map_connection(self, _connection, connection):
+        """
+        Associates the back-end connection with the front-end one, so that
+        the relation between both of them may be resolved latter on.
+
+        The identifier of each of the connections is kept in the other one
+        so that the two sides of the exchange may be correlated even after
+        they have been closed (as required by the diagnostics).
+
+        :type _connection: Connection
+        :param _connection: The back-end connection that is going to be
+        associated with the front-end one.
+        :type connection: Connection
+        :param connection: The front-end connection that is going to be
+        associated with the back-end one.
+        """
+
+        self.conn_map[_connection] = connection
+        _connection.close_paired = connection.id
+        connection.close_paired = _connection.id
 
     def is_upgrade(self, parser):
         """
@@ -431,8 +452,10 @@ class ProxyServer(http2.HTTP2Server):
         proxy_c = hasattr(connection, "proxy_c") and connection.proxy_c
 
         if tunnel_c:
+            tunnel_c.close_reason = netius.REASON_EXPLICIT
             tunnel_c.close()
         if proxy_c:
+            proxy_c.close_reason = netius.REASON_EXPLICIT
             proxy_c.close()
 
         setattr(connection, "tunnel_c", None)
@@ -446,8 +469,10 @@ class ProxyServer(http2.HTTP2Server):
         proxy_c = hasattr(stream, "proxy_c") and stream.proxy_c
 
         if tunnel_c:
+            tunnel_c.close_reason = netius.REASON_EXPLICIT
             tunnel_c.close()
         if proxy_c:
+            proxy_c.close_reason = netius.REASON_EXPLICIT
             proxy_c.close()
 
         setattr(stream, "tunnel_c", None)
@@ -1133,6 +1158,7 @@ class ProxyServer(http2.HTTP2Server):
         # current client connection and that may or may not close the
         # corresponding back-end connection (as defined in specification)
         def close(connection):
+            connection.close_reason = netius.REASON_EXPLICIT
             connection.close(flush=True)
 
         # verifies that the connection is meant to be kept alive, the
@@ -1229,6 +1255,11 @@ class ProxyServer(http2.HTTP2Server):
             )
             return
 
+        # the front-end connection is going to be closed as a consequence of
+        # the back-end one having been closed, so the reason for it is set
+        # before any of the closing operations is started
+        connection.close_reason = netius.REASON_UPSTREAM_ERROR
+
         # in case a response is being held for the deferred encoding decision
         # it must be released before the connection is closed, otherwise the
         # client would receive nothing at all for the current response
@@ -1303,6 +1334,8 @@ class ProxyServer(http2.HTTP2Server):
         # be handled by the error manager, and that should imply
         # a closing operation on the original/proxy connection)
         error_m = str(error) or "Unknown proxy relay error"
+        connection.close_reason = netius.REASON_UPSTREAM_ERROR
+        connection.close_error = error_m
         if _connection.waiting:
             connection.send_response(
                 data=cls.build_text(error_m),
@@ -1354,6 +1387,7 @@ class ProxyServer(http2.HTTP2Server):
 
     def _on_raw_close(self, client, _connection):
         connection = self.conn_map[_connection]
+        connection.close_reason = netius.REASON_UPSTREAM_ERROR
         connection.close(flush=True)
         del self.conn_map[_connection]
 

--- a/src/netius/test/base/client.py
+++ b/src/netius/test/base/client.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import socket
+import logging
+import unittest
+
+import netius
+
+from netius.base import conn
+
+
+class StreamClientTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.client = netius.StreamClient(level=logging.CRITICAL)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.client.close()
+
+    def test_on_exception(self):
+        connection = self._make_connection()
+        self.client.on_exception(netius.NetiusError("boom"), connection)
+
+        # the closing must be identified as an error driven one, carrying
+        # the details of the exception that has originated it
+        self.assertEqual(connection.status, conn.CLOSED)
+        self.assertEqual(connection.close_reason, netius.REASON_ERROR)
+        self.assertEqual(connection.close_error, "boom")
+
+    def test_on_expected(self):
+        connection = self._make_connection()
+        self.client.on_expected(netius.NetiusError("broken pipe"), connection)
+
+        # an expected exception is still an error driven closing, as the
+        # connection was not closed by a decision of the upper layers
+        self.assertEqual(connection.status, conn.CLOSED)
+        self.assertEqual(connection.close_reason, netius.REASON_ERROR)
+        self.assertEqual(connection.close_error, "broken pipe")
+
+    def _make_connection(self):
+        # builds an open connection registered in the client, so that the
+        # closing of it may be run over the complete set of structures
+        _socket = socket.socket()
+        connection = conn.BaseConnection(owner=self.client, socket=_socket)
+        connection.status = conn.OPEN
+        self.client.connections.append(connection)
+        self.client.connections_m[_socket] = connection
+        return connection

--- a/src/netius/test/base/common.py
+++ b/src/netius/test/base/common.py
@@ -145,6 +145,39 @@ class BaseTest(unittest.TestCase):
         self.assertNotEqual(result, None)
         self.assertEqual(isinstance(result, str), True)
 
+    def test_diag_closed_max(self):
+        # the bound of the ring buffer must never be a negative value, as
+        # the construction of the deque would otherwise fail at import
+        self.assertEqual(common.DIAG_CLOSED_MAX >= 0, True)
+        self.assertEqual(
+            common.AbstractBase._DIAG_CLOSED.maxlen, common.DIAG_CLOSED_MAX
+        )
+
+    def test_on_connection_d(self):
+        loop = netius.Base()
+        buffer = common.AbstractBase._DIAG_CLOSED
+        instance = common.AbstractBase._DIAG_INSTANCE
+        try:
+            buffer.clear()
+
+            # with no diagnostics running the closing of a connection must
+            # not be recorded, sparing the regular execution from its cost
+            self._make_connection(loop)
+
+            self.assertEqual(len(buffer), 0)
+
+            # a diagnostics application started from an instance is enough
+            # for the recording to happen, even with the configuration unset
+            common.AbstractBase._DIAG_INSTANCE = loop
+            connection = self._make_connection(loop)
+
+            self.assertEqual(len(buffer), 1)
+            self.assertEqual(buffer[0]["id"], connection.id)
+        finally:
+            common.AbstractBase._DIAG_INSTANCE = instance
+            buffer.clear()
+            loop.close()
+
     def test_record_closed(self):
         loop = netius.Base()
         buffer = common.AbstractBase._DIAG_CLOSED
@@ -233,6 +266,13 @@ class BaseTest(unittest.TestCase):
             loop.record_closed(third)
 
             closed = loop.connections_closed_dict()
+            self.assertEqual(len(closed), 2)
+            self.assertEqual([info["id"] for info in closed], [third.id, second.id])
+
+            # the listing is a snapshot detached from the ring buffer, so a
+            # new record must not change a listing that was already taken
+            loop.record_closed(self._make_connection(loop))
+
             self.assertEqual(len(closed), 2)
             self.assertEqual([info["id"] for info in closed], [third.id, second.id])
         finally:

--- a/src/netius/test/base/common.py
+++ b/src/netius/test/base/common.py
@@ -28,11 +28,14 @@ __copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
+import socket
+import collections
 import unittest
 
 import netius
 
 from netius.base import common
+from netius.base import conn
 
 
 class BaseTest(unittest.TestCase):
@@ -141,3 +144,79 @@ class BaseTest(unittest.TestCase):
 
         self.assertNotEqual(result, None)
         self.assertEqual(isinstance(result, str), True)
+
+    def test_record_closed(self):
+        loop = netius.Base()
+        buffer = common.AbstractBase._DIAG_CLOSED
+        try:
+            buffer.clear()
+
+            # a connection that keeps track of its creation must have the
+            # duration of it calculated from the closing timestamp
+            connection = self._make_connection(loop, diag=True)
+            connection.creation = connection.close_timestamp - 2.0
+            connection.close_paired = "other"
+            loop.record_closed(connection)
+
+            self.assertEqual(len(buffer), 1)
+            self.assertEqual(buffer[0]["id"], connection.id)
+            self.assertEqual(buffer[0]["close_reason"], netius.REASON_TIMEOUT)
+            self.assertEqual(buffer[0]["close_error"], "idle")
+            self.assertEqual(buffer[0]["close_paired"], "other")
+            self.assertEqual(buffer[0]["duration"], 2.0)
+
+            # a connection with no creation time has no duration associated
+            # with it, as there's no value from which to measure it
+            connection = self._make_connection(loop)
+            loop.record_closed(connection)
+
+            self.assertEqual(len(buffer), 2)
+            self.assertEqual(buffer[1]["duration"], None)
+            self.assertEqual(buffer[1]["close_paired"], None)
+        finally:
+            buffer.clear()
+            loop.close()
+
+    def test_connections_closed_dict(self):
+        loop = netius.Base()
+        original = common.AbstractBase._DIAG_CLOSED
+        try:
+            # replaces the ring buffer by a smaller one so that the bound
+            # of it may be verified without a large number of entries
+            common.AbstractBase._DIAG_CLOSED = collections.deque(maxlen=2)
+
+            first = self._make_connection(loop)
+            second = self._make_connection(loop)
+            loop.record_closed(first)
+            loop.record_closed(second)
+
+            # the most recently closed connection must be the first one to
+            # be reported, so that the latest events are the visible ones
+            closed = loop.connections_closed_dict()
+            self.assertEqual([info["id"] for info in closed], [second.id, first.id])
+
+            # once the maximum number of entries is reached the oldest of
+            # them must be dropped, keeping the memory usage bounded
+            third = self._make_connection(loop)
+            loop.record_closed(third)
+
+            closed = loop.connections_closed_dict()
+            self.assertEqual(len(closed), 2)
+            self.assertEqual([info["id"] for info in closed], [third.id, second.id])
+        finally:
+            common.AbstractBase._DIAG_CLOSED = original
+            loop.close()
+
+    def _make_connection(self, loop, diag=False):
+        # builds a closed connection registered in the loop, so that it may
+        # be recorded in the ring buffer of closed connections
+        _socket = socket.socket()
+        cls = conn.DiagConnection if diag else conn.BaseConnection
+        connection = cls(owner=loop, socket=_socket)
+        connection.status = conn.OPEN
+        loop.connections.append(connection)
+        loop.connections_m[_socket] = connection
+        connection.close_reason = netius.REASON_TIMEOUT
+        connection.close_error = "idle"
+        connection.close()
+        return connection

--- a/src/netius/test/base/common.py
+++ b/src/netius/test/base/common.py
@@ -29,13 +29,13 @@ __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
 import socket
-import collections
 import unittest
+import collections
 
 import netius
 
-from netius.base import common
 from netius.base import conn
+from netius.base import common
 
 
 class BaseTest(unittest.TestCase):
@@ -156,6 +156,11 @@ class BaseTest(unittest.TestCase):
             connection = self._make_connection(loop, diag=True)
             connection.creation = connection.close_timestamp - 2.0
             connection.close_paired = "other"
+            connection.recvs = 3
+            connection.sends = 2
+            connection.in_bytes = 512
+            connection.out_bytes = 1024
+            connection.last_recv_ts = connection.close_timestamp - 1.0
             loop.record_closed(connection)
 
             self.assertEqual(len(buffer), 1)
@@ -164,6 +169,33 @@ class BaseTest(unittest.TestCase):
             self.assertEqual(buffer[0]["close_error"], "idle")
             self.assertEqual(buffer[0]["close_paired"], "other")
             self.assertEqual(buffer[0]["duration"], 2.0)
+
+            # the record must reflect the values of the connection at the
+            # moment it was taken, so they are verified one by one
+            self.assertEqual(buffer[0]["status"], connection.status)
+            self.assertEqual(buffer[0]["recvs"], connection.recvs)
+            self.assertEqual(buffer[0]["sends"], connection.sends)
+            self.assertEqual(buffer[0]["in_bytes"], connection.in_bytes)
+            self.assertEqual(buffer[0]["out_bytes"], connection.out_bytes)
+            self.assertEqual(buffer[0]["close_timestamp"], connection.close_timestamp)
+            self.assertEqual(
+                buffer[0]["last_activity_timestamp"], connection._last_activity()
+            )
+
+            # the duration must be the exact distance between the creation
+            # and the closing of the connection
+            self.assertEqual(
+                buffer[0]["duration"],
+                connection.close_timestamp - connection.creation,
+            )
+
+            # the record is detached from the connection, so a change in the
+            # latter must never be reflected in the value already stored
+            connection.close_reason = netius.REASON_ERROR
+            connection.in_bytes = 0
+
+            self.assertEqual(buffer[0]["close_reason"], netius.REASON_TIMEOUT)
+            self.assertEqual(buffer[0]["in_bytes"], 512)
 
             # a connection with no creation time has no duration associated
             # with it, as there's no value from which to measure it

--- a/src/netius/test/base/conn.py
+++ b/src/netius/test/base/conn.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-
 # -*- coding: utf-8 -*-
 
 

--- a/src/netius/test/base/conn.py
+++ b/src/netius/test/base/conn.py
@@ -146,6 +146,16 @@ class DiagConnectionTest(unittest.TestCase):
 
         self.assertEqual(info["last_activity_timestamp"], 200.0)
 
+        # the geographical resolution is an expensive operation, so it must
+        # only be performed for the full version of the information
+        connection._resolve = lambda address: dict(country="PT")
+
+        info = connection.info_dict()
+        self.assertEqual("geo" in info, False)
+
+        info = connection.info_dict(full=True)
+        self.assertEqual(info["geo"], dict(country="PT"))
+
     def test__last_activity(self):
         connection = self._make_connection()
 

--- a/src/netius/test/base/conn.py
+++ b/src/netius/test/base/conn.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+
+# -*- coding: utf-8 -*-
+
+
+# Hive Netius System
+
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+
+#
+
+# This file is part of Hive Netius System.
+
+#
+
+# Hive Netius System is free software: you can redistribute it and/or modify
+
+# it under the terms of the Apache License as published by the Apache
+
+# Foundation, either version 2.0 of the License, or (at your option) any
+
+# later version.
+
+#
+
+# Hive Netius System is distributed in the hope that it will be useful,
+
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+
+# Apache License for more details.
+
+#
+
+# You should have received a copy of the Apache License along with
+
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+
+""" The author(s) of the module """
+
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+
+""" The copyright for the module """
+
+
+__license__ = "Apache License, Version 2.0"
+
+""" The license for the module """
+
+import socket
+import unittest
+
+import netius
+
+from netius.base import conn
+
+
+class BaseConnectionTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.loop = netius.Base()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.loop.close()
+
+    def test_close(self):
+        connection = self._make_connection()
+
+        # an open connection carries no closing information at all, as
+        # the values are only set once the closing is performed
+        self.assertEqual(connection.close_reason, None)
+        self.assertEqual(connection.close_timestamp, None)
+
+        connection.close()
+
+        # a connection closed with no explicit reason must still be
+        # identified, falling back to the unknown reason
+        self.assertEqual(connection.close_reason, netius.REASON_UNKNOWN)
+        self.assertNotEqual(connection.close_timestamp, None)
+
+    def test_close_reason(self):
+        connection = self._make_connection()
+        connection.close_reason = netius.REASON_TIMEOUT
+        connection.close()
+
+        # the reason set before the closing must be preserved, as it's
+        # more specific than the fallback one
+        self.assertEqual(connection.close_reason, netius.REASON_TIMEOUT)
+
+        # the closing of an already closed connection must not change any
+        # of the values that describe the original closing
+        timestamp = connection.close_timestamp
+        connection.close()
+        self.assertEqual(connection.close_reason, netius.REASON_TIMEOUT)
+        self.assertEqual(connection.close_timestamp, timestamp)
+
+    def test_info_dict(self):
+        connection = self._make_connection()
+        info = connection.info_dict()
+
+        self.assertEqual(info["close_reason"], None)
+        self.assertEqual(info["close_error"], None)
+        self.assertEqual(info["close_timestamp"], None)
+
+        connection.close_reason = netius.REASON_ERROR
+        connection.close_error = "broken pipe"
+        connection.close()
+        info = connection.info_dict()
+
+        self.assertEqual(info["close_reason"], netius.REASON_ERROR)
+        self.assertEqual(info["close_error"], "broken pipe")
+        self.assertEqual(info["close_timestamp"], connection.close_timestamp)
+
+    def _make_connection(self):
+        # builds an open connection registered in the loop, so that the
+        # closing of it may be run over the complete set of structures
+        _socket = socket.socket()
+        connection = conn.BaseConnection(owner=self.loop, socket=_socket)
+        connection.status = conn.OPEN
+        self.loop.connections.append(connection)
+        self.loop.connections_m[_socket] = connection
+        return connection
+
+
+class DiagConnectionTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.loop = netius.Base()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.loop.close()
+
+    def test_info_dict(self):
+        connection = self._make_connection()
+        connection.last_recv_ts = 100.0
+        connection.last_send_ts = 200.0
+        info = connection.info_dict()
+
+        self.assertEqual(info["last_activity_timestamp"], 200.0)
+
+    def test__last_activity(self):
+        connection = self._make_connection()
+
+        # a connection with no activity at all has no timestamp to be
+        # reported as the last activity one
+        self.assertEqual(connection._last_activity(), None)
+
+        # the most recent of the receive and send timestamps is the one
+        # that represents the last activity of the connection
+        connection.last_recv_ts = 100.0
+        self.assertEqual(connection._last_activity(), 100.0)
+
+        connection.last_send_ts = 200.0
+        self.assertEqual(connection._last_activity(), 200.0)
+
+        connection.last_recv_ts = 300.0
+        self.assertEqual(connection._last_activity(), 300.0)
+
+    def _make_connection(self):
+        _socket = socket.socket()
+        return conn.DiagConnection(owner=self.loop, socket=_socket)

--- a/src/netius/test/base/conn.py
+++ b/src/netius/test/base/conn.py
@@ -1,54 +1,31 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-
 # Hive Netius System
-
 # Copyright (c) 2008-2024 Hive Solutions Lda.
-
 #
-
 # This file is part of Hive Netius System.
-
 #
-
 # Hive Netius System is free software: you can redistribute it and/or modify
-
 # it under the terms of the Apache License as published by the Apache
-
 # Foundation, either version 2.0 of the License, or (at your option) any
-
 # later version.
-
 #
-
 # Hive Netius System is distributed in the hope that it will be useful,
-
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-
 # Apache License for more details.
-
 #
-
 # You should have received a copy of the Apache License along with
-
 # Hive Netius System. If not, see <http://www.apache.org/licenses/>.
 
-
 __author__ = "João Magalhães <joamag@hive.pt>"
-
 """ The author(s) of the module """
 
-
 __copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
-
 """ The copyright for the module """
 
-
 __license__ = "Apache License, Version 2.0"
-
 """ The license for the module """
 
 import socket

--- a/src/netius/test/base/conn.py
+++ b/src/netius/test/base/conn.py
@@ -28,12 +28,19 @@ __copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
+import time
 import socket
 import unittest
 
 import netius
+import netius.common
 
 from netius.base import conn
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
 
 
 class BaseConnectionTest(unittest.TestCase):
@@ -152,6 +159,120 @@ class DiagConnectionTest(unittest.TestCase):
         unittest.TestCase.tearDown(self)
         self.loop.close()
 
+    def test_isolation(self):
+        first = self._make_connection(payload=b"hello")
+        second = self._make_connection(payload=b"hello")
+        first.status = conn.OPEN
+        second.status = conn.OPEN
+
+        first.recv()
+        first.send(b"abc")
+
+        # the accounting is kept per connection, so the operations of one
+        # of them must never be reflected in another one
+        self.assertEqual(second.recvs, 0)
+        self.assertEqual(second.sends, 0)
+        self.assertEqual(second.in_bytes, 0)
+        self.assertEqual(second.out_bytes, 0)
+        self.assertEqual(second.last_recv_ts, None)
+        self.assertEqual(second.last_send_ts, None)
+
+        # the identifiers of the connections must also be distinct, as they
+        # are what correlates a record with the connection it describes
+        self.assertNotEqual(first.id, second.id)
+
+    def test_recv(self):
+        connection = self._make_connection(payload=b"hello")
+
+        # a connection that has not received anything reports no receive
+        # operations and no bytes accounted for them
+        self.assertEqual(connection.recvs, 0)
+        self.assertEqual(connection.in_bytes, 0)
+        self.assertEqual(connection.last_recv_ts, None)
+
+        # a receive on a connection that is not open reports no data, but
+        # it's still accounted as an operation over the connection
+        self.assertEqual(connection.recv(), b"")
+        self.assertEqual(connection.recvs, 1)
+        self.assertEqual(connection.in_bytes, 0)
+        self.assertNotEqual(connection.last_recv_ts, None)
+
+        # the data of an open connection must be both returned to the caller
+        # and accumulated in the total of the received bytes
+        connection.status = conn.OPEN
+
+        self.assertEqual(connection.recv(), b"hello")
+        self.assertEqual(connection.recvs, 2)
+        self.assertEqual(connection.in_bytes, 5)
+
+        self.assertEqual(connection.recv(), b"hello")
+        self.assertEqual(connection.recvs, 3)
+        self.assertEqual(connection.in_bytes, 10)
+
+    def test_recv_partial(self):
+        payload = b"0123456789"
+        connection = self._make_connection(payload=payload)
+        connection.status = conn.OPEN
+
+        # a receive that is bound by a size smaller than the payload must
+        # account only for the bytes that have effectively been returned
+        data = connection.recv(size=4)
+
+        self.assertEqual(data, payload[:4])
+        self.assertEqual(connection.in_bytes, 4)
+
+        # the accounting must follow the size of every operation, so that
+        # the total matches the sum of the bytes that were returned
+        total = 4
+        for size in (1, 2, 3, 10):
+            data = connection.recv(size=size)
+            total += len(data)
+            self.assertEqual(len(data), min(size, len(payload)))
+            self.assertEqual(connection.in_bytes, total)
+
+        self.assertEqual(connection.recvs, 5)
+
+    def test_send(self):
+        connection = self._make_connection()
+        connection.status = conn.OPEN
+
+        # a connection that has not sent anything reports no send operations
+        # and no bytes accounted for them
+        self.assertEqual(connection.sends, 0)
+        self.assertEqual(connection.out_bytes, 0)
+        self.assertEqual(connection.last_send_ts, None)
+
+        # the number of bytes reported by the send operation is the one that
+        # gets accumulated in the total of the sent bytes
+        self.assertEqual(connection.send(b"abc"), 3)
+        self.assertEqual(connection.sends, 1)
+        self.assertEqual(connection.out_bytes, 3)
+        self.assertNotEqual(connection.last_send_ts, None)
+
+        connection.send(b"de")
+
+        self.assertEqual(connection.sends, 2)
+        self.assertEqual(connection.out_bytes, 5)
+
+    def test_send_sequence(self):
+        connection = self._make_connection()
+        connection.status = conn.OPEN
+
+        # the total of the sent bytes must match the sum of the payloads
+        # that were sent, independently of how they are split
+        payloads = [b"a", b"bc", b"def", b"g" * 128, b"h" * 4096]
+        for payload in payloads:
+            connection.send(payload)
+
+        self.assertEqual(connection.sends, len(payloads))
+        self.assertEqual(connection.out_bytes, sum(len(p) for p in payloads))
+
+        # the accounted bytes are the ones handed to the connection and not
+        # the ones already written to the socket, as the writing is deferred
+        # to the event loop, so they must match the pending amount
+        self.assertEqual(connection.out_bytes, connection.pending_s)
+        self.assertEqual(connection.socket.sent, [])
+
     def test_info_dict(self):
         connection = self._make_connection()
         connection.last_recv_ts = 100.0
@@ -159,6 +280,21 @@ class DiagConnectionTest(unittest.TestCase):
         info = connection.info_dict()
 
         self.assertEqual(info["last_activity_timestamp"], 200.0)
+
+        # the accounting of the connection must be part of the information,
+        # as it's the basis for the diagnostics of the traffic in it
+        connection.status = conn.OPEN
+        connection.recv()
+        connection.send(b"abc")
+        info = connection.info_dict()
+
+        self.assertEqual(info["recvs"], 1)
+        self.assertEqual(info["sends"], 1)
+        self.assertEqual(info["in_bytes"], 0)
+        self.assertEqual(info["out_bytes"], 3)
+        self.assertEqual(info["uptime"], connection._uptime())
+        self.assertEqual(info["last_recv_ts"], connection.last_recv_ts)
+        self.assertEqual(info["last_send_ts"], connection.last_send_ts)
 
         # the geographical resolution is an expensive operation, so it must
         # only be performed for the full version of the information
@@ -188,6 +324,79 @@ class DiagConnectionTest(unittest.TestCase):
         connection.last_recv_ts = 300.0
         self.assertEqual(connection._last_activity(), 300.0)
 
-    def _make_connection(self):
-        _socket = socket.socket()
-        return conn.DiagConnection(owner=self.loop, socket=_socket)
+    def test__last_activity_bounds(self):
+        connection = self._make_connection(payload=b"hello")
+        connection.status = conn.OPEN
+
+        connection.recv()
+        connection.send(b"abc")
+        connection.close(reason=netius.REASON_EXPLICIT)
+
+        # every timestamp of the connection must fall inside its lifetime,
+        # so that the reported activity is coherent with it
+        self.assertEqual(connection.creation <= connection.last_recv_ts, True)
+        self.assertEqual(connection.last_recv_ts <= connection.last_send_ts, True)
+        self.assertEqual(connection.last_send_ts <= connection.close_timestamp, True)
+
+        # the last activity is the most recent of the two operations, which
+        # in this case is the sending one
+        self.assertEqual(connection._last_activity(), connection.last_send_ts)
+
+    def test__uptime(self):
+        connection = self._make_connection()
+
+        # a connection created right now has no measurable uptime, so only
+        # the seconds component is reported for it
+        self.assertEqual(connection._uptime(), "0s")
+
+        # only the two most significant components are reported, meaning
+        # that the seconds are dropped once there are larger ones
+        connection.creation = time.time() - 3661
+        self.assertEqual(connection._uptime(), "1h 1m")
+
+        connection.creation = time.time() - 90000
+        self.assertEqual(connection._uptime(), "1d 1h")
+
+    def test__resolve(self):
+        connection = self._make_connection()
+
+        # an unset address carries no geographical information, so no
+        # resolution is attempted for it
+        self.assertEqual(connection._resolve(None), None)
+
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        # the resolution is delegated to the geo resolver using only the
+        # host part of the address, as the port is not relevant for it
+        with mock.patch.object(
+            netius.common.GeoResolver, "resolve", return_value=dict(country="PT")
+        ) as resolve:
+            result = connection._resolve(("8.8.8.8", 80))
+
+        self.assertEqual(result, dict(country="PT"))
+        self.assertEqual(resolve.call_args[0], ("8.8.8.8",))
+
+    def _make_connection(self, payload=b""):
+        # builds a connection over a socket stand-in that reports the
+        # provided payload on receive and accumulates what is sent through
+        # it, sparing the tests from any real network usage
+        class Socket(object):
+
+            def __init__(self):
+                self.sent = []
+
+            def recv(self, size):
+                return payload[:size]
+
+            def send(self, data):
+                self.sent.append(data)
+                return len(data)
+
+            def close(self):
+                pass
+
+            def fileno(self):
+                return 0
+
+        return conn.DiagConnection(owner=self.loop, socket=Socket())

--- a/src/netius/test/base/conn.py
+++ b/src/netius/test/base/conn.py
@@ -100,6 +100,43 @@ class BaseConnectionTest(unittest.TestCase):
         self.assertEqual(connection.close_reason, netius.REASON_TIMEOUT)
         self.assertEqual(connection.close_timestamp, timestamp)
 
+    def test_close_reason_param(self):
+        connection = self._make_connection()
+        connection.close(reason=netius.REASON_ERROR, error="broken pipe")
+
+        # the values provided to the closing must be associated with the
+        # connection, sparing the caller from setting them before hand
+        self.assertEqual(connection.close_reason, netius.REASON_ERROR)
+        self.assertEqual(connection.close_error, "broken pipe")
+
+        # a reason provided to the closing takes precedence over one that
+        # was set before it, as it's the more immediate of the two
+        connection = self._make_connection()
+        connection.close_reason = netius.REASON_TIMEOUT
+        connection.close(reason=netius.REASON_EXPLICIT)
+
+        self.assertEqual(connection.close_reason, netius.REASON_EXPLICIT)
+
+        # the closing of an already closed connection must not replace the
+        # values that describe the original closing of it
+        connection.close(reason=netius.REASON_ERROR)
+
+        self.assertEqual(connection.close_reason, netius.REASON_EXPLICIT)
+
+    def test_close_reason_flush(self):
+        connection = self._make_connection()
+        connection.close(flush=True, reason=netius.REASON_TIMEOUT)
+
+        # the closing is deferred until the pending data is flushed, but the
+        # reason must be kept so that it's available once it does happen
+        self.assertEqual(connection.status, conn.OPEN)
+        self.assertEqual(connection.close_reason, netius.REASON_TIMEOUT)
+
+        connection.close()
+
+        self.assertEqual(connection.status, conn.CLOSED)
+        self.assertEqual(connection.close_reason, netius.REASON_TIMEOUT)
+
     def test_info_dict(self):
         connection = self._make_connection()
         info = connection.info_dict()

--- a/src/netius/test/base/diag.py
+++ b/src/netius/test/base/diag.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import json
+import unittest
+
+import netius
+
+from netius.base import diag
+
+try:
+    import appier
+except ImportError:
+    appier = None
+
+
+class DiagAppTest(unittest.TestCase):
+
+    def test_list_connections_closed(self):
+        if appier == None:
+            self.skipTest("Skipping test: appier unavailable")
+
+        app = diag.DiagApp(self._make_system())
+        result = app.list_connections_closed()
+        result = json.loads(netius.legacy.str(result))
+
+        # the complete contents of the ring buffer must be reported, with
+        # the most recently closed connection being the first one
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["id"], "second")
+        self.assertEqual(result[1]["id"], "first")
+
+        # the metadata that describes the closing must be preserved by the
+        # serialization, as it's the reason for the endpoint to exist
+        self.assertEqual(result[0]["close_reason"], netius.REASON_TIMEOUT)
+        self.assertEqual(result[0]["close_paired"], "first")
+
+    def _make_system(self):
+        # builds a minimal system stand-in that reports a pair of closed
+        # connections, mimicking the ring buffer of the diagnostics
+        closed = [
+            dict(id="second", close_reason=netius.REASON_TIMEOUT, close_paired="first"),
+            dict(
+                id="first",
+                close_reason=netius.REASON_UPSTREAM_ERROR,
+                close_paired="second",
+            ),
+        ]
+
+        class System(object):
+
+            def connections_closed_dict(self):
+                return closed
+
+        return System()

--- a/src/netius/test/middleware/proxy.py
+++ b/src/netius/test/middleware/proxy.py
@@ -202,6 +202,10 @@ class ProxyMiddlewareTest(unittest.TestCase):
         self.assertEqual(connection.status, netius.CLOSED)
         self.assertNotIn(connection, self.server.connections)
 
+        # the closing must be identified as a timeout driven one, so that
+        # the diagnostics are able to report the cause for it
+        self.assertEqual(connection.close_reason, netius.REASON_TIMEOUT)
+
     def test_timeout_completed(self):
         instance = self.server.register_middleware(
             netius.middleware.ProxyMiddleware, handshake_timeout=1

--- a/src/netius/test/servers/http.py
+++ b/src/netius/test/servers/http.py
@@ -179,6 +179,11 @@ class HTTPConnectionTest(unittest.TestCase):
             with mock.patch.object(connection, "close") as close:
                 connection.close_idle()
         self.assertEqual(close.call_count, 1)
+        self.assertEqual(close.call_args[1]["flush"], True)
+
+        # the closing must be identified as a timeout driven one, as that's
+        # the reason that is going to be reported by the diagnostics
+        self.assertEqual(close.call_args[1]["reason"], netius.REASON_TIMEOUT)
 
     def test_send_gzip(self):
         if mock == None:

--- a/src/netius/test/servers/proxy.py
+++ b/src/netius/test/servers/proxy.py
@@ -173,6 +173,61 @@ class ProxyServerTest(unittest.TestCase):
         self.assertEqual(backend.tunnel_d, b"data")
         self.assertEqual(backend.tunnel_r, None)
 
+    def test_reason_connection(self):
+        class Connection(object):
+            pass
+
+        # a plain connection is the one to be marked, as there's no
+        # protocol wrapping it under the old architecture
+        connection = Connection()
+        self.server.reason_connection(connection, netius.REASON_EXPLICIT)
+        self.assertEqual(connection.close_reason, netius.REASON_EXPLICIT)
+
+        # under the new architecture the value is a protocol, so it's the
+        # underlying connection that must be marked, as that's the object
+        # known by the diagnostics
+        protocol = Connection()
+        protocol.connection = Connection()
+        self.server.reason_connection(protocol, netius.REASON_UPSTREAM_ERROR)
+        self.assertEqual(protocol.connection.close_reason, netius.REASON_UPSTREAM_ERROR)
+        self.assertEqual(hasattr(protocol, "close_reason"), False)
+
+        # a protocol with no underlying connection must be gracefully
+        # handled, as the connection may not have been established yet
+        protocol = Connection()
+        protocol.connection = None
+        self.server.reason_connection(protocol, netius.REASON_ERROR)
+        self.assertEqual(hasattr(protocol, "close_reason"), False)
+
+    def test_pair_connection(self):
+        class Connection(object):
+
+            def __init__(self, id):
+                self.id = id
+
+        # a back-end connection that is not mapped must be ignored, as
+        # there's no front-end counterpart to be associated with it
+        backend = Connection("backend")
+        self.server.pair_connection(backend)
+        self.assertEqual(hasattr(backend, "close_paired"), False)
+
+        # both sides of a mapped exchange must end up knowing about the
+        # identifier of the other one, so that they may be correlated
+        frontend = Connection("frontend")
+        self.server.conn_map[backend] = frontend
+        self.server.pair_connection(backend)
+        self.assertEqual(backend.close_paired, "frontend")
+        self.assertEqual(frontend.close_paired, "backend")
+
+        # a protocol is resolved into its connection, so that it's the
+        # identifier of such connection that is used for the pairing
+        protocol = Connection("protocol")
+        protocol.connection = Connection("underlying")
+        self.server.conn_map[protocol] = frontend
+        self.server.pair_connection(protocol)
+        self.assertEqual(protocol.connection.close_paired, "frontend")
+        self.assertEqual(frontend.close_paired, "underlying")
+
     def test__prx_encoding(self):
         if mock == None:
             self.skipTest("Skipping test: mock unavailable")


### PR DESCRIPTION
Closes #55.

Adds a ring buffer of recently closed connections to the diagnostics, so that a connection that was killed can still be inspected after it is gone, together with the reason it was closed and the connection it was paired with.

## What was built

| Step | Where |
| --- | --- |
| Close reason constants | `REASON_TIMEOUT`, `REASON_CLIENT_EOF`, `REASON_UPSTREAM_ERROR`, `REASON_ERROR`, `REASON_EXPLICIT`, `REASON_UNKNOWN` in `base/conn.py` |
| Close metadata on the connection | `close_reason`, `close_error` and `close_timestamp`, reported by `info_dict()` |
| Closing API | `close(reason=..., error=...)`, so the reason travels with the call |
| Ring buffer | `AbstractBase._DIAG_CLOSED`, a `deque` sized by `DIAG_CLOSED_MAX` (default `512`) |
| Recording | `record_closed()`, called from `on_connection_d()` while under `DIAG` |
| Endpoint | `GET /connections/closed` on `DiagApp`, full buffer, most recent first |
| Correlation | `pair_connection()` and `reason_connection()` on `ProxyServer` |

Verified end to end against a reverse proxy in front of a WSGI back end, with `DIAG=1`:

```
GET /connections/closed -> 200
  id=45809ea4 reason=explicit     paired=b9f088cf  duration=0.0008
  id=b9f088cf reason=error        paired=45809ea4  duration=0.0009
```

The two entries are the two sides of the same exchange, each naming the other.

## How a reason is set

The reason is an argument of the closing rather than a field to remember to assign before it:

```python
connection.close(reason=netius.REASON_CLIENT_EOF)
connection.close(reason=netius.REASON_ERROR, error=str(exception))
```

Both values are applied before the flush branch, so `close(flush=True, reason=...)` keeps them through the deferral and they are still there when the buffer drains and the real close runs.

The `close_reason` attribute stays as the fallback for the three cases where the closing is not the call being made, and only those remain in the codebase:

* `ProxyServer.reason_connection()`, because the target is an `HTTPProtocol` and `Protocol.close()` takes no arguments
* `_on_prx_close()`, where one branch closes through a `send_response` callback, so a single assignment covers both branches
* `_on_prx_error()`, which records the reason without closing anything itself

Every other call site passes the reason as an argument.

## Three decisions worth reviewing

**Reused `DiagConnection` instead of adding new tracking.** The first pass added an `open_timestamp`, a `last_activity_timestamp` and a `DIAG` flag to `BaseConnection`, with the timestamps stamped on every read and write. That duplicated `DiagConnection`, which already keeps `creation`, `last_recv_ts` and `last_send_ts` and is already selected when `DIAG` is on. It was reworked to derive from those, so the regular (non diagnostics) path is untouched and no new gating flag exists. `last_activity_timestamp` is therefore reported by `DiagConnection.info_dict()`, which is the only case where it is tracked.

**The buffer is process-global, not per agent.** A proxy's upstream connections belong to a separate `HTTPClient` agent, and `DiagApp` is bound to a single `system`. A per-instance buffer would show only the front-end side and steps 6 and 7 would have nothing to correlate. The buffer is a class attribute, so both agents feed it.

**The snapshot is shallow (`info_dict()`, not `info_dict(full=True)`).** The full variant embeds the parser dict, which holds a `BytesIO`. That made the endpoint return `500` (`Object of type BytesIO is not JSON serializable`) and, worse, would have kept parser buffers alive for up to 512 closed connections. Every field the issue asks for is present without it.

## Beyond the listed files

Step 5 names `base/common.py`, but the connections in a running server are closed through `base/server.py`, which carries its own `on_read`, `on_error`, `on_exception` and `on_expected`. Traced with a live proxy, every close arrived through those and reported `unknown`. The same audit was applied there, per the agreed scope of closing gaps.

The proxy also needed a fix that is easy to miss: under the Agent/Protocol architecture `proxy_c` and `tunnel_c` are `HTTPProtocol` instances, while the ring buffer records the underlying `Connection`. Setting `close_reason` or the paired id directly on them wrote to the wrapper and was silently lost, which is why `reason_connection()` and `pair_connection()` resolve through `.connection` first. Pairing is also established at connect/acquire time rather than at map time, because `ConnectionCompat.id` is a property that returns `None` until the socket exists.

## Platform note on `client_eof`

A graceful client disconnect reports `client_eof` on epoll and `error` on kqueue. This is pre-existing netius behaviour, not something introduced here: `KqueuePoll` routes `KQ_EV_EOF` into the error list, while `EpollPoll` tests `EPOLLIN` before `EPOLLERR`/`EPOLLHUP`, so the zero length read path runs. The deployment in the issue is Linux, so it will report `client_eof`; local macOS runs will show `error`. Changing the poll classification is out of scope for this issue.

## Performance

Measured against `master` (`8607d13d`) served from a separate worktree, same interpreter, runs interleaved and the order alternated between repetitions so that neither side is systematically favoured.

Wall-clock throughput turned out to be useless here: connection churn on this machine varies by 45% run to run (9.1k to 13.2k req/s on `master` alone), which cannot resolve the effect being looked for. The figures below are therefore **server-side CPU time** measured with `getrusage`, and the per-connection numbers use a two point slope (N=5000 versus N=20000) so that process startup and every other fixed cost cancels out.

### With diagnostics off (the default)

| Path | master | branch | Delta |
| --- | --- | --- | --- |
| Marginal CPU per connection (churn) | 71-78 us | 71-76 us | -0.9% (median, straddles zero) |
| Server keep alive, 40000 requests | 1.69 s | 1.71 s | +1.0%, inside a 2.6% within-master spread |
| `_on_prx_acquire` body (per proxied request) | 0.014 us | 0.075 us | **+0.061 us** |
| Connection build + close (microbenchmark) | 2.51 us | 2.60 us | +0.06 us |

Nothing measurable. The `pair_connection` call added to the proxy acquire path is the only new per-request work and it costs 61 ns against a request that consumes roughly 250 us of CPU, so 0.02%. The per-connection additions (three attribute assignments, one `time.time()` and a branch) come to about 60 ns against a 75 us per-connection budget.

### With diagnostics on (`DIAG=1`)

| | per closed connection |
| --- | --- |
| master | 78 us |
| branch, as first written | 112 us (**+42%**) |
| branch, after the fix below | 86 us (**+10%**) |

**The measurement found a real defect.** The snapshot calls `info_dict()`, and `DiagConnection.info_dict()` ends with `self._resolve(self.address)`, which performs a **GeoIP lookup**. That made every connection close under `DIAG` do a geographical resolution: 19.06 us per snapshot with an address set, against 2.59 us without one. It went unnoticed because the unit tests build connections with no address, so `_resolve` returned immediately.

The resolution is now gated on `full`, in the same spirit as the parser being gated there already. `/connections` and `/connections/<id>` default to `full=True` so they are unaffected, while the per-close snapshot skips it. That took the snapshot from 19.06 us to 2.78 us and the end-to-end cost from +42% to +10%, consistently across repetitions (9.7, 9.7, 10.6, 10.1).

The residual +7.8 us per closed connection is spread rather than concentrated: `BaseConnection.info_dict` is 1.29 us, `_uptime` 0.85 us and the new `_last_activity` 0.06 us, with the remainder in real socket attribute access and the deque append. It applies only to connection closes, only when diagnostics are explicitly enabled, and not at all to the request path.

## Tests

613 pass, 12 new, `black` clean.

* `src/netius/test/base/conn.py` (new) covers the fallback reason, an explicit reason surviving the close, a repeated close not overwriting the record, and the derived last activity value
* `src/netius/test/base/common.py` covers the snapshot contents, the duration calculation, the most recent first ordering and the bound of the ring buffer
* `src/netius/test/base/diag.py` (new) covers the endpoint payload
* `src/netius/test/servers/proxy.py` covers the protocol resolution and the pairing in both directions

## One thing found and not fixed

`GET /connections?full=1` has the same `BytesIO` serialization failure, since `full` embeds the parser for live connections too. It predates this change and is not part of the issue, so it is only flagged here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection teardown across base, server, and proxy paths; behavior is additive but mis-set reasons or buffer recording could affect operational debugging under DIAG.
> 
> **Overview**
> Adds **diagnostics for connections after they close**: standardized close reasons (`REASON_*`), optional `error`, and timestamps on `Connection.close(reason=..., error=...)`, surfaced in `info_dict()`.
> 
> When **`DIAG` is enabled**, closes are copied into a **process-wide ring buffer** (`DIAG_CLOSED_MAX`, default 512) via `record_closed()`, exposed as **`GET /connections/closed`** (newest first). **Proxy** paths set reasons and **`close_paired`** IDs so front-end and back-end entries can be correlated; GeoIP in snapshots is skipped unless `full` to avoid cost and JSON issues.
> 
> Supporting updates: **`doc/configuration.md`** and **CHANGELOG**, **`appier`** in test deps, expanded **pytest** deprecation filters, CI **checkout@v7** and **PyPy 3.11**, plus unit tests for conn/common/diag/proxy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9013f0287a77231cc83de12717c08e16f8746b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->