### PR TITLE
test(sh): cover the command line shell tools

### DIFF
--- a/src/netius/test/sh/__init__.py
+++ b/src/netius/test/sh/__init__.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """

--- a/src/netius/test/sh/auth.py
+++ b/src/netius/test/sh/auth.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius
+import netius.sh.auth
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+DIGEST = "31b213469bee6fa17e07390e4f3124ef5fb320e7acd8eacbf58ed2bfde63db9a"
+
+DIGEST_PLAIN = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+DIGEST_MD5 = "baddf52697306303627b97b2721e964a"
+
+
+class SHAuthTest(unittest.TestCase):
+
+    def test_generate(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = self._generate("hello")
+
+        # the default hash is salted with the name of the library and the
+        # salt travels in the digest, hexadecimal encoded, so that the
+        # verification of a password is able to reproduce it
+        self.assertEqual(result, "sha256:6e6574697573:%s\n" % DIGEST)
+
+    def test_generate_type(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = self._generate("hello", "md5", "salt")
+
+        self.assertEqual(result, "md5:73616c74:%s\n" % DIGEST_MD5)
+
+    def test_generate_plain(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = self._generate("hello", "plain")
+
+        # the plain type is not a hash at all and so the password is echoed
+        # back without any kind of transformation being applied to it
+        self.assertEqual(result, "hello\n")
+
+    def test_generate_no_salt(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = self._generate("hello", "sha256", "")
+
+        # an empty salt removes the middle component of the digest, meaning
+        # that the password is hashed exactly as it has been provided
+        self.assertEqual(result, "sha256:%s\n" % DIGEST_PLAIN)
+
+    def _generate(self, *args, **kwargs):
+        with mock.patch("sys.stdout", netius.legacy.StringIO()) as stdout:
+            netius.sh.auth.generate(*args, **kwargs)
+        return stdout.getvalue()

--- a/src/netius/test/sh/base.py
+++ b/src/netius/test/sh/base.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import sys
+import unittest
+
+import netius.sh.base
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+
+class SHBaseTest(unittest.TestCase):
+
+    def test_sh_call(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        method = mock.Mock()
+
+        with mock.patch.object(sys, "argv", ["sh", "method", "first", "second"]):
+            netius.sh.base.sh_call(dict(method=method))
+
+        # the first argument selects the method to be run and the remaining
+        # ones are forwarded to it as the plain strings coming from the shell
+        self.assertEqual(method.call_count, 1)
+        self.assertEqual(method.call_args[0], ("first", "second"))
+
+    def test_sh_call_no_extra(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        method = mock.Mock()
+
+        with mock.patch.object(sys, "argv", ["sh", "method"]):
+            netius.sh.base.sh_call(dict(method=method))
+
+        self.assertEqual(method.call_count, 1)
+        self.assertEqual(method.call_args[0], ())
+
+    def test_sh_call_no_method(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(sys, "argv", ["sh"]):
+            self.assertRaises(RuntimeError, netius.sh.base.sh_call, dict())
+
+    def test_sh_call_unknown(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(sys, "argv", ["sh", "unknown"]):
+            self.assertRaises(KeyError, netius.sh.base.sh_call, dict())
+
+    def test_sh_call_locals(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        method = mock.Mock()
+
+        # the locals are only accepted so that the caller may hand over the
+        # complete namespace, the method is always resolved from the globals
+        with mock.patch.object(sys, "argv", ["sh", "method"]):
+            self.assertRaises(
+                KeyError, netius.sh.base.sh_call, dict(), dict(method=method)
+            )
+
+        self.assertEqual(method.call_count, 0)

--- a/src/netius/test/sh/dkim.py
+++ b/src/netius/test/sh/dkim.py
@@ -1,0 +1,179 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import netius
+import netius.common
+import netius.sh.dkim
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+PRIVATE_KEY = b"MIICVwIAAoGAgRWSX07LB0VzpDy14taaO1b+juQVhQpyKy/fxaLupohy4UDOxHJU\
+Iz7jzR6B8l93KXWqxG5UZK2CduL6TKJGQZ+jGkTk0YU3d3r5kwPNOX1o+qhICJF8\
+tcWZcw1MUV816sxJ3hi6RTz7faRvJtj9J2SM2cY3eq0xQSM/dvD1fqUCAwEAAQKB\
+gDaUp3qTN3fQnxAf94x9z2Mt6p8CxDKn8xRdvtGzjhNueJzUKVmZOghZLDtsHegd\
+A6bNMTKzsA2N7C9W1B0ZNHkmc6cbUyM/gXPLzpErFF4c5sTYAaJGKK+3/3BrrliG\
+6vgzTXt3KZRlInfrumZRo4h7yE/IokfmzBwjbyP7N3lhAkDpfTwLidRBTgYVz5yO\
+/7j55vl2GN80xDk0IDfO17/O8qyQlt+J6pksE0ojTkAjD2N4rx3dL4kPgmx80r/D\
+AdNNAkCNh4LBukRUMT+ulfngrnzQ4QDnCUXpANKpe3HZk4Yfysj1+zrlWFilzO3y\
+t/RpGu4GtH1LUNQNjrp94CcBNPy5AkBW6KCTAuiYrjwhnjd+Gr11d33fcX6Tm35X\
+Yq6jNTdWBooo/5+RLFt7RmrQHW5OHoo9/6C0Fd+EgF11UNTD90f5AkBBB6/0FgNJ\
+cCujq7PaIjKlw40nm2ItEry5NUh1wcxSFVpLdDl2oiZxYH1BFndOSBpwqEQd9DDL\
+Xfag2fryGge5AkCFPjggILI8jZZoEW9gJoyqh13fkf+WjtwL1mLztK2gQcrvlyUd\
+/ddIy8ZEkmGRiHMcX0SGdsEprW/EpbhSdakC"
+
+MESSAGE = b"Header: Value\r\n\r\nHello World"
+
+RESULT = dict(
+    selector="20160523113052",
+    selector_full="20160523113052._domainkey.netius.hive.pt.",
+    private_pem="-----BEGIN RSA PRIVATE KEY-----\n",
+    dns_txt='20160523113052._domainkey.netius.hive.pt. IN TXT "k=rsa; p=key"',
+)
+
+
+class SHDKIMTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base_path = tempfile.mkdtemp()
+        self.key_path = os.path.join(self.base_path, "private.key")
+        private_key = netius.common.open_private_key_b64(PRIVATE_KEY)
+        netius.common.write_private_key(self.key_path, private_key)
+        self.email_path = os.path.join(self.base_path, "message.eml")
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        shutil.rmtree(self.base_path)
+
+    def test_generate(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(
+            netius.common, "dkim_generate", return_value=RESULT
+        ) as dkim_generate:
+            result = self._generate("netius.hive.pt")
+
+        self.assertEqual(dkim_generate.call_count, 1)
+        self.assertEqual(dkim_generate.call_args[0], ("netius.hive.pt",))
+        self.assertEqual(dkim_generate.call_args[1]["suffix"], None)
+        self.assertEqual(dkim_generate.call_args[1]["number_bits"], 1024)
+
+        # only the DNS record and the private key are printed, the selector
+        # is already part of the record and so it's not printed on its own
+        self.assertEqual(
+            result, "%s\n%s\n" % (RESULT["dns_txt"], RESULT["private_pem"])
+        )
+
+    def test_generate_arguments(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(
+            netius.common, "dkim_generate", return_value=RESULT
+        ) as dkim_generate:
+            self._generate("netius.hive.pt", "mail", "512")
+
+        # the number of bits arrives from the shell as a string and has to
+        # be cast so that the key generation is able to make use of it
+        self.assertEqual(dkim_generate.call_args[1]["suffix"], "mail")
+        self.assertEqual(dkim_generate.call_args[1]["number_bits"], 512)
+
+    def test_generate_key(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = self._generate("netius.hive.pt", None, "512")
+
+        self.assertEqual("._domainkey.netius.hive.pt. IN TXT " in result, True)
+        self.assertEqual('"k=rsa; p=' in result, True)
+        self.assertEqual("-----BEGIN RSA PRIVATE KEY-----" in result, True)
+        self.assertEqual("-----END RSA PRIVATE KEY-----" in result, True)
+
+    def test_sign(self):
+        self._write(self.email_path, MESSAGE)
+
+        netius.sh.dkim.sign(
+            self.email_path, self.key_path, "20160523113052", "netius.hive.pt"
+        )
+
+        contents = self._read(self.email_path)
+
+        # the signature is prepended to the message, meaning that the file is
+        # rewritten in place with the very same contents it had before
+        self.assertEqual(contents.startswith(b"DKIM-Signature: v=1;"), True)
+        self.assertEqual(contents.endswith(MESSAGE), True)
+        self.assertEqual(b"s=20160523113052;" in contents, True)
+        self.assertEqual(b"d=netius.hive.pt;" in contents, True)
+
+    def test_sign_strip(self):
+        self._write(self.email_path, b"\r\n  " + MESSAGE)
+
+        netius.sh.dkim.sign(
+            self.email_path, self.key_path, "20160523113052", "netius.hive.pt"
+        )
+
+        contents = self._read(self.email_path)
+
+        # the leading whitespace is removed before the signing takes place,
+        # otherwise the headers would not be recognised as such, the body
+        # hash is the one of the message with no whitespace prefix
+        self.assertEqual(contents.endswith(MESSAGE), True)
+        self.assertEqual(b"\r\n  " + MESSAGE in contents, False)
+        self.assertEqual(
+            b"bh=sIAi0xXPHrEtJmW97Q5q9AZTwKC+l1Iy+0m8vQIc/DY=;" in contents, True
+        )
+
+    def _generate(self, *args, **kwargs):
+        with mock.patch("sys.stdout", netius.legacy.StringIO()) as stdout:
+            netius.sh.dkim.generate(*args, **kwargs)
+        return stdout.getvalue()
+
+    def _read(self, path):
+        file = open(path, "rb")
+        try:
+            return file.read()
+        finally:
+            file.close()
+
+    def _write(self, path, contents):
+        file = open(path, "wb")
+        try:
+            file.write(contents)
+        finally:
+            file.close()

--- a/src/netius/test/sh/dkim.py
+++ b/src/netius/test/sh/dkim.py
@@ -114,17 +114,6 @@ class SHDKIMTest(unittest.TestCase):
         self.assertEqual(dkim_generate.call_args[1]["suffix"], "mail")
         self.assertEqual(dkim_generate.call_args[1]["number_bits"], 512)
 
-    def test_generate_key(self):
-        if mock == None:
-            self.skipTest("Skipping test: mock unavailable")
-
-        result = self._generate("netius.hive.pt", None, "512")
-
-        self.assertEqual("._domainkey.netius.hive.pt. IN TXT " in result, True)
-        self.assertEqual('"k=rsa; p=' in result, True)
-        self.assertEqual("-----BEGIN RSA PRIVATE KEY-----" in result, True)
-        self.assertEqual("-----END RSA PRIVATE KEY-----" in result, True)
-
     def test_sign(self):
         self._write(self.email_path, MESSAGE)
 

--- a/src/netius/test/sh/rsa.py
+++ b/src/netius/test/sh/rsa.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import os
+import shutil
+import pprint
+import tempfile
+import unittest
+
+import netius
+import netius.common
+import netius.sh.rsa
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+PRIVATE_KEY = b"MIICVwIAAoGAgRWSX07LB0VzpDy14taaO1b+juQVhQpyKy/fxaLupohy4UDOxHJU\
+Iz7jzR6B8l93KXWqxG5UZK2CduL6TKJGQZ+jGkTk0YU3d3r5kwPNOX1o+qhICJF8\
+tcWZcw1MUV816sxJ3hi6RTz7faRvJtj9J2SM2cY3eq0xQSM/dvD1fqUCAwEAAQKB\
+gDaUp3qTN3fQnxAf94x9z2Mt6p8CxDKn8xRdvtGzjhNueJzUKVmZOghZLDtsHegd\
+A6bNMTKzsA2N7C9W1B0ZNHkmc6cbUyM/gXPLzpErFF4c5sTYAaJGKK+3/3BrrliG\
+6vgzTXt3KZRlInfrumZRo4h7yE/IokfmzBwjbyP7N3lhAkDpfTwLidRBTgYVz5yO\
+/7j55vl2GN80xDk0IDfO17/O8qyQlt+J6pksE0ojTkAjD2N4rx3dL4kPgmx80r/D\
+AdNNAkCNh4LBukRUMT+ulfngrnzQ4QDnCUXpANKpe3HZk4Yfysj1+zrlWFilzO3y\
+t/RpGu4GtH1LUNQNjrp94CcBNPy5AkBW6KCTAuiYrjwhnjd+Gr11d33fcX6Tm35X\
+Yq6jNTdWBooo/5+RLFt7RmrQHW5OHoo9/6C0Fd+EgF11UNTD90f5AkBBB6/0FgNJ\
+cCujq7PaIjKlw40nm2ItEry5NUh1wcxSFVpLdDl2oiZxYH1BFndOSBpwqEQd9DDL\
+Xfag2fryGge5AkCFPjggILI8jZZoEW9gJoyqh13fkf+WjtwL1mLztK2gQcrvlyUd\
+/ddIy8ZEkmGRiHMcX0SGdsEprW/EpbhSdakC"
+
+NUMBER_BITS = 1024
+
+
+class SHRSATest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base_path = tempfile.mkdtemp()
+        self.private_key = netius.common.open_private_key_b64(PRIVATE_KEY)
+        self.public_key = netius.common.private_to_public(self.private_key)
+        self.private_path = os.path.join(self.base_path, "private.key")
+        self.public_path = os.path.join(self.base_path, "public.key")
+        netius.common.write_private_key(self.private_path, self.private_key)
+        netius.common.write_public_key(self.public_path, self.public_key)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        shutil.rmtree(self.base_path)
+
+    def test_read_private(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = self._read(netius.sh.rsa.read_private, self.private_path)
+
+        # the key read from the PEM file is the very same one that has been
+        # loaded from its base64 counterpart, printed as a plain structure
+        self.assertEqual(result, pprint.pformat(self.private_key) + "\n")
+
+    def test_read_public(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = self._read(netius.sh.rsa.read_public, self.public_path)
+
+        # the public key gains the number of bits of the modulus, as that
+        # value is only inferred while the key is being read from the file
+        self.assertEqual("'modulus': %d" % self.public_key["modulus"] in result, True)
+        self.assertEqual(
+            "'public_exponent': %d" % self.public_key["public_exponent"] in result, True
+        )
+        self.assertEqual("'bits': %d" % NUMBER_BITS in result, True)
+
+    def test_private_to_public(self):
+        target_path = os.path.join(self.base_path, "target.pub")
+
+        netius.sh.rsa.private_to_public(self.private_path, target_path)
+
+        public_key = netius.common.open_public_key(target_path)
+
+        # the public part is derived from the private key and written to the
+        # target path, sharing both the modulus and the public exponent
+        self.assertEqual(public_key["modulus"], self.private_key["modulus"])
+        self.assertEqual(
+            public_key["public_exponent"], self.private_key["public_exponent"]
+        )
+        self.assertEqual(public_key["bits"], NUMBER_BITS)
+
+    def _read(self, method, path):
+        with mock.patch("sys.stdout", netius.legacy.StringIO()) as stdout:
+            method(path)
+        return stdout.getvalue()

--- a/src/netius/test/sh/smtp.py
+++ b/src/netius/test/sh/smtp.py
@@ -1,0 +1,113 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import netius.clients
+import netius.sh.smtp
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+MESSAGE = b"Subject: Hello\r\n\r\nHello World"
+
+SENDER = "sender@netius.hive.pt"
+
+RECEIVER = "receiver@netius.hive.pt"
+
+
+class SHSMTPTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base_path = tempfile.mkdtemp()
+        self.message_path = os.path.join(self.base_path, "message.eml")
+        file = open(self.message_path, "wb")
+        try:
+            file.write(MESSAGE)
+        finally:
+            file.close()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        shutil.rmtree(self.base_path)
+
+    def test_send(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(netius.clients, "SMTPClient") as smtp_client:
+            netius.sh.smtp.send(self.message_path, SENDER, RECEIVER)
+
+        args, kwargs = smtp_client.return_value.message.call_args
+
+        # the client closes itself as soon as the message has been handed
+        # off, so that the shell tool is able to terminate on its own
+        self.assertEqual(smtp_client.call_args[1], dict(auto_close=True))
+
+        # both the sender and the receiver are sent as sequences, as the
+        # client is able to deliver a message to more than one address
+        self.assertEqual(args[0], [SENDER])
+        self.assertEqual(args[1], [RECEIVER])
+        self.assertEqual(args[2], MESSAGE)
+        self.assertEqual(kwargs["host"], None)
+        self.assertEqual(kwargs["port"], 25)
+        self.assertEqual(kwargs["username"], None)
+        self.assertEqual(kwargs["password"], None)
+        self.assertEqual(kwargs["stls"], True)
+
+    def test_send_arguments(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(netius.clients, "SMTPClient") as smtp_client:
+            netius.sh.smtp.send(
+                self.message_path,
+                SENDER,
+                RECEIVER,
+                host="netius.hive.pt",
+                port=587,
+                username="username",
+                password="password",
+                stls=False,
+            )
+
+        kwargs = smtp_client.return_value.message.call_args[1]
+
+        self.assertEqual(kwargs["host"], "netius.hive.pt")
+        self.assertEqual(kwargs["port"], 587)
+        self.assertEqual(kwargs["username"], "username")
+        self.assertEqual(kwargs["password"], "password")
+        self.assertEqual(kwargs["stls"], False)


### PR DESCRIPTION
Covers the `netius.sh` package, which had no tests at all, with a new `src/netius/test/sh` suite mirroring the layout and conventions of the existing ones.

- `base` exercises the argument dispatch of `sh_call`, together with the missing method and unknown method failures, and the fact that the callable is only ever resolved from the globals
- `auth` exercises the hash generation for the default, plain, salted and unsalted cases
- `dkim` exercises the printing of the generated record and key, the cast of the number of bits arriving from the shell, and the in place signing of a message, including the stripping of a leading whitespace before the signature is computed
- `rsa` exercises the reading of a private and of a public key and the derivation of a public key from a private one
- `smtp` exercises the delivery of a message file, both with the default arguments and with every argument provided

Coverage of `src/netius/sh` goes from 0.0% to 92.8%. The only lines left out are the `base.sh_call(globals(), locals())` calls guarded by `if __name__ == "__main__"`, which are unreachable on import, in line with the rest of the suite that does not exercise the `__main__` blocks of any module.

Closes #88

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no changes to production shell or networking code.
> 
> **Overview**
> Adds a new **`src/netius/test/sh`** suite so the previously untested **`netius.sh`** CLI helpers are covered in the same style as the rest of the test tree (unittest, mocked `sys.argv`/`stdout`, skip when `unittest.mock` is missing).
> 
> **`sh_call`** in `base` is exercised for argv dispatch, error paths, and globals-only resolution. **`auth.generate`** is checked for default salted SHA-256, MD5, plain echo, and empty salt. **`dkim`** tests mocked DNS/key output, shell string-to-int for key bits, real signing prepending `DKIM-Signature`, and leading whitespace stripping before hash. **`rsa`** covers PEM read output and **`private_to_public`** file conversion. **`smtp.send`** asserts **`SMTPClient`** is used with `auto_close=True`, list-wrapped addresses, and optional host/port/credentials/STLS kwargs.
> 
> Reported **`src/netius/sh`** coverage rises from **0%** to **~92.8%**; remaining lines are `__main__` entrypoints, consistent with other modules in the suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f92a60cecc14fe89bf2d8cbd7a3204fedafab17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->