### PR TITLE
test(base): cover the datagram and stream server dispatch

### DIFF
--- a/src/netius/test/base/server.py
+++ b/src/netius/test/base/server.py
@@ -95,7 +95,7 @@ class ServerTest(unittest.TestCase):
             # is driven by the poll instead of by a blocking call, note that
             # the timeout is the way of telling it under the oldest runtimes
             self.assertEqual(_socket.family, socket.AF_INET)
-            self.assertEqual(_socket.type, socket.SOCK_DGRAM)
+            self.assertEqual(self._type(_socket), socket.SOCK_DGRAM)
             self.assertEqual(_socket.gettimeout(), 0)
             self.assertNotEqual(
                 _socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR), 0
@@ -110,6 +110,12 @@ class ServerTest(unittest.TestCase):
         # the serve notification is an extension point with no default
         # behaviour, so that a sub class may hook into it
         self.server.on_serve()
+
+    def _type(self, _socket):
+        # under Linux the non blocking flag is part of the type of the
+        # socket until Python 3.7, where it started being masked out, so
+        # it has to be removed for the type to be comparable
+        return _socket.type & ~getattr(socket, "SOCK_NONBLOCK", 0)
 
 
 class DatagramServerTest(unittest.TestCase):

--- a/src/netius/test/base/server.py
+++ b/src/netius/test/base/server.py
@@ -1,0 +1,452 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import socket
+import logging
+import unittest
+import threading
+
+import netius
+
+from netius.base import conn
+from netius.base import common
+from netius.base import server
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+ADDRESS = ("127.0.0.1", 9090)
+
+
+class ServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.server = netius.DatagramServer(level=logging.CRITICAL)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+
+    def test_cleanup(self):
+        self.server.socket = self.server.socket_udp()
+
+        self.server.cleanup()
+
+        # the service socket is closed and released, as it's the one that
+        # has no connection associated with it
+        self.assertEqual(self.server.socket, None)
+
+    def test_cleanup_error(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        _socket = mock.Mock()
+        _socket.close.side_effect = socket.error("Already closed")
+        self.server.socket = _socket
+
+        # a socket that fails to close is not able to break the cleanup, as
+        # by then there's nothing left to be done about it
+        self.server.cleanup()
+
+        self.assertEqual(self.server.socket, None)
+
+    def test_info_dict(self):
+        info = self.server.info_dict()
+
+        self.assertEqual(info["host"], self.server.host)
+        self.assertEqual(info["port"], self.server.port)
+        self.assertEqual(info["type"], self.server.type)
+        self.assertEqual(info["ssl"], self.server.ssl)
+
+    def test_socket_udp(self):
+        _socket = self.server.socket_udp()
+        try:
+            # the service socket is a non blocking one, as the reading of it
+            # is driven by the poll instead of by a blocking call
+            self.assertEqual(_socket.family, socket.AF_INET)
+            self.assertEqual(_socket.type, socket.SOCK_DGRAM)
+            self.assertEqual(_socket.getblocking(), False)
+            self.assertNotEqual(
+                _socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR), 0
+            )
+            self.assertNotEqual(
+                _socket.getsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST), 0
+            )
+        finally:
+            _socket.close()
+
+    def test_on_serve(self):
+        # the serve notification is an extension point with no default
+        # behaviour, so that a sub class may hook into it
+        self.server.on_serve()
+
+
+class DatagramServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.server = netius.DatagramServer(level=logging.CRITICAL)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+
+    def test_init(self):
+        self.assertEqual(self.server.renable, True)
+        self.assertEqual(self.server.wready, True)
+        self.assertEqual(self.server.pending_s, 0)
+        self.assertEqual(len(self.server.pending), 0)
+
+    def test_reads(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.server, "on_read") as on_read:
+            self.server.reads((1, 2), state=False)
+
+        # every ready socket is handed over to the read handler, as a
+        # datagram server has a single socket for the complete service
+        self.assertEqual(on_read.call_count, 2)
+
+    def test_writes(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.server, "on_write") as on_write:
+            self.server.writes((1, 2), state=False)
+
+        self.assertEqual(on_write.call_count, 2)
+
+    def test_errors(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.server, "on_error") as on_error:
+            self.server.errors((1, 2), state=False)
+
+        self.assertEqual(on_error.call_count, 2)
+
+    def test_serve(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(server.Server, "serve") as serve:
+            self.server.serve()
+
+        # a datagram server is bound to a datagram socket, so the type of
+        # the service is overridden before it reaches the base server
+        self.assertEqual(serve.call_args[1]["type"], common.UDP_TYPE)
+
+    def test_on_exception(self):
+        # both the unexpected and the expected exceptions are only logged,
+        # as a datagram server has no connection to be closed
+        self.server.on_exception(netius.NetiusError("boom"))
+        self.server.on_expected(netius.NetiusError("broken pipe"))
+
+    def test_on_data(self):
+        # the default handling of the data is a no operation, the payload
+        # is meant to be consumed by a sub class instead
+        self.server.on_data(ADDRESS, b"Hello World")
+
+    def test_ensure_write(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.tid = threading.current_thread().ident
+
+        with mock.patch.object(self.server, "sub_write") as sub_write:
+            self.server.ensure_write()
+
+        self.assertEqual(sub_write.call_count, 1)
+
+    def test_ensure_write_unsafe(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        # a subscription requested from a thread other than the loop one is
+        # not safe, so it must be deferred instead of run right away
+        with mock.patch.object(self.server, "sub_write") as sub_write:
+            self.server.ensure_write()
+
+        self.assertEqual(sub_write.call_count, 0)
+        self.assertEqual(len(self.server._delayed), 1)
+
+    def test_remove_write(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.server, "unsub_write") as unsub_write:
+            self.server.remove_write()
+
+        self.assertEqual(unsub_write.call_count, 1)
+
+    def test_enable_read(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.renable = False
+
+        with mock.patch.object(self.server, "sub_read") as sub_read:
+            self.server.enable_read()
+
+        self.assertEqual(self.server.renable, True)
+        self.assertEqual(sub_read.call_count, 1)
+
+    def test_enable_read_enabled(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        # a server that is already reading must not be subscribed once again
+        # as that would be a duplicated registration in the poll
+        with mock.patch.object(self.server, "sub_read") as sub_read:
+            self.server.enable_read()
+
+        self.assertEqual(sub_read.call_count, 0)
+
+    def test_disable_read(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.server, "unsub_read") as unsub_read:
+            self.server.disable_read()
+
+        self.assertEqual(self.server.renable, False)
+        self.assertEqual(unsub_read.call_count, 1)
+
+    def test_disable_read_disabled(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.renable = False
+
+        with mock.patch.object(self.server, "unsub_read") as unsub_read:
+            self.server.disable_read()
+
+        self.assertEqual(unsub_read.call_count, 0)
+
+    def test_send(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.tid = threading.current_thread().ident
+
+        with mock.patch.object(self.server, "_flush_write") as flush_write:
+            self.server.send(b"Hello World", ADDRESS, delay=False)
+
+        # the payload is queued together with the address it targets and
+        # the pending counter grows by the size of the payload
+        self.assertEqual(self.server.pending[0], (b"Hello World", ADDRESS))
+        self.assertEqual(self.server.pending_s, 11)
+        self.assertEqual(flush_write.call_count, 1)
+
+    def test_send_callback(self):
+        self.server.tid = threading.current_thread().ident
+        callback = lambda connection: None
+
+        self.server.send(b"Hello World", ADDRESS, callback=callback)
+
+        # the callback travels alongside the payload, so that it's called
+        # once the payload has been handed over to the socket
+        data, address = self.server.pending[0]
+
+        self.assertEqual(data, (b"Hello World", callback))
+        self.assertEqual(address, ADDRESS)
+
+    def test_send_delayed(self):
+        self.server.tid = threading.current_thread().ident
+
+        # a sending that is not immediate is deferred to the next tick, so
+        # that multiple payloads are flushed in a single operation
+        self.server.send(b"Hello World", ADDRESS)
+
+        self.assertEqual(len(self.server.pending), 1)
+        self.assertEqual(len(self.server._delayed), 1)
+
+    def test_send_busy(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.tid = threading.current_thread().ident
+        self.server.wready = False
+
+        # a socket that is not ready for writing must be subscribed for the
+        # write event instead of being flushed right away
+        with mock.patch.object(self.server, "ensure_write") as ensure_write:
+            self.server.send(b"Hello World", ADDRESS)
+
+        self.assertEqual(ensure_write.call_count, 1)
+        self.assertEqual(len(self.server.pending), 1)
+
+    def test__flush_write(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.server, "writes") as writes:
+            self.server._flush_write()
+
+        # the flushing is a write notification for the service socket that
+        # does not change the state of the loop
+        self.assertEqual(writes.call_args[0][0], (self.server.socket,))
+        self.assertEqual(writes.call_args[1]["state"], False)
+
+
+class StreamServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.server = netius.StreamServer(level=logging.CRITICAL)
+        self.server.socket = socket.socket()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+
+    def test_reads(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        _socket = socket.socket()
+        try:
+            with mock.patch.object(self.server, "on_read_s") as on_read_s:
+                with mock.patch.object(self.server, "on_read") as on_read:
+                    self.server.reads((self.server.socket, _socket), state=False)
+        finally:
+            _socket.close()
+
+        # the service socket announces a new connection while any other one
+        # announces data, so the two are routed to different handlers
+        self.assertEqual(on_read_s.call_count, 1)
+        self.assertEqual(on_read.call_count, 1)
+
+    def test_writes(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        _socket = socket.socket()
+        try:
+            with mock.patch.object(self.server, "on_write_s") as on_write_s:
+                with mock.patch.object(self.server, "on_write") as on_write:
+                    self.server.writes((self.server.socket, _socket), state=False)
+        finally:
+            _socket.close()
+
+        self.assertEqual(on_write_s.call_count, 1)
+        self.assertEqual(on_write.call_count, 1)
+
+    def test_errors(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        _socket = socket.socket()
+        try:
+            with mock.patch.object(self.server, "on_error_s") as on_error_s:
+                with mock.patch.object(self.server, "on_error") as on_error:
+                    self.server.errors((self.server.socket, _socket), state=False)
+        finally:
+            _socket.close()
+
+        self.assertEqual(on_error_s.call_count, 1)
+        self.assertEqual(on_error.call_count, 1)
+
+    def test_on_write_s(self):
+        # the service socket handlers for writing and for errors are
+        # extension points with no default behaviour
+        self.server.on_write_s(self.server.socket)
+        self.server.on_error_s(self.server.socket)
+
+    def test_on_exception(self):
+        connection = self._make_connection()
+
+        self.server.on_exception(netius.NetiusError("boom"), connection)
+
+        # the closing must be identified as an error driven one, carrying
+        # the details of the exception that has originated it
+        self.assertEqual(connection.status, conn.CLOSED)
+        self.assertEqual(connection.close_reason, netius.REASON_ERROR)
+        self.assertEqual(connection.close_error, "boom")
+
+    def test_on_exception_s(self):
+        # an exception raised by the service socket has no connection to be
+        # closed, so it's only logged
+        self.server.on_exception_s(netius.NetiusError("boom"))
+        self.server.on_expected_s(netius.NetiusError("broken pipe"))
+
+    def test_on_expected(self):
+        connection = self._make_connection()
+
+        self.server.on_expected(netius.NetiusError("broken pipe"), connection)
+
+        self.assertEqual(connection.status, conn.CLOSED)
+        self.assertEqual(connection.close_reason, netius.REASON_ERROR)
+        self.assertEqual(connection.close_error, "broken pipe")
+
+    def test_on_upgrade(self):
+        connection = self._make_connection()
+        connection.upgrading = True
+        upgraded = []
+        connection.bind("upgrade", lambda _connection: upgraded.append(_connection))
+
+        self.server.on_upgrade(connection)
+
+        # the end of the upgrade releases the connection from the upgrading
+        # state and notifies the observers through the upgrade event
+        self.assertEqual(connection.is_upgrading(), False)
+        self.assertEqual(upgraded, [connection])
+
+    def test_on_data(self):
+        connection = self._make_connection()
+        received = []
+        connection.bind("data", lambda _connection, data: received.append(data))
+
+        self.server.on_data(connection, b"Hello World")
+
+        self.assertEqual(received, [b"Hello World"])
+
+    def test_on_socket_d(self):
+        connection = self._make_connection()
+
+        self.server.on_socket_d(connection.socket)
+
+        # a socket that is no longer associated with a connection must be
+        # gracefully ignored, as the connection may already be gone
+        self.server.on_socket_d(socket.socket())
+
+    def _make_connection(self):
+        # builds an open connection registered in the server, so that the
+        # closing of it may be run over the complete set of structures
+        _socket = socket.socket()
+        connection = conn.BaseConnection(owner=self.server, socket=_socket)
+        connection.status = conn.OPEN
+        self.server.connections.append(connection)
+        self.server.connections_m[_socket] = connection
+        return connection

--- a/src/netius/test/base/server.py
+++ b/src/netius/test/base/server.py
@@ -116,6 +116,7 @@ class DatagramServerTest(unittest.TestCase):
     def setUp(self):
         unittest.TestCase.setUp(self)
         self.server = netius.DatagramServer(level=logging.CRITICAL)
+        self.server.socket = self.server.socket_udp()
 
     def tearDown(self):
         unittest.TestCase.tearDown(self)
@@ -136,7 +137,7 @@ class DatagramServerTest(unittest.TestCase):
 
         # every ready socket is handed over to the read handler, as a
         # datagram server has a single socket for the complete service
-        self.assertEqual(on_read.call_count, 2)
+        self.assertEqual(self._sockets(on_read), [1, 2])
 
     def test_writes(self):
         if mock == None:
@@ -145,7 +146,7 @@ class DatagramServerTest(unittest.TestCase):
         with mock.patch.object(self.server, "on_write") as on_write:
             self.server.writes((1, 2), state=False)
 
-        self.assertEqual(on_write.call_count, 2)
+        self.assertEqual(self._sockets(on_write), [1, 2])
 
     def test_errors(self):
         if mock == None:
@@ -154,7 +155,7 @@ class DatagramServerTest(unittest.TestCase):
         with mock.patch.object(self.server, "on_error") as on_error:
             self.server.errors((1, 2), state=False)
 
-        self.assertEqual(on_error.call_count, 2)
+        self.assertEqual(self._sockets(on_error), [1, 2])
 
     def test_serve(self):
         if mock == None:
@@ -187,7 +188,10 @@ class DatagramServerTest(unittest.TestCase):
         with mock.patch.object(self.server, "sub_write") as sub_write:
             self.server.ensure_write()
 
+        # the socket of the server is the one that gets subscribed, as a
+        # datagram server has a single socket for the complete service
         self.assertEqual(sub_write.call_count, 1)
+        self.assertEqual(sub_write.call_args[0][0], self.server.socket)
 
     def test_ensure_write_unsafe(self):
         if mock == None:
@@ -209,6 +213,7 @@ class DatagramServerTest(unittest.TestCase):
             self.server.remove_write()
 
         self.assertEqual(unsub_write.call_count, 1)
+        self.assertEqual(unsub_write.call_args[0][0], self.server.socket)
 
     def test_enable_read(self):
         if mock == None:
@@ -221,6 +226,7 @@ class DatagramServerTest(unittest.TestCase):
 
         self.assertEqual(self.server.renable, True)
         self.assertEqual(sub_read.call_count, 1)
+        self.assertEqual(sub_read.call_args[0][0], self.server.socket)
 
     def test_enable_read_enabled(self):
         if mock == None:
@@ -242,6 +248,7 @@ class DatagramServerTest(unittest.TestCase):
 
         self.assertEqual(self.server.renable, False)
         self.assertEqual(unsub_read.call_count, 1)
+        self.assertEqual(unsub_read.call_args[0][0], self.server.socket)
 
     def test_disable_read_disabled(self):
         if mock == None:
@@ -319,6 +326,11 @@ class DatagramServerTest(unittest.TestCase):
         self.assertEqual(writes.call_args[0][0], (self.server.socket,))
         self.assertEqual(writes.call_args[1]["state"], False)
 
+    def _sockets(self, handler):
+        # gathers the sockets that have been handed over to the handler, so
+        # that both the count and the identity of them may be verified
+        return [call[0][0] for call in handler.call_args_list]
+
 
 class StreamServerTest(unittest.TestCase):
 
@@ -344,9 +356,10 @@ class StreamServerTest(unittest.TestCase):
             _socket.close()
 
         # the service socket announces a new connection while any other one
-        # announces data, so the two are routed to different handlers
-        self.assertEqual(on_read_s.call_count, 1)
-        self.assertEqual(on_read.call_count, 1)
+        # announces data, so each of them must reach its own handler and
+        # never the one of the other, which would accept instead of read
+        self.assertEqual(on_read_s.call_args[0][0], self.server.socket)
+        self.assertEqual(on_read.call_args[0][0], _socket)
 
     def test_writes(self):
         if mock == None:
@@ -360,8 +373,8 @@ class StreamServerTest(unittest.TestCase):
         finally:
             _socket.close()
 
-        self.assertEqual(on_write_s.call_count, 1)
-        self.assertEqual(on_write.call_count, 1)
+        self.assertEqual(on_write_s.call_args[0][0], self.server.socket)
+        self.assertEqual(on_write.call_args[0][0], _socket)
 
     def test_errors(self):
         if mock == None:
@@ -375,8 +388,8 @@ class StreamServerTest(unittest.TestCase):
         finally:
             _socket.close()
 
-        self.assertEqual(on_error_s.call_count, 1)
-        self.assertEqual(on_error.call_count, 1)
+        self.assertEqual(on_error_s.call_args[0][0], self.server.socket)
+        self.assertEqual(on_error.call_args[0][0], _socket)
 
     def test_on_write_s(self):
         # the service socket handlers for writing and for errors are

--- a/src/netius/test/base/server.py
+++ b/src/netius/test/base/server.py
@@ -92,10 +92,11 @@ class ServerTest(unittest.TestCase):
         _socket = self.server.socket_udp()
         try:
             # the service socket is a non blocking one, as the reading of it
-            # is driven by the poll instead of by a blocking call
+            # is driven by the poll instead of by a blocking call, note that
+            # the timeout is the way of telling it under the oldest runtimes
             self.assertEqual(_socket.family, socket.AF_INET)
             self.assertEqual(_socket.type, socket.SOCK_DGRAM)
-            self.assertEqual(_socket.getblocking(), False)
+            self.assertEqual(_socket.gettimeout(), 0)
             self.assertNotEqual(
                 _socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR), 0
             )


### PR DESCRIPTION
Step 4 of #90, covering the dispatch and the write queue of `DatagramServer` and `StreamServer`.

`base/server.py` had no test module of its own, so this adds `src/netius/test/base/server.py` following the shape of the neighbouring `client.py`, with a `ServerTest`, a `DatagramServerTest` and a `StreamServerTest` in the declaration order of the module.

The part that matters most here is the routing of the ready sockets. A stream server multiplexes the service socket, which announces a new connection, against every connection socket, which announces data, and telling one from the other is what keeps an accept from being handled as a read. That branch had no coverage at all.

Covered:

- `cleanup` for the releasing of the service socket, including the socket that fails to close and must not break the cleanup
- `info_dict` and `socket_udp`, the latter for the non blocking mode and for the address re-usage and broadcast options
- the construction of the datagram server and the delegation of `reads`, `writes` and `errors` to the handlers
- `serve` for the datagram type that is forced before it reaches the base server
- `ensure_write` for the subscription made from the loop thread and for the one deferred when made from another
- `remove_write`, `enable_read` and `disable_read` including the guards against a duplicated poll registration
- `send` for the queued payload and the counter, for the callback that travels with it, for the deferred flushing and for the socket that is not ready and has to be subscribed instead
- `_flush_write` for the write notification it raises on the service socket
- the routing of `reads`, `writes` and `errors` of the stream server, that tells the service socket from the connection ones
- the exception and expected handlers of both flavours, the connection bound ones closing the connection and the service ones only logging
- `on_upgrade` for the release of the upgrading state and the event it triggers, plus `on_data` and `on_socket_d`

Every one of the targeted methods is now fully covered, 76 uncovered lines down to 0. `base/server.py` goes from 44.0% to 55.0%, 69 lines newly covered, and the global figure from 54.8% to 55.2%.

What is left in the module is the socket driven part, `serve`, `socket_tcp`, `on_read`, `on_write`, `_send`, `on_socket_c`, `on_ssl` and `_ssl_handshake`, which needs a listening socket and is better handled on its own.

No production code is touched, so there is no runtime impact to measure; the diff is a single new file under `src/netius/test`.

Part of #90, which stays open for the remaining phases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no runtime or production behavior changes.
> 
> **Overview**
> Adds **`src/netius/test/base/server.py`**, the first dedicated tests for `base/server.py`, modeled after the neighboring `client.py` suite. **No production code changes.**
> 
> The new module groups **`ServerTest`**, **`DatagramServerTest`**, and **`StreamServerTest`**. Coverage emphasizes **poll dispatch**: stream servers must route the service socket to `on_*_s` handlers (accept/new connection) and other sockets to connection `on_*` handlers so accepts are not treated as ordinary reads. Datagram tests cover **cleanup** (including close failures), **UDP socket setup**, **read/write subscription guards**, and the **`send` / pending queue / `_flush_write`** path (callbacks, delayed flush, write-not-ready subscription, cross-thread deferral).
> 
> Stream tests assert **connection-scoped exception handling** closes with error metadata while **service-socket handlers** only log, plus **`on_upgrade`**, **`on_data`**, and **`on_socket_d`** behavior. Tests use **`unittest.mock`** where needed and skip when mock is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa6c892fad865a4aee5b691a671a5eadb2e129f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->