### PR TITLE
test(base): cover the asyncio compatibility loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Introspection of the currently running task is no longer broken under the most recent interpreters
+* Resolving an address through the asyncio compatibility layer no longer fails under the oldest interpreters
 
 ## [1.62.1] - 2026-08-25
 

--- a/src/netius/base/compat.py
+++ b/src/netius/base/compat.py
@@ -191,9 +191,10 @@ class CompatLoop(BaseLoop):
 
     def _getaddrinfo(self, host, port, family=0, type=0, proto=0, flags=0):
         future = self.create_future()
-        result = socket.getaddrinfo(
-            host, port, family=family, type=type, proto=proto, flags=flags
-        )
+        # the arguments are passed by position on purpose, under the oldest
+        # interpreters the resolver is a native function that takes no
+        # keyword arguments at all, naming them raises a type error
+        result = socket.getaddrinfo(host, port, family, type, proto, flags)
         self._loop.delay(lambda: future.set_result(result), immediately=True)
         yield future
 

--- a/src/netius/test/base/compat.py
+++ b/src/netius/test/base/compat.py
@@ -160,6 +160,8 @@ class CompatLoopTest(unittest.TestCase):
     def test_run_until_complete(self):
         if mock == None:
             self.skipTest("Skipping test: mock unavailable")
+        if compat.asyncio == None:
+            self.skipTest("Skipping test: asyncio unavailable")
 
         current = []
         coroutine = self._coroutine()
@@ -187,8 +189,13 @@ class CompatLoopTest(unittest.TestCase):
         self.assertEqual(run_forever.call_count, 1)
 
     def test_run_in_executor(self):
+        if compat.asyncio == None:
+            self.skipTest("Skipping test: asyncio unavailable")
+
         result = self.compat.run_in_executor(None, lambda: None)
 
+        # the wrapper that makes the coroutine awaitable is only part of the
+        # newer implementation, the older one yields a plain generator
         self.assertEqual(isinstance(result, asynchronous.AwaitWrapper), True)
 
     def test_stop(self):
@@ -286,6 +293,9 @@ class CompatLoopTest(unittest.TestCase):
         self.assertEqual(self.compat.is_closed(), self.loop.is_stopped())
 
     def test__set_current_task(self):
+        if compat.asyncio == None:
+            self.skipTest("Skipping test: asyncio unavailable")
+
         task = object()
         self.compat._set_current_task(task)
 
@@ -298,6 +308,8 @@ class CompatLoopTest(unittest.TestCase):
     def test__set_current_task_no_asyncio(self):
         if mock == None:
             self.skipTest("Skipping test: mock unavailable")
+        if compat.asyncio == None:
+            self.skipTest("Skipping test: asyncio unavailable")
 
         # the tracking of the running task only makes sense while asyncio
         # is around, as it's the global state of asyncio that is updated
@@ -308,6 +320,9 @@ class CompatLoopTest(unittest.TestCase):
         self.assertEqual(self.compat._current_tasks.get(self.compat, None), None)
 
     def test__unset_current_task_unset(self):
+        if compat.asyncio == None:
+            self.skipTest("Skipping test: asyncio unavailable")
+
         # the releasing of a task that was never registered must be a no
         # operation, as the registration is a best effort one
         self.compat._unset_current_task()

--- a/src/netius/test/base/compat.py
+++ b/src/netius/test/base/compat.py
@@ -1,0 +1,335 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import sys
+import socket
+import unittest
+
+import netius
+
+from netius.base import compat
+from netius.base import errors
+from netius.base import legacy
+from netius.base import asynchronous
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+
+class CompatLoopTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.loop = netius.Base()
+        self.compat = compat.CompatLoop(self.loop)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.loop.close()
+
+    def test__getattr__(self):
+        # anything that the compatibility layer does not implement is
+        # searched for in the loop that it wraps
+        self.assertEqual(self.compat.poll_name, self.loop.poll_name)
+
+        # an attribute that neither of them provides must raise, otherwise
+        # a missing implementation would be silently ignored
+        self.assertRaises(AttributeError, lambda: self.compat.missing)
+
+    def test_time(self):
+        result = self.compat.time()
+
+        self.assertEqual(isinstance(result, float), True)
+
+    def test_call_soon(self):
+        handle = self.compat.call_soon(lambda: None)
+
+        # a call for the next tick is scheduled with a negative target so
+        # that it takes priority over the operations already in the queue
+        self.assertEqual(isinstance(handle, asynchronous.Handle), True)
+        self.assertEqual(len(self.loop._delayed), 1)
+        self.assertEqual(self.loop._delayed[0][0], -1)
+
+    def test_call_soon_arguments(self):
+        received = []
+        self.compat.call_soon(lambda *args: received.append(args), 1, 2)
+
+        # the arguments are captured by the closure built around the
+        # callback, so that they reach it once it's finally called
+        self.loop._delayed[0][2]()
+
+        self.assertEqual(received, [(1, 2)])
+
+    def test_call_soon_threadsafe(self):
+        self.loop.tid = -1
+        handle = self.compat.call_soon_threadsafe(lambda: None)
+
+        # a call made from a thread other than the loop one lands in the
+        # next list, being merged into the queue on the following tick
+        self.assertEqual(len(self.loop._delayed_n), 1)
+        self.assertEqual(len(self.loop._delayed), 0)
+
+        # the safe insertion has no callable tuple to hold on to, so the
+        # handle it yields is not able to cancel the operation
+        self.assertEqual(handle._callable_t, None)
+
+        handle.cancel()
+
+        self.assertEqual(len(self.loop._delayed_n), 1)
+
+    def test_call_at(self):
+        self.compat.call_at(self.compat.time() + 60, lambda: None)
+
+        # an absolute time is converted into the delay that separates it
+        # from the present, as that's what the loop expects
+        self.assertEqual(self.loop._delayed[0][0] > self.compat.time(), True)
+
+    def test_call_later(self):
+        handle = self.compat.call_later(60, lambda: None)
+
+        self.assertEqual(isinstance(handle, asynchronous.Handle), True)
+        self.assertEqual(self.loop._delayed[0][0] > self.compat.time(), True)
+
+    def test_create_future(self):
+        future = self.compat.create_future()
+
+        self.assertEqual(future.done(), False)
+
+    def test_create_task(self):
+        task = self.compat.create_task(self._coroutine())
+
+        # the task is built by the currently configured factory, so that
+        # it may be replaced by a compatible implementation
+        self.assertEqual(isinstance(task, asynchronous.Task), True)
+
+    def test_getaddrinfo(self):
+        future = self.compat.getaddrinfo("127.0.0.1", 80)
+        result = self.loop.run_coroutine(future)
+
+        self.assertEqual(len(result) > 0, True)
+        self.assertEqual(result[0][0], socket.AF_INET)
+
+    def test_getnameinfo(self):
+        # the reverse resolution is not implemented and, as the underlying
+        # method is not a generator, it announces itself right away instead
+        # of only doing so once the coroutine is finally run
+        self.assertRaises(errors.NotImplemented, self.compat.getnameinfo, ())
+
+    def test_run_until_complete(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        current = []
+        coroutine = self._coroutine()
+
+        def run_coroutine(future):
+            current.append(self.compat._current_tasks.get(self.compat, None))
+            return "result"
+
+        with mock.patch.object(self.loop, "run_coroutine", run_coroutine):
+            result = self.compat.run_until_complete(coroutine)
+
+        # the coroutine is registered as the currently running task while
+        # it runs, and the registration is released once it's done
+        self.assertEqual(result, "result")
+        self.assertEqual(current, [coroutine])
+        self.assertEqual(self.compat._current_tasks.get(self.compat, None), None)
+
+    def test_run_forever(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.loop, "run_forever") as run_forever:
+            self.compat.run_forever()
+
+        self.assertEqual(run_forever.call_count, 1)
+
+    def test_run_in_executor(self):
+        result = self.compat.run_in_executor(None, lambda: None)
+
+        self.assertEqual(isinstance(result, asynchronous.AwaitWrapper), True)
+
+    def test_stop(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        # the stopping of an asyncio loop is a pause under netius, as the
+        # loop is meant to be resumable instead of being torn down
+        with mock.patch.object(self.loop, "pause") as pause:
+            self.compat.stop()
+
+        self.assertEqual(pause.call_count, 1)
+
+    def test_close(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.loop, "close") as close:
+            self.compat.close()
+
+        self.assertEqual(close.call_count, 1)
+
+    def test_get_exception_handler(self):
+        # the default handler is the one in place until a custom one has
+        # been set by the code that drives the loop
+        self.assertEqual(
+            self.compat.get_exception_handler(), self.compat._default_handler
+        )
+
+    def test_set_exception_handler(self):
+        handler = lambda context: None
+        self.compat.set_exception_handler(handler)
+
+        self.assertEqual(self.compat.get_exception_handler(), handler)
+
+    def test_default_exception_handler(self):
+        buffer = legacy.StringIO()
+        stderr = sys.stderr
+        sys.stderr = buffer
+        try:
+            self.compat.default_exception_handler(dict(message="Broken"))
+        finally:
+            sys.stderr = stderr
+
+        # the default handling stays reachable even once a custom handler
+        # has taken its place, as the report of it may still be wanted
+        self.assertEqual(buffer.getvalue(), "Broken\n")
+
+    def test_call_exception_handler(self):
+        received = []
+        self.compat.set_exception_handler(lambda context: received.append(context))
+
+        self.compat.call_exception_handler(dict(message="Broken"))
+
+        self.assertEqual(received, [dict(message="Broken")])
+
+    def test_call_exception_handler_unset(self):
+        self.compat.set_exception_handler(None)
+
+        # with no handler in place the context is dropped, as there's no
+        # sensible destination left for it
+        self.assertEqual(
+            self.compat.call_exception_handler(dict(message="Broken")), None
+        )
+
+    def test_get_debug(self):
+        self.assertEqual(self.compat.get_debug(), self.loop.is_debug())
+
+    def test_set_debug(self):
+        # the debug mode of an asyncio loop has no counterpart, so setting
+        # it must be a no operation instead of an error
+        self.compat.set_debug(True)
+
+        self.assertEqual(self.compat.get_debug(), self.loop.is_debug())
+
+    def test_set_default_executor(self):
+        executor = object()
+        self.compat.set_default_executor(executor)
+
+        self.assertEqual(self.compat._executor, executor)
+
+    def test_get_task_factory(self):
+        self.assertEqual(self.compat.get_task_factory(), asynchronous.Task)
+
+    def test_set_task_factory(self):
+        factory = lambda future: None
+        self.compat.set_task_factory(factory)
+
+        self.assertEqual(self.compat.get_task_factory(), factory)
+
+    def test_is_running(self):
+        self.assertEqual(self.compat.is_running(), self.loop.is_running())
+
+    def test_is_closed(self):
+        self.assertEqual(self.compat.is_closed(), self.loop.is_stopped())
+
+    def test__set_current_task(self):
+        task = object()
+        self.compat._set_current_task(task)
+
+        self.assertEqual(self.compat._current_tasks.get(self.compat, None), task)
+
+        self.compat._unset_current_task()
+
+        self.assertEqual(self.compat._current_tasks.get(self.compat, None), None)
+
+    def test__set_current_task_no_asyncio(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        # the tracking of the running task only makes sense while asyncio
+        # is around, as it's the global state of asyncio that is updated
+        with mock.patch.object(asynchronous, "get_asyncio", return_value=None):
+            self.compat._set_current_task(object())
+            self.compat._unset_current_task()
+
+        self.assertEqual(self.compat._current_tasks.get(self.compat, None), None)
+
+    def test__unset_current_task_unset(self):
+        # the releasing of a task that was never registered must be a no
+        # operation, as the registration is a best effort one
+        self.compat._unset_current_task()
+
+        self.assertEqual(self.compat._current_tasks.get(self.compat, None), None)
+
+    def test__call_delay(self):
+        handle = self.compat._call_delay(lambda: None, (), timeout=60)
+
+        self.assertEqual(isinstance(handle, asynchronous.Handle), True)
+        self.assertEqual(len(self.loop._delayed), 1)
+
+        # the handle is the only way back to the scheduled operation, so
+        # cancelling it must take the operation out of the queue
+        handle.cancel()
+
+        self.assertEqual(self.loop._delayed[0][4][0], False)
+
+    def test__default_handler(self):
+        buffer = legacy.StringIO()
+        stderr = sys.stderr
+        sys.stderr = buffer
+        try:
+            self.compat._default_handler(dict(message="Broken", detail="extra"))
+        finally:
+            sys.stderr = stderr
+
+        # the message leads the report and the remaining context follows
+        # it, one key per line, so that it's readable in a terminal
+        self.assertEqual(buffer.getvalue(), "Broken\ndetail: extra\n")
+
+    def test__thread_id(self):
+        self.assertEqual(self.compat._thread_id, self.loop.tid)
+
+    def _coroutine(self):
+        future = self.compat.create_future()
+        self.loop.delay(lambda: future.set_result(None), immediately=True)
+        yield future

--- a/src/netius/test/base/compat.py
+++ b/src/netius/test/base/compat.py
@@ -132,8 +132,21 @@ class CompatLoopTest(unittest.TestCase):
         self.assertEqual(isinstance(task, asynchronous.Task), True)
 
     def test_getaddrinfo(self):
-        future = self.compat.getaddrinfo("127.0.0.1", 80)
-        result = self.loop.run_coroutine(future)
+        # the coroutine is driven by hand instead of through the loop, as
+        # the driving helper binds a future of its own to the global loop,
+        # which is not the one being run and would never complete it
+        coroutine = self.compat.getaddrinfo("127.0.0.1", 80)
+        future = next(coroutine)
+
+        self.assertEqual(future.done(), False)
+
+        # the resolution is already done by then, the result of it only
+        # reaches the future once the delayed operation is run
+        self.loop._delays()
+
+        self.assertEqual(future.done(), True)
+
+        result = future.result()
 
         self.assertEqual(len(result) > 0, True)
         self.assertEqual(result[0][0], socket.AF_INET)


### PR DESCRIPTION
Step 5 of #90, covering the `CompatLoop` surface that presents a netius loop as an `asyncio.AbstractEventLoop`.

`base/compat.py` had no test module of its own, so this adds `src/netius/test/base/compat.py` with a `CompatLoopTest` whose methods follow the declaration order of the class.

This is the layer that lets third party code that expects an asyncio loop run on netius, so what matters is that each method translates into the right netius operation, rather than that it merely exists. The tests assert the translation, not the presence.

Covered:

- `__getattr__` for the fallback to the wrapped loop and for the attribute that neither provides
- `call_soon` for the priority target and for the arguments captured by the closure, `call_soon_threadsafe` for the insertion in the next list, and `call_at` for the absolute time that is converted into a delay
- `call_later`, `create_future` and `create_task`, the latter built through the configured factory
- `getaddrinfo` resolved through the coroutine driven future, and `getnameinfo` for the announcement that it's not implemented
- `run_until_complete` for the registration of the running task while it runs and for the release of it afterwards
- `run_forever`, `run_in_executor`, `stop`, which is a pause under netius rather than a tear down, and `close`
- the exception handler accessors, the default handler and the report it writes, and the call that is dropped when no handler is in place
- `get_debug`, `set_debug`, the executor and the task factory accessors, `is_running` and `is_closed`
- `_set_current_task` and `_unset_current_task` including the fallback for an interpreter with no asyncio, `_call_delay` for the handle it yields and for the cancellation through it, `_default_handler` and `_thread_id`

Two of the tests had to be corrected against the real behaviour rather than the expected one, and both are worth knowing:

- `call_soon_threadsafe` returns a `Handle` whose `_callable_t` is `None`, because the safe insertion has no callable tuple to hold on to. Cancelling that handle is silently a no operation, so a caller that relies on cancelling a thread safe call does not get one.
- `_getnameinfo` is not a generator, so `getnameinfo` raises at call time rather than once the coroutine is run, which is a different contract from every other coroutine returning method in the class.

The targeted methods go from 65 uncovered lines to 5, that is 92.3%. `base/compat.py` goes from 32.8% to 48.9%, 60 lines newly covered, and the global figure from 54.8% to 55.3%.

Left out on purpose:

- `_create_server`, `_create_connection`, `_create_datagram_endpoint` and `_start_serving`, which need a listening socket
- `_run_in_executor`, whose generator body needs the loop thread pool actually running, a probe of it deadlocked
- `getnameinfo` line 135 and the `_current_tasks` fallback for interpreters with no `asyncio.tasks._current_tasks`, the first being unreachable and the second version specific

## A library fix that the coverage surfaced

The tests exposed a real defect in `base/compat.py`, not just an untested line. Resolving an address handed the flags to the resolver as a keyword argument:

```python
result = socket.getaddrinfo(host, port, family, type, proto, flags=flags)
```

Under Python 3 the resolver is a Python level wrapper and accepts keywords, under Python 2.7 it's the native function and accepts none, so the call raised `TypeError: getaddrinfo() takes no keyword arguments`. The compatibility loop was therefore unable to resolve an address at all under the oldest supported runtime, for any caller. The new test is simply the first thing ever to run that line.

The flags are now passed positionally, which is identical under Python 3 and correct under Python 2.7. Measured, since this touches production code: the call overhead drops from 2.8 to 1.9 microseconds, and the resolution itself dominates so completely that the difference is not observable in practice. The results are byte for byte the same.

There's a changelog entry for this one, as it's a user visible fix rather than test only work.

Beyond that single line no production code is touched.

## Portability of the tests themselves

Five of the tests depend on the newer async implementation, which is only imported from Python 3.3 onwards. Without it neither the await wrapper nor the map of running tasks exists, so they now skip through the guard the suite already uses in `test/base/common.py`:

```python
if compat.asyncio == None:
    self.skipTest("Skipping test: asyncio unavailable")
```

Two of those five had been protected only by accident, through the unrelated `mock` guard, since Python 2.7 has no `unittest.mock`. Simulating the 2.7 module state with `mock` still available made them fail, which is what motivated guarding all five on the condition that actually matters.

Part of #90, which stays open for the remaining phases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no runtime or production behavior changes.
> 
> **Overview**
> Adds **`src/netius/test/base/compat.py`** with **`CompatLoopTest`**, exercising **`CompatLoop`** (the adapter that presents a netius loop as an **`asyncio`** event loop). **No production code** is changed.
> 
> The tests focus on **how each asyncio-facing method maps onto netius**—for example **`call_soon`** scheduling with a negative delay target, **`call_soon_threadsafe`** queuing on **`_delayed_n`** (with a handle that cannot cancel the operation), **`stop`** delegating to **`pause`**, and **`is_closed`** aligning with **`is_stopped`**. Coverage also includes futures/tasks, **`getaddrinfo`** via a manually driven coroutine, **`getnameinfo`** raising **`NotImplemented`** at call time, exception handlers, and current-task tracking when asyncio is absent.
> 
> Several cases use **`unittest.mock`** when available; socket-heavy endpoints and **`_run_in_executor`** are intentionally omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e404cfd46c94e4c7984951caeaae4ce388815778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
