### PR TITLE
fix(adapters): raise when a value that does not exist is asked for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * An email address without a domain no longer breaks the delivery of a message
 * The type command of the FTP server now switches the transfer mode that it names
 * Counting down to zero with the compatibility range helpers now yields the expected sequence
+* Asking the memory adapter for a value that does not exist now reports a proper error
 
 ## [1.62.1] - 2026-08-25
 

--- a/src/netius/adapters/memory.py
+++ b/src/netius/adapters/memory.py
@@ -60,7 +60,7 @@ class MemoryAdapter(base.BaseAdapter):
 
     def get_file(self, key, mode="rb"):
         if not key in self.map:
-            netius.NetiusError("Key not found")
+            raise netius.NetiusError("Key not found")
         item = self.map[key]
         value = item["value"]
         # the buffer has to be a writable one, as the closing of the file

--- a/src/netius/test/adapters/memory.py
+++ b/src/netius/test/adapters/memory.py
@@ -30,6 +30,7 @@ __license__ = "Apache License, Version 2.0"
 
 import unittest
 
+import netius
 import netius.adapters
 
 
@@ -68,6 +69,12 @@ class MemoryAdapterTest(unittest.TestCase):
             self.assertEqual(file.read(), b"Hello World")
         finally:
             file.close()
+
+    def test_get_file_missing(self):
+        # a key that names no value is reported through the error of the
+        # library instead of leaking the one of the underlying structure
+        self.assertRaises(netius.NetiusError, self.adapter.get_file, "missing")
+        self.assertRaises(netius.NetiusError, self.adapter.get, "missing")
 
     def test_delete(self):
         key = self.adapter.set(b"Hello World", owner="joe")


### PR DESCRIPTION
Takes `adapters/memory.py` from 97.2% to 100%, and the single line that was left uncovered turned out to be a defect rather than a gap in the tests.

## The defect

`get_file` guards against a key that names no value, but the guard never fires:

```python
if not key in self.map:
    netius.NetiusError("Key not found")
```

The error is built and then dropped, so the flow falls through to the lookup on the following line and the caller receives the `KeyError` of the underlying dictionary instead:

```
get_file("missing") -> KeyError: 'missing'
get("missing")      -> KeyError: 'missing'
```

`get` is affected as well, as it is implemented on top of `get_file`. Both now report the error of the library:

```
get_file("missing") -> NetiusError: Key not found
get("missing")      -> NetiusError: Key not found
```

This is the only place in the tree where an error is built without being raised, so it is an isolated slip rather than a pattern.

The only caller that reaches this path is the retrieval of a message by the POP server, and nothing anywhere catches a `KeyError` from it, so surfacing the error of the library is safe and is what the message of the guard always intended.

## Coverage

`adapters/memory.py` reaches 100%, with no statement and no branch left uncovered:

```
Name                            Stmts   Miss Branch BrPart   Cover
src/netius/adapters/memory.py      69      0      2      0  100.0%
```

The remaining gap was closed by `test_get_file_missing`, which asserts the error for both entry points rather than merely walking the line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated one-line fix in the in-memory adapter; missing-key behavior changes from KeyError to NetiusError, which matches the intended guard and is described as safe for known callers.
> 
> **Overview**
> Fixes a bug in **`MemoryAdapter.get_file`** where a missing key constructed **`NetiusError("Key not found")`** without **`raise`**, so callers hit a **`KeyError`** from the internal map instead of the library error. **`get`** is affected because it opens values through **`get_file`**.
> 
> Adds **`test_get_file_missing`** to assert **`NetiusError`** for both **`get_file`** and **`get`**, and records the fix in the unreleased changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e36e68b8203b83917841387f0b2a6619ab615f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->