### PR TITLE
fix(http): bound the body of a message by the length that it announces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A retrieved message whose body has a line starting with a dot is no longer cut short - [#96](https://github.com/hivesolutions/netius/issues/96)
 * A delivered message is now stored as it was written instead of as it was sent - [#96](https://github.com/hivesolutions/netius/issues/96)
 * The POP and SMTP greetings now announce the configured hostname instead of the bound address - [#95](https://github.com/hivesolutions/netius/issues/95)
+* A request whose body is longer than it declares no longer leaves the connection stalled - [#83](https://github.com/hivesolutions/netius/issues/83)
+* Two requests that arrive together are now both handled instead of the second being swallowed - [#83](https://github.com/hivesolutions/netius/issues/83)
 
 ## [1.62.1] - 2026-08-25
 

--- a/src/netius/common/http.py
+++ b/src/netius/common/http.py
@@ -1014,10 +1014,24 @@ class HTTPParser(parser.Parser):
 
     def _parse_normal(self, data):
         # retrieves the size of the data that has just been
-        # received and then in case the store flag is set
-        # stores the data in the proper buffer and increments
-        # the message length counter with the size of the data
+        # received, to be used as the amount of bytes that are
+        # going to be consumed by the current parsing operation
         data_l = len(data)
+
+        # clamps the data to the number of bytes that are still
+        # missing for the message to be complete, so that the ones
+        # that follow the body are left for the message that comes
+        # after it, this is critical both for the pipelining of
+        # requests and for the detection of a framing violation
+        if not self.content_l == -1:
+            remaining = self.content_l - self.message_l
+            if data_l > remaining:
+                data = data[:remaining]
+                data_l = remaining
+
+        # in case the store flag is set stores the data in the
+        # proper buffer and then increments the message length
+        # counter with the size of the data that was consumed
         if self.store:
             self._store_data(data)
         self.message_l += data_l

--- a/src/netius/test/common/http.py
+++ b/src/netius/test/common/http.py
@@ -542,6 +542,84 @@ class HTTPParserTest(unittest.TestCase):
         parser = self._parse(b"GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n")
         self.assertEqual(parser.keep_alive, True)
 
+    def test_overshoot(self):
+        parser = netius.common.HTTPParser(self, type=netius.common.REQUEST, store=True)
+        seen = []
+        partials = []
+        parser.bind("on_data", lambda: seen.append(parser.get_message()))
+        parser.bind("on_partial", lambda data: partials.append(data))
+        try:
+            # a body that carries more octets than the length announces is
+            # consumed up to the boundary alone, so that the message is able
+            # to complete and the surplus is left for the one that follows
+            parser.parse(
+                b"POST /x HTTP/1.1\r\nHost: localhost\r\n"
+                b"Content-Length: 4\r\n\r\nAAAAAAAAAAAA"
+            )
+
+            self.assertEqual(seen, [b"AAAA"])
+
+            # the surplus never reaches the handler of the partial data, which
+            # would otherwise be given more payload than the message declares
+            self.assertEqual(partials, [b"AAAA"])
+        finally:
+            parser.clear()
+
+    def test_overshoot_invalid(self):
+        # the surplus of the body is parsed as the message that follows it, so
+        # a sequence that is not a valid request line is rejected instead of
+        # being absorbed as payload of the message that precedes it
+        self._assert_error(
+            b"POST /x HTTP/1.1\r\nHost: localhost\r\n"
+            b"Content-Length: 4\r\n\r\nAAAAAAAAAAAA\r\n\r\n"
+        )
+
+    def test_partial_body(self):
+        parser = netius.common.HTTPParser(self, type=netius.common.REQUEST, store=True)
+        seen = []
+        parser.bind("on_data", lambda: seen.append(parser.get_message()))
+        try:
+            # the length that is still missing is tracked across the reads, so
+            # a body that arrives split over several of them only completes
+            # once the boundary that was announced is reached
+            parser.parse(
+                b"POST /x HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\n"
+            )
+            self.assertEqual(seen, [])
+
+            parser.parse(b"AA")
+            self.assertEqual(seen, [])
+
+            parser.parse(b"AABBBB")
+
+            # the surplus of the final read is left for the message that comes
+            # after it, rather than being taken as payload of this one
+            self.assertEqual(seen, [b"AAAA"])
+        finally:
+            parser.clear()
+
+    def test_pipelining(self):
+        parser = netius.common.HTTPParser(self, type=netius.common.REQUEST, store=True)
+        seen = []
+        parser.bind(
+            "on_data", lambda: seen.append((parser.path_s, parser.get_message()))
+        )
+        try:
+            # two requests that share the same segment are parsed as two
+            # messages, the body of the first one being bounded by the length
+            # that it announces instead of absorbing the one that follows
+            parser.parse(
+                b"POST /a HTTP/1.1\r\nHost: localhost\r\n"
+                b"Content-Length: 4\r\n\r\nAAAA"
+                b"POST /b HTTP/1.1\r\nHost: localhost\r\n"
+                b"Content-Length: 4\r\n\r\nBBBB"
+            )
+
+            self.assertEqual(seen, [("/a", b"AAAA"), ("/b", b"BBBB")])
+            self.assertEqual(parser.state, netius.common.http.FINISH_STATE)
+        finally:
+            parser.clear()
+
     def test_chunked_malformed(self):
         # the size of a chunk must be a sequence of hexadecimal digits, the
         # signed and the prefixed values must be rejected as they would be


### PR DESCRIPTION
Closes #83.

## Validation of the report

The issue was filed by an external reporter and marked as a static analysis finding that had not been executed, so it was reproduced before anything was written. Driving the parser over the exact payload of the report:

```
POST /x HTTP/1.1  Host: h  Content-Length: 4    body AAAAAAAAAAAA

master        messages completed 0, no error raised, the segment is absorbed
this branch   messages completed 1, with a body of AAAA
```

The report is accurate: `_parse_normal` counted every octet handed to it, the completion was gated on an exact equality that an overshoot can never satisfy again, and the parser stayed in the message state with the surplus consumed as payload.

## A second defect with the same cause

The same absence of a bound breaks a case that is entirely legal, and that the repository already supports elsewhere. Two requests that share a single segment are pipelining, not a violation, and `len(data) > remaining` describes them just as well as it describes an overshoot:

```
POST /a ... Content-Length: 4  AAAA POST /b ... Content-Length: 4  BBBB

master        messages completed 0
this branch   messages completed 2, with bodies of AAAA and BBBB
```

Before this branch the second request was swallowed as the body of the first whenever the two arrived together, the parse loop of `parse` never reaching the finish state that it clears for the next message. This was not reported and is the reason the shape of the fix matters.

## Shape of the fix

The issue offers two directions, either bounding the body at the boundary or raising a `ParserError` when the segment carries more than the length announces. The second one was not taken: raising on `len(data) > remaining` would reject the pipelining above, which is valid HTTP and which this branch is what repairs.

So `_parse_normal` now clamps the data to `self.content_l - self.message_l` before storing it, counting it and triggering the partial handler, and returns only what it consumed. The surplus stays in the buffer of `parse`, which reaches the finish state, clears and parses it as the message that follows.

That single change covers both of the directions of the issue, because the surplus of a malformed body is parsed as a new message and fails on its own:

```
POST /x ... Content-Length: 4    body AAAAAAAAAAAA\r\n\r\n   ->   ParserError, code 400
```

A surplus that is not yet a complete line is held in the buffer instead, which is the only behaviour available given that a body followed by more octets is byte for byte identical to a pipelined request until the line that follows it is complete.

The path taken by a message with no announced length, where `content_l` is `-1`, is left untouched, so a response that is terminated by the closing of the connection still reads to the end.

## Tests

Added to `src/netius/test/common/http.py`, next to `test_framing` which covers the neighbouring framing rules, using the `bind` idiom that `test_interim_response` already uses to observe more than one message. All four fail against the code before the fix:

| Test | What it pins |
| --- | --- |
| `test_overshoot` | the body completes at the boundary and the partial handler sees only what was declared |
| `test_overshoot_invalid` | the surplus is rejected when it does not start a valid message |
| `test_partial_body` | the length still missing is tracked across the reads |
| `test_pipelining` | two requests sharing a segment are parsed as two messages |

Coverage of the new and changed code:

| File | Statements in the change | Covered |
| --- | --- | --- |
| `src/netius/common/http.py` | 5 | 100.0% |

No partial branches are introduced by the change.

## Validation

Suite status: 1178 passed and 7 skipped on Linux with Python 3.14, 1177 passed and 8 skipped on macOS. `black --check` is clean over 338 files and `mypy.stubtest` reports no issues in 132 modules. Both changed files were also compiled under Python 2.7, as that interpreter is still part of the matrix.

Beyond the unit tests the parser was driven over the payload of the report, a pipelined pair, a body split across several reads, a body arriving one octet at a time and a response with no announced length, the last two confirming that the paths which were already correct are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core HTTP request/response framing in a shared parser used by client and server; behavior shifts for oversized bodies and pipelining but is covered by new tests and leaves unknown-length responses untouched.
> 
> **Overview**
> Fixes **HTTP/1.x body parsing** when `Content-Length` is set: `_parse_normal` now **clamps** each read to the bytes still needed for the body instead of treating the whole chunk as payload.
> 
> That stops connections from **stalling** when the peer sends more body octets than declared, and fixes **pipelining** so a second request in the same TCP segment is parsed as its own message instead of being swallowed by the first body. Extra bytes after a complete body stay in the `parse` buffer; invalid surplus is parsed as the next message and rejected. Messages with **no** announced length (`content_l == -1`) are unchanged.
> 
> **CHANGELOG** entries and unit tests cover overshoot, split reads, invalid surplus, and back-to-back requests on one segment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3306ffd9c083216f98d31137aa0a224c5cbc5639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->