### PR TITLE
refactor(http2): remove the unreachable paths of the frame parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* The HTTP/2 frame parser no longer carries checks that no message is able to reach - [#100](https://github.com/hivesolutions/netius/issues/100)
 
 ### Fixed
 

--- a/src/netius/common/http2.py
+++ b/src/netius/common/http2.py
@@ -475,10 +475,6 @@ class HTTP2Parser(parser.Parser):
             raise netius.ParserError(
                 "Stream cannot depend on current stream", error_code=PROTOCOL_ERROR
             )
-        if stream and dependency == stream.identifier:
-            raise netius.ParserError(
-                "Stream cannot depend on itself", error_code=PROTOCOL_ERROR
-            )
 
     def assert_rst_stream(self, stream):
         if self.stream == 0x00:
@@ -786,25 +782,19 @@ class HTTP2Parser(parser.Parser):
         self.trigger("on_settings", settings, ack)
 
     def _parse_push_promise(self, data):
-        data_l = len(data)
-
-        end_headers = True if self.flags & 0x04 else False
         padded = self.flags & 0x08
 
         index = 0
-        padded_l = 0
 
         if padded:
-            (padded_l,) = struct.unpack("!B", data[index : index + 1])
             index += 1
 
         (promised_stream,) = struct.unpack("!I", data[index : index + 4])
 
-        fragment = data[index : data_l - padded_l]
-
+        # a promise may only travel from a server towards a client, so the
+        # one that reaches this parser is always refused, note that no event
+        # is triggered for it as the assertion never returns
         self.assert_push_promise(promised_stream)
-
-        self.trigger("on_push_promise", promised_stream, fragment, end_headers)
 
     def _parse_ping(self, data):
         ack = self.flags & 0x01

--- a/src/netius/test/common/http2.py
+++ b/src/netius/test/common/http2.py
@@ -222,8 +222,8 @@ class HTTP2ParserTest(unittest.TestCase):
 
             parser.assert_priority(self._make_stream(parser, identifier=1), 3)
 
-            # a stream that depends on itself would form a cycle, either
-            # named through the frame or through the stream itself
+            # a stream that depends on itself would form a cycle, the
+            # dependency of the frame naming the very stream that it reorders
             self.assertRaises(
                 netius.ParserError,
                 parser.assert_priority,
@@ -962,6 +962,8 @@ class HTTP2ParserTest(unittest.TestCase):
     def test_parse_push_promise(self):
         connection = self._make_connection()
         parser = connection.parser
+        seen = []
+        parser.bind("on_push_promise", lambda *args: seen.append(args))
         try:
             # a promise may only travel from a server towards a client, so
             # one that arrives at the server is always a protocol error
@@ -973,6 +975,10 @@ class HTTP2ParserTest(unittest.TestCase):
             )
 
             self.assertRaises(netius.ParserError, parser.parse, frame)
+
+            # the refusal happens before any event, so a promise never
+            # reaches a listener that is bound to the parser
+            self.assertEqual(seen, [])
         finally:
             parser.clear(force=True)
 


### PR DESCRIPTION
Closes #100.

## The decision the issue leaves open

The issue asks whether the parser is meant to stay server only before the promise is touched. It is, and the evidence is unanimous:

* there is no HTTP/2 client in the package, `src/netius/clients` carries none and `HTTP2Parser` is reached only from `src/netius/servers/http2.py`
* `assert_push_promise` refuses unconditionally, with a message that names the server
* the stub already declares it as `NoReturn`

So the trailing trigger and the values that only it consumed are removed, and the refusal is left as the whole of the method. A client side parser is a feature rather than a cleanup, and the fragment slice that the issue notes is left alone with it, since fixing a slice on a path that cannot run would only give a future reader something else to trust.

## The priority guard

The third guard is provably dead rather than merely untested. `_parse_priority` resolves the stream with `_get_stream(self.stream)`, `_get_stream` returns `self.streams.get(stream)`, and `_set_stream` keys that map by `stream.identifier`. So `_get_stream(x).identifier` is always `x`, which makes `dependency == stream.identifier` the very same comparison as the `dependency == self.stream` immediately above it.

Only the third guard is dropped. The `stream` argument becomes unused by the method, which is already the case for `assert_rst_stream` right below it, so the signature is left as it stands and no caller has to change.

## Behaviour

Nothing observable changes for a server, which is what the issue asks for. The whole of `src/netius/test/common/http2.py`, 52 tests including the ones that this branch adds to, passes unchanged against the code before the change as well as after it. That is the expected shape of the evidence for the removal of code that cannot run, there is no behaviour to regress.

## Tests

`test_parse_push_promise` now also binds a listener and asserts that it is never called, which pins the refusal together with the absence of the event that used to be built after it. The comment of `test_assert_priority` named the guard that is being dropped and now names the one that does the work.

Coverage of the change is degenerate to report, as the only lines that the diff adds are the comment that explains why no event is triggered. The two methods that it touches are covered in full instead:

| Method | Statements | Covered |
| --- | --- | --- |
| `assert_priority` | 4 | 100.0% |
| `_parse_push_promise` | 7 | 100.0% |
| **total** | **11** | **100.0%** |

## Validation

Suite status: 1178 passed and 7 skipped on Linux with Python 3.14, 1177 passed and 8 skipped on macOS. `black --check` is clean over 338 files and `mypy.stubtest` reports no issues in 132 modules, the stub needing no change as neither signature moves. Both changed files were also compiled under Python 2.7, as that interpreter is still part of the matrix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal parser cleanup with tests locking prior refusal semantics; no change to live server HTTP/2 handling beyond removing unreachable branches.
> 
> **Overview**
> Removes dead code from the **server-only** `HTTP2Parser` so parsing stops at checks that can actually run.
> 
> In **`assert_priority`**, drops the redundant “stream depends on itself via `stream.identifier`” guard because it duplicates the existing `dependency == self.stream` check when streams are keyed by identifier.
> 
> In **`_parse_push_promise`**, strips header-fragment handling and the `on_push_promise` trigger; incoming PUSH_PROMISE frames still fail immediately via `assert_push_promise` (server parsers never accept them). Tests now assert that refusal happens before any listener runs.
> 
> **CHANGELOG** records this under *Changed*. No intended behavior change for HTTP/2 servers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eded83edda034e39024eef47401401ffe2404158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->