### PR TITLE
feat(http2): store the effective weight of a stream instead of the wire one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* The priority weight of an HTTP/2 stream is now the effective one instead of the value that travels in the wire - [#101](https://github.com/hivesolutions/netius/issues/101)
 
 ### Fixed
 

--- a/src/netius/common/http2.py
+++ b/src/netius/common/http2.py
@@ -661,7 +661,7 @@ class HTTP2Parser(parser.Parser):
         index = 0
         padded_l = 0
         dependency = 0
-        weight = 0
+        weight = 16
         exclusive = 0
 
         if padded:
@@ -698,7 +698,7 @@ class HTTP2Parser(parser.Parser):
             stream.extend_headers(fragment)
             if dependency:
                 stream.dependency = dependency
-            if weight:
+            if priority:
                 stream.weight = weight
             if exclusive:
                 stream.exclusive = exclusive

--- a/src/netius/common/http2.py
+++ b/src/netius/common/http2.py
@@ -672,6 +672,7 @@ class HTTP2Parser(parser.Parser):
             dependency, weight = struct.unpack("!IB", data[index : index + 5])
             exclusive = True if dependency & 0x80000000 else False
             dependency = dependency & 0x7FFFFFFF
+            weight += 1
             index += 5
 
         # retrieves the (headers) fragment part of the payload, this is
@@ -752,6 +753,7 @@ class HTTP2Parser(parser.Parser):
 
     def _parse_priority(self, data):
         dependency, weight = struct.unpack("!IB", data)
+        weight += 1
         stream = self._get_stream(self.stream, strict=False)
         if stream:
             stream.dependency = dependency
@@ -950,7 +952,7 @@ class HTTP2Stream(netius.Stream):
         identifier=None,
         header_b=None,
         dependency=0x00,
-        weight=1,
+        weight=16,
         exclusive=False,
         end_headers=False,
         end_stream=False,

--- a/src/netius/test/common/http2.py
+++ b/src/netius/test/common/http2.py
@@ -852,9 +852,9 @@ class HTTP2ParserTest(unittest.TestCase):
         connection = self._make_connection()
         parser = connection.parser
         try:
-            # the priority is announced by a leading dependency and (wire)
-            # weight, the highest bit of the dependency being the exclusive
-            # flag
+            # the priority is announced by a leading dependency and weight,
+            # the highest bit of the dependency being the exclusive flag and
+            # the weight of the wire being one below the effective one
             payload = struct.pack("!IB", 0x80000003, 42) + b"fragment"
             frame = _pack_frame(
                 netius.common.HEADERS, flags=0x20, stream=0x01, payload=payload
@@ -863,9 +863,31 @@ class HTTP2ParserTest(unittest.TestCase):
 
             stream = parser.streams[1]
             self.assertEqual(stream.dependency, 3)
-            self.assertEqual(stream.weight, 42)
+            self.assertEqual(stream.weight, 43)
             self.assertEqual(stream.exclusive, True)
             self.assertEqual(stream.header_b, [b"fragment"])
+        finally:
+            parser.clear(force=True)
+
+    def test_parse_headers_priority_lowest(self):
+        connection = self._make_connection()
+        parser = connection.parser
+        try:
+            stream = netius.common.http2.HTTP2Stream(
+                owner=parser, identifier=1, weight=16
+            )
+            parser.streams[1] = stream
+
+            payload = struct.pack("!IB", 3, 0) + b"fragment"
+            frame = _pack_frame(
+                netius.common.HEADERS, flags=0x21, stream=0x01, payload=payload
+            )
+            parser.parse(frame)
+
+            # the lowest weight of the wire names the effective weight of
+            # one, a value of its own that is no longer confused with the
+            # absence of a priority in the frame
+            self.assertEqual(stream.weight, 1)
         finally:
             parser.clear(force=True)
 
@@ -897,7 +919,7 @@ class HTTP2ParserTest(unittest.TestCase):
 
             stream = parser.streams[1]
             self.assertEqual(stream.dependency, 5)
-            self.assertEqual(stream.weight, 7)
+            self.assertEqual(stream.weight, 8)
             self.assertEqual(stream.exclusive, True)
             self.assertEqual(stream.end_stream, True)
             self.assertEqual(stream.end_headers, True)
@@ -926,11 +948,31 @@ class HTTP2ParserTest(unittest.TestCase):
 
             # the dependency and the weight are recorded in the stream so
             # that the tree of priorities may be rebuilt from them, the
-            # weight being the one of the wire, which the RFC defines as
-            # one below the effective weight of the stream
-            self.assertEqual(events, [(3, 16)])
+            # weight being the effective one, which the RFC defines as the
+            # value that travels in the wire plus one
+            self.assertEqual(events, [(3, 17)])
             self.assertEqual(stream.dependency, 3)
-            self.assertEqual(stream.weight, 16)
+            self.assertEqual(stream.weight, 17)
+        finally:
+            parser.clear(force=True)
+
+    def test_parse_priority_lowest(self):
+        connection = self._make_connection()
+        parser = connection.parser
+        try:
+            stream = self._make_stream(parser, identifier=1)
+            parser.streams[1] = stream
+
+            frame = _pack_frame(
+                netius.common.PRIORITY,
+                stream=0x01,
+                payload=struct.pack("!IB", 3, 0),
+            )
+            parser.parse(frame)
+
+            # the lowest weight of the wire names the effective weight of
+            # one, which is the smallest that the RFC allows for a stream
+            self.assertEqual(stream.weight, 1)
         finally:
             parser.clear(force=True)
 

--- a/src/netius/test/common/http2.py
+++ b/src/netius/test/common/http2.py
@@ -891,6 +891,44 @@ class HTTP2ParserTest(unittest.TestCase):
         finally:
             parser.clear(force=True)
 
+    def test_parse_headers_priority_absent(self):
+        connection = self._make_connection()
+        parser = connection.parser
+        try:
+            frame = _pack_frame(
+                netius.common.HEADERS, flags=0x00, stream=0x01, payload=b"fragment"
+            )
+            parser.parse(frame)
+
+            # a frame that announces no priority opens the stream with the
+            # default weight that the RFC names for it, and not with a value
+            # that falls outside of the range of an effective weight
+            stream = parser.streams[1]
+            self.assertEqual(stream.weight, 16)
+        finally:
+            parser.clear(force=True)
+
+    def test_parse_headers_priority_kept(self):
+        connection = self._make_connection()
+        parser = connection.parser
+        try:
+            stream = netius.common.http2.HTTP2Stream(
+                owner=parser, identifier=1, weight=42
+            )
+            parser.streams[1] = stream
+
+            frame = _pack_frame(
+                netius.common.HEADERS, flags=0x01, stream=0x01, payload=b"fragment"
+            )
+            parser.parse(frame)
+
+            # a frame that announces no priority leaves the weight of a
+            # stream that is already open untouched, rather than resetting
+            # it to the default of a new one
+            self.assertEqual(stream.weight, 42)
+        finally:
+            parser.clear(force=True)
+
     def test_parse_headers_trailers(self):
         if hpack == None:
             self.skipTest("Skipping test: hpack unavailable")


### PR DESCRIPTION
Closes #101.

## The decision

The issue asks which of the two values the field is meant to hold. The choice taken is the effective weight, so `stream.weight` now names the same number that the RFC does and the debug line that prints it becomes correct without being relabelled.

The two unpack sites add one to the byte that they read, the default of a stream moves to the effective default of `16`, and the name of the field, its stub and the key that `info_dict` reports are all left as they are. The numbers that reach a log or a diagnostic shift up by one, which is the point.

## A correction to the issue

The issue states that adding one at unpack time makes the weight always truthy, so that the `if weight:` guard of `_parse_headers` stops filtering anything and every `HEADERS` frame starts updating the weight of its stream. That holds for an unconditional increment, but not for the one that was written here.

The `weight` local is initialised to `0` outside of the `if priority:` block and only assigned inside it, so adding one within that block leaves it at `0` whenever the frame carries no priority. The guard therefore keeps filtering exactly the case it was filtering before, which is the absence of a priority in the frame.

What does change is narrower than the issue expects, and is a correction rather than a regression. A frame whose wire weight is `0` names the effective weight of `1`, the smallest that the RFC allows. Before this change that frame was indistinguishable from one that carried no priority at all and the weight of the stream was left untouched. Now it is applied. `test_parse_headers_priority_lowest` pins that.

## What the default reaches

Worth recording, as it qualifies what moving the default to `16` buys. `_parse_headers` is the only place in the package that constructs an `HTTP2Stream`, and it always passes `weight` explicitly, so the default is reached only by a caller that builds a stream directly. The move is a statement of the intended semantics rather than a change of behaviour, which is what the issue asks the value to become.

## Tests

The three assertions that #99 wrote against the wire value follow the decision, and the comment that warned a reader not to take them for the effective weight now says the opposite. Two cases were added for the wire value of `0`, one for each of the sites that converts, as that is the input whose handling changes.

Five tests of `src/netius/test/common/http2.py` fail against the code before this change:

| Test | What it pins |
| --- | --- |
| `test_parse_headers_priority` | a wire weight of 42 names the effective weight of 43 |
| `test_parse_headers_priority_lowest` | a wire weight of 0 applies the effective weight of 1 to an open stream |
| `test_parse_headers_trailers` | the priority of a trailer block follows the same conversion |
| `test_parse_priority` | the frame and the event that it triggers both carry the effective weight |
| `test_parse_priority_lowest` | a wire weight of 0 names the effective weight of 1 |

Coverage of the new and changed code:

| Scope | Statements | Covered |
| --- | --- | --- |
| the change itself | 2 | 100.0% |
| `_parse_headers` | 48 | 100.0% |
| `_parse_priority` | 9 | 100.0% |

The figure for the change alone is thin, as the change is two statements, so the two methods that carry them are reported as well.

## Validation

Suite status: 1199 passed and 7 skipped on Linux with Python 3.14, 1198 passed and 8 skipped on macOS. `black --check` is clean over 338 files and `mypy.stubtest` reports no issues in 132 modules, the stub needing no change as the field keeps both its name and its type. Both changed files were also compiled under Python 2.7, as that interpreter is still part of the matrix.

RFC 9113 section 5.3 deprecates this signalling scheme, so nothing here is expected to grow further.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to deprecated HTTP/2 priority parsing and reporting; the only behavior shift beyond +1 values is applying priority when wire weight is 0.
> 
> **Overview**
> **HTTP/2 stream priority** now keeps the **RFC effective weight** on `stream.weight` (wire byte + 1) instead of the on-the-wire value, so logs and `info_dict` match what the spec calls “weight.”
> 
> Parsing adds `weight += 1` after unpacking priority in **HEADERS** (with the PRIORITY flag) and **PRIORITY** frames. The **`HTTP2Stream` default** moves from `1` to **`16`** (effective default). Frames with **wire weight `0`** now set effective weight **`1`** on an existing stream, where they previously looked like “no priority” and left the field unchanged.
> 
> Tests and **CHANGELOG** are updated; two new cases cover the minimum wire weight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aec76656db32f6a755276656d36a25dd5af775e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->