### PR TITLE
test(common,ws,smtp): cover the codecs, the websocket stack and the relay

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           pip install coverage
           coverage combine
-          coverage report --sort=-miss --fail-under=62
+          coverage report --sort=-miss --fail-under=63
       - name: Publish coverage summary
         run: |
           echo "## Coverage" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           pip install coverage
           coverage combine
-          coverage report --sort=-miss --fail-under=63
+          coverage report --sort=-miss --fail-under=64
       - name: Publish coverage summary
         run: |
           echo "## Coverage" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           pip install coverage
           coverage combine
-          coverage report --sort=-miss
+          coverage report --sort=-miss --fail-under=62
       - name: Publish coverage summary
         run: |
           echo "## Coverage" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * A GeoIP database that is downloaded on demand is now used instead of being discarded
 * A POP command with no argument no longer reports its message as a byte sequence
+* Two WebSocket frames that arrive together are now both handled instead of the second being swallowed
 
 ## [1.63.0] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * A GeoIP database that is downloaded on demand is now used instead of being discarded
 * A POP command with no argument no longer reports its message as a byte sequence
+* A file opened through the asynchronous file pool now honours the mode that was asked for
+* A file written through the asynchronous file pool now reaches the disk instead of failing
+* A stored password that carries a separator no longer breaks the authentication
+* An asynchronous file operation that is not a known one is now refused instead of being ignored
 * Two WebSocket frames that arrive together are now both handled instead of the second being swallowed
 
 ## [1.63.0] - 2026-08-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * The priority weight of an HTTP/2 stream is now the effective one instead of the value that travels in the wire - [#101](https://github.com/hivesolutions/netius/issues/101)
+* The coverage job now fails when the package falls below the floor that it has reached - [#102](https://github.com/hivesolutions/netius/issues/102)
 
 ### Fixed
 
-*
+* A GeoIP database that is downloaded on demand is now used instead of being discarded
+* A POP command with no argument no longer reports its message as a byte sequence
 
 ## [1.63.0] - 2026-08-29
 

--- a/src/netius/auth/base.py
+++ b/src/netius/auth/base.py
@@ -104,13 +104,13 @@ class Auth(object):
     @classmethod
     def unpack(cls, password):
         count = password.count(":")
+        plain = password
         if count == 2:
             type, salt, digest = password.split(":")
         elif count == 1:
             type, digest = password.split(":")
             salt = None
         else:
-            plain = password
             type = "plain"
             salt = None
             digest = None

--- a/src/netius/common/geo.py
+++ b/src/netius/common/geo.py
@@ -130,7 +130,7 @@ class GeoResolver(object):
         if not download:
             return None
         cls._download_db(path=path)
-        exists = not os.path.exists(path)
+        exists = os.path.exists(path)
         if not exists:
             return None
         return path

--- a/src/netius/common/pop.py
+++ b/src/netius/common/pop.py
@@ -119,7 +119,7 @@ class POPParser(parser.Parser):
         # value is added to the sequence of values for compatibility
         values = self.line_s.split(" ", 1)
         if not len(values) > 1:
-            values.append(b"")
+            values.append("")
 
         # unpacks the set of values that have just been parsed into the code
         # and the message items as expected by the pop specification

--- a/src/netius/common/ws.py
+++ b/src/netius/common/ws.py
@@ -148,11 +148,16 @@ def decode_ws(data):
     if raw_size < length:
         raise netius.DataError("Not enough data")
 
-    # in case the frame data is not masked the complete set of contents
-    # may be returned immediately to the caller as there's no issue with
-    # avoiding the unmasking operation (as the data is not masked)
+    # in case the frame data is not masked the payload may be returned
+    # immediately to the caller as there's no issue with avoiding the
+    # unmasking operation, note that the payload is bounded by the length
+    # that the frame announces so that the bytes of the frame that follows
+    # it are left pending instead of being taken as part of this one
     if not has_mask:
-        return data[index_mask_f:], b""
+        return (
+            data[index_mask_f : index_mask_f + length],
+            data[index_mask_f + length :],
+        )
 
     # retrieves the mask part of the data that are going to be
     # used in the decoding part of the process

--- a/src/netius/pool/file.py
+++ b/src/netius/pool/file.py
@@ -56,7 +56,7 @@ class FileThread(common.Thread):
     def execute(self, work):
         type = work[0]
         if not type == FILE_WORK:
-            netius.NotImplemented("Cannot execute type '%d'" % type)
+            raise netius.NotImplemented("Cannot execute type '%d'" % type)
 
         try:
             self._execute(work)
@@ -64,7 +64,7 @@ class FileThread(common.Thread):
             self.owner.push_event((ERROR_ACTION, exception, work[-1]))
 
     def open(self, path, mode, data):
-        file = open(path)
+        file = open(path, mode)
         self.owner.push_event((OPEN_ACTION, file, data))
 
     def close(self, file, data):
@@ -88,9 +88,9 @@ class FileThread(common.Thread):
         elif action == READ_ACTION:
             self.read(*work[2:])
         elif action == WRITE_ACTION:
-            self.read(*work[2:])
+            self.write(*work[2:])
         else:
-            netius.NotImplemented("Undefined file action '%d'" % action)
+            raise netius.NotImplemented("Undefined file action '%d'" % action)
 
 
 class FilePool(common.EventPool):

--- a/src/netius/test/auth/base.py
+++ b/src/netius/test/auth/base.py
@@ -1,0 +1,231 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import netius
+import netius.auth
+
+
+class AuthTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base = tempfile.mkdtemp()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        shutil.rmtree(self.base)
+
+    def test_auth(self):
+        # the base class provides no authentication of its own, so the
+        # class level method must refuse any attempt made against it
+        self.assertRaises(netius.NotImplemented, netius.auth.Auth.auth)
+
+    def test_meta(self):
+        self.assertEqual(netius.auth.Auth.meta(), {})
+
+    def test_auth_assert(self):
+        self.assertEqual(netius.auth.AllowAuth.auth_assert(), None)
+
+        # an authentication that does not succeed is turned into a
+        # security error, instead of a simple invalid return value
+        self.assertRaises(netius.SecurityError, netius.auth.DenyAuth.auth_assert)
+        self.assertRaises(netius.NotImplemented, netius.auth.Auth.auth_assert)
+
+    def test_verify(self):
+        encoded = netius.auth.Auth.generate("secret")
+
+        self.assertEqual(netius.auth.Auth.verify(encoded, "secret"), True)
+        self.assertEqual(netius.auth.Auth.verify(encoded, "secret_"), False)
+
+        # a value that carries no salt is verified against the digest of
+        # the password alone, as there's nothing to append to it
+        encoded = netius.auth.Auth.generate("secret", salt=None)
+
+        self.assertEqual(netius.auth.Auth.verify(encoded, "secret"), True)
+        self.assertEqual(netius.auth.Auth.verify(encoded, "secret_"), False)
+
+        # the type of the digest is normalized before the hash is built,
+        # so that an upper cased one is still a valid value
+        self.assertEqual(netius.auth.Auth.verify(encoded.upper(), "secret"), False)
+        self.assertEqual(
+            netius.auth.Auth.verify("SHA256:" + encoded.split(":")[1], "secret"), True
+        )
+
+        # the plain type is the only one for which the two values are
+        # compared literally, with no digest being computed for them
+        self.assertEqual(netius.auth.Auth.verify("secret", "secret"), True)
+        self.assertEqual(netius.auth.Auth.verify("secret", "secret_"), False)
+
+        # the salt takes part in the digest, so the password on its own
+        # does not verify against a value that was salted
+        encoded = netius.auth.Auth.generate("secret", salt="extra")
+
+        self.assertEqual(netius.auth.Auth.verify(encoded, "secret"), True)
+        self.assertEqual(
+            netius.auth.Auth.verify(encoded, "secretextra"),
+            False,
+        )
+
+    def test_generate(self):
+        encoded = netius.auth.Auth.generate("secret")
+        type, salt, digest = encoded.split(":")
+
+        self.assertEqual(type, "sha256")
+        self.assertEqual(salt, "6e6574697573")
+        self.assertEqual(len(digest), 64)
+
+        # the plain type gives the password back unchanged, as no digest
+        # is ever computed for that kind of value
+        self.assertEqual(netius.auth.Auth.generate("secret", type="plain"), "secret")
+
+        # a value generated without salt carries only the type and the
+        # digest, there being no salt to place in between them
+        encoded = netius.auth.Auth.generate("secret", salt=None)
+
+        self.assertEqual(encoded.count(":"), 1)
+        self.assertEqual(encoded.startswith("sha256:"), True)
+
+        # the type drives the hash that is used, so a different one
+        # produces a digest of a different length
+        encoded = netius.auth.Auth.generate("secret", type="md5", salt=None)
+
+        self.assertEqual(len(encoded.split(":")[1]), 32)
+
+        # the salt is part of what is hashed, meaning that the same
+        # password salted differently gives a different digest
+        first = netius.auth.Auth.generate("secret", salt="first")
+        second = netius.auth.Auth.generate("secret", salt="second")
+
+        self.assertNotEqual(first.split(":")[2], second.split(":")[2])
+
+    def test_unpack(self):
+        self.assertEqual(
+            netius.auth.Auth.unpack("secret"), ("plain", None, None, "secret")
+        )
+        self.assertEqual(
+            netius.auth.Auth.unpack("sha256:digest"), ("sha256", None, "digest", None)
+        )
+        self.assertEqual(
+            netius.auth.Auth.unpack("sha256:6e6574697573:digest"),
+            ("sha256", "netius", "digest", None),
+        )
+
+        # a plain password that carries the separator is still unpacked
+        # as a plain one, instead of raising an unexpected exception
+        self.assertEqual(
+            netius.auth.Auth.unpack("plain:secret"),
+            ("plain", None, "secret", "plain:secret"),
+        )
+
+        # the value that is generated must be the exact reverse of the
+        # one that is unpacked, closing the round trip of the two
+        encoded = netius.auth.Auth.generate("secret")
+        type, salt, digest, plain = netius.auth.Auth.unpack(encoded)
+
+        self.assertEqual(type, "sha256")
+        self.assertEqual(salt, "netius")
+        self.assertEqual(plain, None)
+        self.assertEqual(encoded.endswith(digest), True)
+
+    def test_get_file(self):
+        path = self._store("simple.txt", b"hello world")
+
+        self.assertEqual(netius.auth.Auth.get_file(path), b"hello world")
+
+        # the encoding turns the byte based contents into a string one,
+        # decoded according to the encoding that was requested
+        self.assertEqual(
+            netius.auth.Auth.get_file(path, encoding="utf-8"), "hello world"
+        )
+
+        # the contents are only remembered when the cache flag is set, so
+        # that a change to the file is still visible for the other reads
+        self.assertEqual(netius.auth.Auth.get_file(path, cache=True), b"hello world")
+
+        self._store("simple.txt", b"hello mundo")
+
+        self.assertEqual(netius.auth.Auth.get_file(path), b"hello mundo")
+        self.assertEqual(netius.auth.Auth.get_file(path, cache=True), b"hello world")
+
+        # a file that is not there raises, as there are no contents to
+        # be given back for such a path
+        self.assertRaises(
+            IOError, netius.auth.Auth.get_file, os.path.join(self.base, "missing.txt")
+        )
+
+    def test_is_simple(self):
+        self.assertEqual(netius.auth.Auth.is_simple(), False)
+        self.assertEqual(netius.auth.AllowAuth.is_simple(), True)
+
+    def test_auth_i(self):
+        auth = netius.auth.AllowAuth()
+
+        self.assertEqual(auth.auth_i(), True)
+
+        # the constructor binds the instance method as the authentication
+        # one, so that the instance shadows the class level method
+        self.assertEqual(auth.auth(), True)
+
+        auth = netius.auth.DenyAuth()
+
+        self.assertEqual(auth.auth_i(), False)
+
+        auth = netius.auth.Auth()
+
+        self.assertRaises(netius.NotImplemented, auth.auth_i)
+
+    def test_auth_assert_i(self):
+        auth = netius.auth.AllowAuth()
+
+        self.assertEqual(auth.auth_assert_i(), None)
+        self.assertEqual(auth.auth_assert(), None)
+
+        auth = netius.auth.DenyAuth()
+
+        self.assertRaises(netius.SecurityError, auth.auth_assert_i)
+        self.assertRaises(netius.SecurityError, auth.auth_assert)
+
+    def test_is_simple_i(self):
+        self.assertEqual(netius.auth.Auth().is_simple_i(), False)
+        self.assertEqual(netius.auth.AllowAuth().is_simple_i(), True)
+
+    def _store(self, name, contents):
+        path = os.path.join(self.base, name)
+        file = open(path, "wb")
+        try:
+            file.write(contents)
+        finally:
+            file.close()
+        return path

--- a/src/netius/test/auth/passwd.py
+++ b/src/netius/test/auth/passwd.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import netius.auth
+
+
+class PasswdAuthTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base = tempfile.mkdtemp()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        shutil.rmtree(self.base)
+
+    def test_auth(self):
+        path = self._store("simple", "root:%s\n" % netius.auth.Auth.generate("root"))
+
+        self.assertEqual(netius.auth.PasswdAuth.auth("root", "root", path=path), True)
+        self.assertEqual(netius.auth.PasswdAuth.auth("root", "root_", path=path), False)
+
+        # a username that is not part of the file is refused instead of
+        # raising, as the lookup gives no password for it
+        self.assertEqual(netius.auth.PasswdAuth.auth("dummy", "root", path=path), False)
+
+        # the password of the file may also be a plain one, in which case
+        # the two values are compared literally
+        path = self._store("plain", "root:root\n")
+
+        self.assertEqual(netius.auth.PasswdAuth.auth("root", "root", path=path), True)
+        self.assertEqual(netius.auth.PasswdAuth.auth("root", "root_", path=path), False)
+
+    def test_get_passwd(self):
+        path = self._store("simple", "root:first\n\nextra:second\n")
+
+        passwd = netius.auth.PasswdAuth.get_passwd(path, cache=False)
+
+        # the empty line of the file is skipped, only the two lines that
+        # carry a username taking part in the result
+        self.assertEqual(passwd, dict(root="first", extra="second"))
+
+        # only the first separator of the line splits it, so that a
+        # password that carries one is not truncated by the parsing
+        path = self._store("encoded", "root:sha256:6e6574697573:digest\n")
+
+        passwd = netius.auth.PasswdAuth.get_passwd(path, cache=False)
+
+        self.assertEqual(passwd["root"], "sha256:6e6574697573:digest")
+
+        # the result is remembered when the cache flag is set, so a change
+        # to the file is only visible for an uncached retrieval
+        path = self._store("cached", "root:first\n")
+
+        self.assertEqual(netius.auth.PasswdAuth.get_passwd(path)["root"], "first")
+
+        self._store("cached", "root:second\n")
+
+        self.assertEqual(netius.auth.PasswdAuth.get_passwd(path)["root"], "first")
+        self.assertEqual(
+            netius.auth.PasswdAuth.get_passwd(path, cache=False)["root"], "second"
+        )
+
+        # a file that is not there raises, as there's no set of passwords
+        # to be built from such a path
+        self.assertRaises(
+            IOError,
+            netius.auth.PasswdAuth.get_passwd,
+            os.path.join(self.base, "missing"),
+        )
+
+    def test_auth_i(self):
+        path = self._store("simple", "root:%s\n" % netius.auth.Auth.generate("root"))
+
+        auth = netius.auth.PasswdAuth(path=path)
+
+        # the path of the instance is the one used for the lookup, so
+        # that no explicit path has to be given for the authentication
+        self.assertEqual(auth.auth_i("root", "root"), True)
+        self.assertEqual(auth.auth_i("root", "root_"), False)
+        self.assertEqual(auth.auth("root", "root"), True)
+
+    def _store(self, name, contents):
+        path = os.path.join(self.base, name)
+        file = open(path, "wb")
+        try:
+            file.write(contents.encode("utf-8"))
+        finally:
+            file.close()
+        return path

--- a/src/netius/test/clients/ws.py
+++ b/src/netius/test/clients/ws.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import base64
+import unittest
+
+import netius
+import netius.clients
+
+from netius.clients import ws
+
+KEY = "dGhlIHNhbXBsZSBub25jZQ=="
+""" The key of the example of the RFC 6455, whose accept key is
+the one that the specification uses to demonstrate the handshake """
+
+ACCEPT_KEY = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+""" The accept key that the RFC 6455 names as the answer to the
+key above, used as the vector of the validation """
+
+RESPONSE = (
+    b"HTTP/1.1 101 Switching Protocols\r\n"
+    b"Upgrade: websocket\r\n"
+    b"Connection: Upgrade\r\n"
+    b"Sec-WebSocket-Accept: " + netius.legacy.bytes(ACCEPT_KEY) + b"\r\n\r\n"
+)
+""" The answer of a server to the upgrade request, carrying the
+accept key that the specification names for the key above """
+
+
+class WSProtocolTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.protocol = ws.WSProtocol()
+        self.protocol.key = KEY
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.protocol.close()
+
+    def test__key(self):
+        result = ws.WSProtocol._key()
+
+        # the key is the base 64 of sixteen bytes, which is what the
+        # specification asks a client to offer in the handshake
+        self.assertEqual(len(base64.b64decode(result)), 16)
+        self.assertNotEqual(result, ws.WSProtocol._key())
+
+    def test_add_buffer(self):
+        self.protocol.add_buffer(b"first")
+        self.protocol.add_buffer(b"second")
+
+        # the buffer joins the reads that it gathers and is emptied by the
+        # reading of it, so that the data is only handled once
+        self.assertEqual(self.protocol.get_buffer(), b"firstsecond")
+        self.assertEqual(self.protocol.get_buffer(), b"")
+
+    def test_get_buffer_keep(self):
+        self.protocol.add_buffer(b"first")
+
+        # the reading may keep the buffer in place, which the handshake
+        # needs so that the data is still there for a second attempt
+        self.assertEqual(self.protocol.get_buffer(delete=False), b"first")
+        self.assertEqual(self.protocol.get_buffer(), b"first")
+
+    def test_do_handshake(self):
+        self.protocol.add_buffer(RESPONSE)
+
+        self.protocol.do_handshake()
+
+        # the status line and the headers of the answer are gathered, the
+        # names of the headers being lowered so that they may be resolved
+        self.assertEqual(self.protocol.handshake, True)
+        self.assertEqual(self.protocol.version, "HTTP/1.1")
+        self.assertEqual(self.protocol.code, "101")
+        self.assertEqual(self.protocol.headers["upgrade"], "websocket")
+
+    def test_do_handshake_remaining(self):
+        frame = netius.common.encode_ws(b"Hello World", mask=False)
+        self.protocol.add_buffer(RESPONSE + frame)
+
+        self.protocol.do_handshake()
+
+        # the bytes that follow the headers belong to the frames that come
+        # after the handshake, so they are kept for the parsing that follows
+        self.assertEqual(self.protocol.get_buffer(), frame)
+
+    def test_do_handshake_partial(self):
+        self.protocol.add_buffer(RESPONSE[:30])
+
+        # an answer whose headers have not been completely received yet
+        # cannot be handled, which is reported so that it may be retried
+        self.assertRaises(netius.DataError, self.protocol.do_handshake)
+
+    def test_do_handshake_repeated(self):
+        self.protocol.add_buffer(RESPONSE)
+        self.protocol.do_handshake()
+
+        # the handshake of a protocol happens once alone, so a second
+        # attempt at it is refused instead of resetting the state
+        self.assertRaises(netius.NetiusError, self.protocol.do_handshake)
+
+    def test_validate_key(self):
+        self.protocol.add_buffer(RESPONSE)
+        self.protocol.do_handshake()
+
+        # the accept key of the answer is the one that the specification
+        # names for the key that was offered, so it validates
+        self.assertEqual(self.protocol.validate_key(), None)
+
+    def test_validate_key_missing(self):
+        self.protocol.add_buffer(
+            b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\n"
+        )
+        self.protocol.do_handshake()
+
+        # an answer that names no accept key proves nothing, so it is
+        # refused instead of being taken for a valid handshake
+        self.assertRaises(netius.NetiusError, self.protocol.validate_key)
+
+    def test_validate_key_invalid(self):
+        self.protocol.add_buffer(
+            b"HTTP/1.1 101 Switching Protocols\r\n"
+            b"Sec-WebSocket-Accept: aW52YWxpZCBhY2NlcHQga2V5\r\n\r\n"
+        )
+        self.protocol.do_handshake()
+
+        # an accept key that does not follow from the key that was offered
+        # is refused, as it does not prove that the peer read the request
+        self.assertRaises(netius.SecurityError, self.protocol.validate_key)

--- a/src/netius/test/common/dhcp.py
+++ b/src/netius/test/common/dhcp.py
@@ -1,0 +1,125 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius
+import netius.common
+
+
+class AddressPoolTest(unittest.TestCase):
+
+    def test_init(self):
+        pool = netius.common.AddressPool("192.168.0.1", "192.168.0.3")
+
+        # the pool is populated with the complete range that it spans, the
+        # bounds of it included, and none of the addresses is yet valid
+        self.assertEqual(pool.exists("192.168.0.1"), True)
+        self.assertEqual(pool.exists("192.168.0.3"), True)
+        self.assertEqual(pool.exists("192.168.0.4"), False)
+        self.assertEqual(pool.is_valid("192.168.0.1"), False)
+
+    def test_get_next(self):
+        self.assertEqual(
+            netius.common.AddressPool.get_next("192.168.0.1"), "192.168.0.2"
+        )
+
+        # the last octet rolls over into the one that precedes it, so that
+        # the sequence walks the complete range of a network
+        self.assertEqual(
+            netius.common.AddressPool.get_next("192.168.0.255"), "192.168.1.0"
+        )
+        self.assertEqual(
+            netius.common.AddressPool.get_next("192.168.255.255"), "192.169.0.0"
+        )
+
+    def test_peek(self):
+        pool = netius.common.AddressPool("192.168.0.1", "192.168.0.2")
+
+        # the peeking of an address does not reserve it, so the very same
+        # address is offered again by a second peek
+        self.assertEqual(pool.peek(), "192.168.0.1")
+        self.assertEqual(pool.peek(), "192.168.0.2")
+
+    def test_peek_exhausted(self):
+        pool = netius.common.AddressPool("192.168.0.1", "192.168.0.1")
+        pool.reserve(owner="joe")
+
+        # a pool whose only address has been reserved has nothing left to
+        # offer, which is reported as an error instead of an empty value
+        self.assertRaises(netius.NetiusError, pool.peek)
+
+    def test_peek_touched(self):
+        pool = netius.common.AddressPool("192.168.0.1", "192.168.0.1")
+        addr = pool.reserve(owner="joe", lease=1)
+        pool.touch(addr, lease=3600)
+
+        # the touching of an address leaves the entry of the previous lease
+        # behind, which the peeking skips instead of taking it for a free
+        # address and handing the very same one out twice
+        self.assertRaises(netius.NetiusError, pool.peek)
+
+    def test_reserve(self):
+        pool = netius.common.AddressPool("192.168.0.1", "192.168.0.2")
+
+        addr = pool.reserve(owner="joe")
+
+        # the reserved address becomes a valid one, bound to the owner that
+        # asked for it and resolvable from that owner alone
+        self.assertEqual(addr, "192.168.0.1")
+        self.assertEqual(pool.is_valid(addr), True)
+        self.assertEqual(pool.is_owner("joe", addr), True)
+        self.assertEqual(pool.is_owner("mary", addr), False)
+        self.assertEqual(pool.assigned("joe"), addr)
+        self.assertEqual(pool.assigned("mary"), None)
+
+    def test_is_owner_invalid(self):
+        pool = netius.common.AddressPool("192.168.0.1", "192.168.0.2")
+
+        # an address whose lease was never taken belongs to nobody, so the
+        # ownership of it is denied even to the owner that asks for it
+        self.assertEqual(pool.is_owner("joe", "192.168.0.1"), False)
+
+    def test_touch(self):
+        pool = netius.common.AddressPool("192.168.0.1", "192.168.0.2")
+        addr = pool.reserve(owner="joe", lease=1)
+
+        pool.touch(addr, lease=3600)
+
+        # the touching of a valid address extends the lease that it carries,
+        # keeping it out of the addresses that may be offered
+        self.assertEqual(pool.is_valid(addr), True)
+
+    def test_touch_invalid(self):
+        pool = netius.common.AddressPool("192.168.0.1", "192.168.0.2")
+
+        # an address whose lease has never been taken cannot be extended, as
+        # there is no lease for it to prolong
+        self.assertRaises(netius.NetiusError, pool.touch, "192.168.0.1")

--- a/src/netius/test/common/ftp.py
+++ b/src/netius/test/common/ftp.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius.common
+
+
+class FTPParserTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.lines = []
+        self.parser = netius.common.FTPParser(self)
+        self.parser.bind("on_line", self._on_line)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.parser.destroy()
+
+    def test_parse(self):
+        count = self.parser.parse(b"220 ready\r\n")
+
+        # the complete line is consumed and reported with the code and the
+        # message split apart, a space naming the end of a response
+        self.assertEqual(count, 11)
+        self.assertEqual(self.lines, [("220", "ready", True)])
+
+    def test_parse_multiple(self):
+        self.parser.parse(b"220 first\r\n221 second\r\n")
+
+        # a payload that carries more than one line reports each of them,
+        # in the order in which they arrive
+        self.assertEqual(self.lines, [("220", "first", True), ("221", "second", True)])
+
+    def test_parse_partial(self):
+        count = self.parser.parse(b"220 re")
+
+        # a line that has not been terminated yet is buffered instead of
+        # being reported, and none of its bytes are counted as parsed
+        self.assertEqual(count, 0)
+        self.assertEqual(self.lines, [])
+
+        self.parser.parse(b"ady\r\n")
+
+        # the remainder of the line completes it, the two reads being
+        # joined into the single line that they form
+        self.assertEqual(self.lines, [("220", "ready", True)])
+
+    def test_parse_line_continuation(self):
+        self.parser.parse(b"220-first\r\n220 last\r\n")
+
+        # a dash in the place of the space marks a line that is continued,
+        # so only the one that carries the space ends the response
+        self.assertEqual(self.lines, [("220", "first", False), ("220", "last", True)])
+
+    def test_parse_line_bare(self):
+        self.parser.parse(b"220\r\n")
+
+        # a line that carries no message at all is a final one, as it holds
+        # no dash that would continue the response
+        self.assertEqual(self.lines, [("220", "", True)])
+
+    def _on_line(self, code, message, is_final=True):
+        self.lines.append((code, message, is_final))

--- a/src/netius/test/common/geo.py
+++ b/src/netius/test/common/geo.py
@@ -1,0 +1,224 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import os
+import gzip
+import shutil
+import tempfile
+import unittest
+
+import netius.common
+
+from netius.common import geo
+
+
+class GeoResolverTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base = tempfile.mkdtemp()
+        self.downloads = []
+        self.original = geo.GeoResolver.__dict__["_download_db"]
+        self.original_try = geo.GeoResolver.__dict__["_try_db"]
+        self.db = geo.GeoResolver._db
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        geo.GeoResolver._download_db = self.original
+        geo.GeoResolver._try_db = self.original_try
+        geo.GeoResolver._db = self.db
+        shutil.rmtree(self.base)
+
+    def test_resolve(self):
+        geo.GeoResolver._db = dict(a=dict(city=dict(names=dict(en="Lisbon"))))
+
+        # the resolution is delegated to the database, the simplified mode
+        # flattening the names of the entry into a single one
+        result = geo.GeoResolver.resolve("a")
+        self.assertEqual(result["city"]["name"], "Lisbon")
+
+    def test_resolve_no_db(self):
+        geo.GeoResolver._db = None
+        self._patch_download()
+
+        # with no database available at all the resolution reports no value
+        # rather than raising, as the feature is an optional one
+        self.assertEqual(geo.GeoResolver.resolve("a"), None)
+
+    def test_resolve_full(self):
+        geo.GeoResolver._db = dict(a=dict(city=dict(names=dict(en="Lisbon"))))
+
+        # the complete result is served when the simplification is not asked
+        # for, so that a caller may read the values that it would drop
+        result = geo.GeoResolver.resolve("a", simplified=False)
+        self.assertEqual(result["city"]["names"]["en"], "Lisbon")
+
+    def test__get_db_cached(self):
+        geo.GeoResolver._db = "database"
+
+        # a database that has already been opened is served from the cache,
+        # so that the search for the file of it happens only once
+        self.assertEqual(geo.GeoResolver._get_db(), "database")
+
+    def test__try_all(self):
+        tried = self._patch_try(found=False)
+
+        self.assertEqual(geo.GeoResolver._try_all(), None)
+
+        # the prefixes are walked in the order that they are declared and the
+        # download is only attempted once none of them holds the database
+        expected = [
+            (prefix + geo.GeoResolver.DB_NAME, False)
+            for prefix in geo.GeoResolver.PREFIXES
+        ]
+        expected.append((geo.GeoResolver.DB_NAME, True))
+        self.assertEqual(tried, expected)
+
+    def test__try_all_found(self):
+        tried = self._patch_try(found=True)
+
+        # the first prefix that holds the database ends the search, so that
+        # no further prefix is looked at and no download is attempted
+        self.assertEqual(geo.GeoResolver._try_all(), geo.GeoResolver.DB_NAME)
+        self.assertEqual(len(tried), 1)
+
+    def test__simplify(self):
+        result = geo.GeoResolver._simplify(
+            dict(
+                city=dict(names=dict(en="Lisbon", pt="Lisboa")),
+                postal=dict(code="1000"),
+            )
+        )
+
+        # only the names that the model considers valid are kept, and the
+        # localized names of each of them collapse into a single one
+        self.assertEqual(result["city"]["name"], "Lisbon")
+        self.assertEqual("names" in result["city"], False)
+        self.assertEqual("postal" in result, False)
+
+    def test__simplify_empty(self):
+        # a result that carries no value is returned as it is, so that the
+        # absence of a resolution is not confused with an empty one
+        self.assertEqual(geo.GeoResolver._simplify(None), None)
+
+    def test__try_db(self):
+        path = os.path.join(self.base, "db.mmdb")
+        self._store(path, b"database")
+
+        # a database that is already in place is used as it is, with no
+        # download being attempted for it
+        self._patch_download()
+        self.assertEqual(geo.GeoResolver._try_db(path=path), path)
+        self.assertEqual(self.downloads, [])
+
+    def test__try_db_missing(self):
+        path = os.path.join(self.base, "missing.mmdb")
+        self._patch_download()
+
+        # a database that is absent is not downloaded unless the download is
+        # asked for, the absence being reported instead
+        self.assertEqual(geo.GeoResolver._try_db(path=path), None)
+        self.assertEqual(self.downloads, [])
+
+    def test__try_db_download(self):
+        path = os.path.join(self.base, "downloaded.mmdb")
+        self._patch_download(contents=b"database")
+
+        # a download that produces the file names the path of it, which the
+        # caller needs in order to open the database that was fetched
+        self.assertEqual(geo.GeoResolver._try_db(path=path, download=True), path)
+        self.assertEqual(self.downloads, [path])
+
+    def test__try_db_download_failed(self):
+        path = os.path.join(self.base, "failed.mmdb")
+        self._patch_download()
+
+        # a download that produces no file reports the absence, instead of
+        # naming a path that nothing is able to open
+        self.assertEqual(geo.GeoResolver._try_db(path=path, download=True), None)
+        self.assertEqual(self.downloads, [path])
+
+    def test__store_db(self):
+        path = os.path.join(self.base, "stored.mmdb")
+        contents = self._compress(b"database")
+
+        result = geo.GeoResolver._store_db(contents, path=path)
+
+        # the payload is decompressed into the target path and the archive
+        # that carried it is removed, leaving only the database behind
+        self.assertEqual(result, path)
+        self.assertEqual(self._read(path), b"database")
+        self.assertEqual(os.path.exists(path + ".gz"), False)
+
+    def _patch_download(self, contents=None):
+        # replaces the download by one that records the path that it was
+        # asked for, writing the provided contents when there are any
+        def _download_db(cls, path=geo.GeoResolver.DB_NAME):
+            self.downloads.append(path)
+            if contents == None:
+                return
+            self._store(path, contents)
+
+        geo.GeoResolver._download_db = classmethod(_download_db)
+
+    def _patch_try(self, found=False):
+        # replaces the lookup of a database by one that records the paths
+        # that it was asked for, reporting them as found or as absent
+        tried = []
+
+        def _try_db(cls, path=geo.GeoResolver.DB_NAME, download=False):
+            tried.append((path, download))
+            return path if found else None
+
+        geo.GeoResolver._try_db = classmethod(_try_db)
+        return tried
+
+    def _compress(self, contents):
+        path = os.path.join(self.base, "source.gz")
+        file = gzip.open(path, "wb")
+        try:
+            file.write(contents)
+        finally:
+            file.close()
+        return self._read(path)
+
+    def _store(self, path, contents):
+        file = open(path, "wb")
+        try:
+            file.write(contents)
+        finally:
+            file.close()
+
+    def _read(self, path):
+        file = open(path, "rb")
+        try:
+            return file.read()
+        finally:
+            file.close()

--- a/src/netius/test/common/geo.py
+++ b/src/netius/test/common/geo.py
@@ -66,7 +66,7 @@ class GeoResolverTest(unittest.TestCase):
 
     def test_resolve_no_db(self):
         geo.GeoResolver._db = None
-        self._patch_download()
+        self._patch_try(found=False)
 
         # with no database available at all the resolution reports no value
         # rather than raising, as the feature is an optional one

--- a/src/netius/test/common/pop.py
+++ b/src/netius/test/common/pop.py
@@ -76,11 +76,13 @@ class POPParserTest(unittest.TestCase):
 
     def test_parse_line_bare(self):
         self.parser.parse(b"NOOP\r\n")
+        self.parser.parse(b"+OK ready\r\n")
 
         # a line that carries no argument reports an empty message, of the
-        # same string type as the one of a line that carries one
-        self.assertEqual(self.lines, [("NOOP", "")])
-        self.assertEqual(netius.legacy.is_bytes(self.lines[0][1]), False)
+        # same string type as the one that a line carrying an argument
+        # reports, instead of a byte sequence of its own
+        self.assertEqual(self.lines[0], ("NOOP", ""))
+        self.assertEqual(type(self.lines[0][1]), type(self.lines[1][1]))
 
     def _on_line(self, code, message):
         self.lines.append((code, message))

--- a/src/netius/test/common/pop.py
+++ b/src/netius/test/common/pop.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius.common
+
+
+class POPParserTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.lines = []
+        self.parser = netius.common.POPParser(self)
+        self.parser.bind("on_line", self._on_line)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.parser.destroy()
+
+    def test_parse(self):
+        count = self.parser.parse(b"+OK ready\r\n")
+
+        # the complete line is consumed and reported with the code and the
+        # message that follows it split apart
+        self.assertEqual(count, 11)
+        self.assertEqual(self.lines, [("+OK", "ready")])
+
+    def test_parse_multiple(self):
+        self.parser.parse(b"+OK first\r\n-ERR second\r\n")
+
+        # a payload that carries more than one line reports each of them,
+        # in the order in which they arrive
+        self.assertEqual(self.lines, [("+OK", "first"), ("-ERR", "second")])
+
+    def test_parse_partial(self):
+        count = self.parser.parse(b"+OK re")
+
+        # a line that has not been terminated yet is buffered instead of
+        # being reported, and none of its bytes are counted as parsed
+        self.assertEqual(count, 0)
+        self.assertEqual(self.lines, [])
+
+        self.parser.parse(b"ady\r\n")
+
+        # the remainder of the line completes it, the two reads being
+        # joined into the single line that they form
+        self.assertEqual(self.lines, [("+OK", "ready")])
+
+    def test_parse_line_bare(self):
+        self.parser.parse(b"NOOP\r\n")
+
+        # a line that carries no argument reports an empty message, of the
+        # same string type as the one of a line that carries one
+        self.assertEqual(self.lines, [("NOOP", "")])
+        self.assertEqual(netius.legacy.is_bytes(self.lines[0][1]), False)
+
+    def _on_line(self, code, message):
+        self.lines.append((code, message))

--- a/src/netius/test/common/smtp.py
+++ b/src/netius/test/common/smtp.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius.common
+
+
+class SMTPParserTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.lines = []
+        self.parser = netius.common.SMTPParser(self)
+        self.parser.bind("on_line", self._on_line)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.parser.destroy()
+
+    def test_parse(self):
+        count = self.parser.parse(b"250 ready\r\n")
+
+        # the complete line is consumed and reported with the code and the
+        # message split apart, a space naming the end of a response
+        self.assertEqual(count, 11)
+        self.assertEqual(self.lines, [("250", "ready", True)])
+
+    def test_parse_multiple(self):
+        self.parser.parse(b"250 first\r\n354 second\r\n")
+
+        # a payload that carries more than one line reports each of them,
+        # in the order in which they arrive
+        self.assertEqual(self.lines, [("250", "first", True), ("354", "second", True)])
+
+    def test_parse_partial(self):
+        count = self.parser.parse(b"250 re")
+
+        # a line that has not been terminated yet is buffered instead of
+        # being reported, and none of its bytes are counted as parsed
+        self.assertEqual(count, 0)
+        self.assertEqual(self.lines, [])
+
+        self.parser.parse(b"ady\r\n")
+
+        # the remainder of the line completes it, the two reads being
+        # joined into the single line that they form
+        self.assertEqual(self.lines, [("250", "ready", True)])
+
+    def test_parse_line_continuation(self):
+        self.parser.parse(b"250-first\r\n250 last\r\n")
+
+        # a dash in the place of the space marks a line that is continued,
+        # so only the one that carries the space ends the response
+        self.assertEqual(self.lines, [("250", "first", False), ("250", "last", True)])
+
+    def test_parse_line_bare(self):
+        self.parser.parse(b"250\r\n")
+
+        # a line that carries no message at all is a final one, as it holds
+        # no dash that would continue the response
+        self.assertEqual(self.lines, [("250", "", True)])
+
+    def _on_line(self, code, message, is_final=True):
+        self.lines.append((code, message, is_final))

--- a/src/netius/test/common/structures.py
+++ b/src/netius/test/common/structures.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius.common
+
+from netius.common import structures
+
+
+class PriorityDictTest(unittest.TestCase):
+
+    def test_init(self):
+        result = structures.PriorityDict(dict(a=2, b=1))
+
+        # the heap is built from the values that the map is created with,
+        # so the smallest of them is available right away
+        self.assertEqual(result.smallest(), "b")
+
+    def test_setitem(self):
+        result = structures.PriorityDict()
+        result["a"] = 2
+        result["b"] = 1
+
+        self.assertEqual(result["a"], 2)
+        self.assertEqual(result.smallest(), "b")
+
+        # a value that is lowered takes the place of the previous smallest
+        # one, the stale entry of the heap being skipped when it is read
+        result["a"] = 0
+        self.assertEqual(result.smallest(), "a")
+
+    def test_setitem_rebuild(self):
+        result = structures.PriorityDict(dict(a=1))
+        result["a"] = 2
+        result["a"] = 3
+
+        # the heap is rebuilt once the entries that it holds outnumber the
+        # keys of the map, so that it does not grow without bound as the
+        # values of a key are replaced over and over
+        self.assertEqual(len(result._heap), 1)
+        self.assertEqual(result.smallest(), "a")
+
+    def test_smallest(self):
+        result = structures.PriorityDict(dict(a=3, b=1, c=2))
+
+        # the reading of the smallest key does not consume it, so the very
+        # same key is returned by a second reading of the map
+        self.assertEqual(result.smallest(), "b")
+        self.assertEqual(result.smallest(), "b")
+        self.assertEqual(len(result), 3)
+
+    def test_smallest_stale(self):
+        result = structures.PriorityDict(dict(a=0, b=1))
+        result["a"] = 5
+
+        # the previous value of the key is left behind in the heap, so the
+        # reading of the smallest key skips it instead of naming a key whose
+        # value is no longer the one that the entry carries
+        self.assertEqual(result.smallest(), "b")
+
+    def test_pop_smallest(self):
+        result = structures.PriorityDict(dict(a=3, b=1, c=2))
+
+        # the popping of the smallest key removes it from the map, so the
+        # keys come out in the order of their values
+        self.assertEqual(result.pop_smallest(), "b")
+        self.assertEqual(result.pop_smallest(), "c")
+        self.assertEqual(result.pop_smallest(), "a")
+        self.assertEqual(len(result), 0)
+
+    def test_pop_smallest_stale(self):
+        result = structures.PriorityDict(dict(a=0, b=1))
+        result["a"] = 5
+
+        # the stale entry is discarded by the popping as well, so that the
+        # key that is removed is the one that really holds the lowest value
+        self.assertEqual(result.pop_smallest(), "b")
+        self.assertEqual(result.smallest(), "a")
+
+    def test_setdefault(self):
+        result = structures.PriorityDict(dict(a=1))
+
+        # a key that is already in the map keeps the value that it carries,
+        # while a new one is set with the value that is provided for it
+        self.assertEqual(result.setdefault("a", 9), 1)
+        self.assertEqual(result.setdefault("b", 0), 0)
+        self.assertEqual(result.smallest(), "b")
+
+    def test_update(self):
+        result = structures.PriorityDict(dict(a=3))
+        result.update(dict(b=1))
+
+        # the heap is rebuilt by the update, so a value that arrives through
+        # it takes part in the resolution of the smallest key
+        self.assertEqual(result.smallest(), "b")
+
+    def test_sorted_iter(self):
+        result = structures.PriorityDict(dict(a=3, b=1, c=2))
+
+        # the iteration consumes the map by the order of the values, leaving
+        # it empty once the sequence has been exhausted
+        self.assertEqual(list(result.sorted_iter()), ["b", "c", "a"])
+        self.assertEqual(len(result), 0)
+
+
+class FileIteratorTest(unittest.TestCase):
+
+    def test_file_iterator(self):
+        file = netius.legacy.BytesIO(b"hello world")
+        iterator = structures.file_iterator(file, chunk_size=5)
+
+        # the size of the file is the first value of the sequence, the ones
+        # that follow it being the chunks of the contents
+        self.assertEqual(next(iterator), 11)
+        self.assertEqual(list(iterator), [b"hello", b" worl", b"d"])
+
+    def test_file_iterator_empty(self):
+        file = netius.legacy.BytesIO(b"")
+        iterator = structures.file_iterator(file)
+
+        # an empty file announces the size of zero and yields no chunk of
+        # contents at all, instead of an empty one
+        self.assertEqual(next(iterator), 0)
+        self.assertEqual(list(iterator), [])

--- a/src/netius/test/common/tls.py
+++ b/src/netius/test/common/tls.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import netius
+import netius.common
+
+from netius.common import tls
+
+
+class TLSContextDictTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base = tempfile.mkdtemp()
+        self.owner = self._make_owner()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        shutil.rmtree(self.base)
+
+    def test_init(self):
+        self._store("first.com")
+
+        contexts = tls.LetsEncryptDict(
+            self.owner, ["first.com", "second.com"], letse_path=self.base
+        )
+
+        # only the domain whose certificate and key are both in place gets a
+        # context, the one that is missing them being skipped
+        self.assertEqual("first.com" in contexts, True)
+        self.assertEqual("second.com" in contexts, False)
+
+        # every domain that was asked for is remembered, so that a reload is
+        # able to pick up the ones whose files appear later on
+        self.assertEqual(contexts.domains, set(["first.com", "second.com"]))
+
+    def test_reload(self):
+        self._store("first.com")
+        contexts = tls.LetsEncryptDict(self.owner, ["first.com"], letse_path=self.base)
+        context = contexts["first.com"][0]
+
+        # a reload that finds no change at all rebuilds nothing, so the very
+        # same context keeps being served for the domain
+        self.assertEqual(contexts.reload(), False)
+        self.assertEqual(contexts["first.com"][0], context)
+
+    def test_reload_changed(self):
+        self._store("first.com")
+        contexts = tls.LetsEncryptDict(self.owner, ["first.com"], letse_path=self.base)
+        context = contexts["first.com"][0]
+
+        # the certificate is renewed, which the modification time of it is
+        # what signals to the reload
+        self._store("first.com", mtime=contexts.mtimes["first.com"] + 10)
+
+        self.assertEqual(contexts.reload(), True)
+        self.assertNotEqual(contexts["first.com"][0], context)
+
+    def test_reload_added(self):
+        contexts = tls.LetsEncryptDict(self.owner, ["first.com"], letse_path=self.base)
+
+        # the domain had no files when the dictionary was built, so it got
+        # no context of its own at that moment
+        self.assertEqual("first.com" in contexts, False)
+
+        self._store("first.com")
+
+        # once the certificate is issued the reload picks it up, without the
+        # process having to be restarted for it
+        self.assertEqual(contexts.reload(), True)
+        self.assertEqual("first.com" in contexts, True)
+
+    def test_has_definition(self):
+        contexts = tls.LetsEncryptDict(self.owner, [], letse_path=self.base)
+
+        # a domain with neither of the files, and one with only the
+        # certificate, are both incomplete and so not usable
+        self.assertEqual(contexts.has_definition("first.com"), False)
+
+        os.makedirs(os.path.join(self.base, "first.com"))
+        self._write(os.path.join(self.base, "first.com", "fullchain.pem"))
+        self.assertEqual(contexts.has_definition("first.com"), False)
+
+        self._write(os.path.join(self.base, "first.com", "privkey.pem"))
+        self.assertEqual(contexts.has_definition("first.com"), True)
+
+    def test_cer_path(self):
+        contexts = tls.TLSContextDict(self.owner, [])
+
+        # the base dictionary defines no layout of its own, so the paths of
+        # a domain are the responsibility of the implementation that follows
+        self.assertRaises(netius.NotImplemented, contexts.cer_path, "first.com")
+        self.assertRaises(netius.NotImplemented, contexts.key_path, "first.com")
+
+    def test_cer_path_letse(self):
+        contexts = tls.LetsEncryptDict(self.owner, [], letse_path=self.base)
+
+        # the layout is the one that certbot produces, with the files of a
+        # domain under a directory that is named after it
+        self.assertEqual(
+            contexts.cer_path("first.com"),
+            os.path.join(self.base, "first.com", "fullchain.pem"),
+        )
+        self.assertEqual(
+            contexts.key_path("first.com"),
+            os.path.join(self.base, "first.com", "privkey.pem"),
+        )
+
+    def _make_owner(self):
+        # builds an owner stand-in that answers the environment probe and
+        # hands out a new context for every request, so that the rebuilding
+        # of one may be observed by identity
+        class Owner(object):
+
+            def get_env(self, name, default, cast=None):
+                return default
+
+            def _ssl_ctx(self, values, secure=1):
+                return object()
+
+        return Owner()
+
+    def _store(self, domain, mtime=None):
+        domain_path = os.path.join(self.base, domain)
+        if not os.path.exists(domain_path):
+            os.makedirs(domain_path)
+        for name in ("fullchain.pem", "privkey.pem"):
+            path = os.path.join(domain_path, name)
+            self._write(path)
+            if mtime == None:
+                continue
+            os.utime(path, (mtime, mtime))
+
+    def _write(self, path):
+        file = open(path, "wb")
+        try:
+            file.write(b"contents")
+        finally:
+            file.close()

--- a/src/netius/test/common/ws.py
+++ b/src/netius/test/common/ws.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius
+import netius.common
+
+
+class WSTest(unittest.TestCase):
+
+    def test_encode_ws(self):
+        result = netius.common.encode_ws(b"Hello World", mask=False)
+
+        # a short payload is announced by the seven bits of the second byte,
+        # the first one carrying the final flag together with the opcode
+        self.assertEqual(result[:2], b"\x81\x0b")
+        self.assertEqual(result[2:], b"Hello World")
+
+    def test_encode_ws_masked(self):
+        result = netius.common.encode_ws(b"Hello World", mask=True)
+
+        # the mask flag is the highest bit of the second byte and the four
+        # bytes of the mask are placed before the payload that they cover
+        self.assertEqual(netius.legacy.ord(result[1:2]) & 0x80, 0x80)
+        self.assertEqual(len(result), 2 + 4 + 11)
+        self.assertNotEqual(result[6:], b"Hello World")
+
+    def test_encode_ws_extended(self):
+        result = netius.common.encode_ws(b"x" * 200, mask=False)
+
+        # a payload that does not fit the seven bits is announced by the
+        # sentinel of 126 followed by the length in two bytes
+        self.assertEqual(result[:4], b"\x81\x7e\x00\xc8")
+
+    def test_encode_ws_extended_long(self):
+        result = netius.common.encode_ws(b"x" * 70000, mask=False)
+
+        # a payload that does not fit two bytes is announced by the sentinel
+        # of 127 followed by the length in eight bytes
+        self.assertEqual(result[:2], b"\x81\x7f")
+        self.assertEqual(result[2:10], b"\x00\x00\x00\x00\x00\x01\x11\x70")
+
+    def test_decode_ws(self):
+        frame = netius.common.encode_ws(b"Hello World", mask=False)
+        decoded, remaining = netius.common.decode_ws(frame)
+
+        # the payload is recovered as it was encoded and nothing is left
+        # pending, as the frame carried a single message
+        self.assertEqual(decoded, b"Hello World")
+        self.assertEqual(remaining, b"")
+
+    def test_decode_ws_masked(self):
+        frame = netius.common.encode_ws(b"Hello World", mask=True)
+        decoded, remaining = netius.common.decode_ws(frame)
+
+        # the unmasking of the payload recovers the original one, the mask
+        # being carried by the frame itself
+        self.assertEqual(decoded, b"Hello World")
+        self.assertEqual(remaining, b"")
+
+    def test_decode_ws_extended(self):
+        for size in (200, 70000):
+            frame = netius.common.encode_ws(b"x" * size, mask=False)
+            decoded, remaining = netius.common.decode_ws(frame)
+
+            # both of the extended forms of the length are understood, so a
+            # payload of any size is recovered as it was encoded
+            self.assertEqual(decoded, b"x" * size)
+            self.assertEqual(remaining, b"")
+
+    def test_decode_ws_pending(self):
+        first = netius.common.encode_ws(b"first", mask=False)
+        second = netius.common.encode_ws(b"second", mask=False)
+
+        decoded, remaining = netius.common.decode_ws(first + second)
+
+        # a payload is bounded by the length that the frame announces, so
+        # the frame that follows it is left pending instead of being taken
+        # as part of the one that precedes it
+        self.assertEqual(decoded, b"first")
+
+        decoded, remaining = netius.common.decode_ws(remaining)
+        self.assertEqual(decoded, b"second")
+        self.assertEqual(remaining, b"")
+
+    def test_decode_ws_pending_masked(self):
+        first = netius.common.encode_ws(b"first", mask=True)
+        second = netius.common.encode_ws(b"second", mask=True)
+
+        decoded, remaining = netius.common.decode_ws(first + second)
+
+        # the very same bounding applies to a masked frame, so that the two
+        # directions of a connection behave in the same way
+        self.assertEqual(decoded, b"first")
+        self.assertEqual(netius.common.decode_ws(remaining)[0], b"second")
+
+    def test_decode_ws_insufficient(self):
+        # a frame that does not carry the two bytes of its header, or the
+        # payload that it announces, cannot be decoded yet
+        self.assertRaises(netius.DataError, netius.common.decode_ws, b"\x81")
+        self.assertRaises(netius.DataError, netius.common.decode_ws, b"\x81\x0bHello")
+
+    def test_decode_ws_insufficient_extended(self):
+        # the extended forms of the length need their own bytes to be read
+        # before the length that they carry may be known
+        self.assertRaises(netius.DataError, netius.common.decode_ws, b"\x81\x7e\x00")
+        self.assertRaises(netius.DataError, netius.common.decode_ws, b"\x81\x7f\x00")
+
+    def test_assert_ws(self):
+        # the assertion passes for a buffer that carries at least the size
+        # that is required and fails for one that does not
+        self.assertEqual(netius.common.assert_ws(4, 2), None)
+        self.assertRaises(netius.DataError, netius.common.assert_ws, 1, 2)

--- a/src/netius/test/extra/dhcp_s.py
+++ b/src/netius/test/extra/dhcp_s.py
@@ -1,0 +1,212 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius.common
+import netius.extra
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+
+class DHCPServerSTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.pool = netius.common.AddressPool("192.168.0.61", "192.168.0.69")
+        self.server = netius.extra.DHCPServerS(pool=self.pool)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+
+    def test_init(self):
+        server = netius.extra.DHCPServerS()
+
+        try:
+            # the default pool covers the small range of addresses that
+            # the server is able to hand out, none of them taken yet
+            self.assertEqual(server.pool.start_addr, "192.168.0.61")
+            self.assertEqual(server.pool.end_addr, "192.168.0.69")
+            self.assertEqual(server.options, {})
+            self.assertEqual(server.lease, 3600)
+        finally:
+            server.cleanup()
+
+    def test_init_values(self):
+        server = netius.extra.DHCPServerS(
+            pool=self.pool,
+            options=dict(subnet=dict(subnet="255.255.255.0"), lease=dict(time=60)),
+        )
+
+        try:
+            self.assertEqual(server.pool, self.pool)
+            self.assertEqual(
+                server.options,
+                {
+                    netius.common.SUBNET_DHCP: dict(subnet="255.255.255.0"),
+                    netius.common.LEASE_DHCP: dict(time=60),
+                },
+            )
+            self.assertEqual(server.lease, 60)
+        finally:
+            server.cleanup()
+
+    def test_get_type(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        request = self._make_request(type=0x01)
+
+        # a discovery is always answered with an offer, as there's no
+        # address associated with the client at that point
+        self.assertEqual(self.server.get_type(request), netius.common.OFFER_DHCP)
+
+        addr = self.pool.reserve(owner="00:00:00:00:00:01")
+        request = self._make_request(type=0x03, mac="00:00:00:00:00:01")
+
+        # the address is owned by the client that requests it, so the
+        # request is acknowledged instead of being refused
+        self.assertEqual(self.server.get_type(request), netius.common.ACK_DHCP)
+
+        request = self._make_request(type=0x03, mac="00:00:00:00:00:02", requested=addr)
+
+        # the address that is requested belongs to another client, which
+        # makes the request an invalid one
+        self.assertEqual(self.server.get_type(request), netius.common.NAK_DHCP)
+
+    def test_get_options(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.options[netius.common.SUBNET_DHCP] = dict(subnet="255.255.255.0")
+
+        options = self.server.get_options(self._make_request(type=0x01))
+
+        self.assertEqual(
+            options, {netius.common.SUBNET_DHCP: dict(subnet="255.255.255.0")}
+        )
+
+        # the options are copied before being given away, so that the
+        # response of a request does not change the ones of the server
+        options[netius.common.NAME_DHCP] = dict(name="hive")
+
+        self.assertEqual(netius.common.NAME_DHCP in self.server.options, False)
+
+    def test_get_yiaddr(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        request = self._make_request(type=0x01, mac="00:00:00:00:00:01")
+
+        addr = self.server.get_yiaddr(request)
+
+        # the discovery reserves the first address of the pool for the
+        # client, associating the two of them
+        self.assertEqual(addr, "192.168.0.61")
+        self.assertEqual(self.pool.assigned("00:00:00:00:00:01"), addr)
+
+        request = self._make_request(type=0x03, mac="00:00:00:00:00:01")
+
+        # the request that follows the discovery confirms the very same
+        # address, as it is the one that is assigned to the client
+        self.assertEqual(self.server.get_yiaddr(request), addr)
+
+    def test__build(self):
+        self.server.options = {}
+        self.server._build(dict(router=dict(routers=["192.168.0.1"])))
+
+        self.assertEqual(
+            self.server.options,
+            {netius.common.ROUTER_DHCP: dict(routers=["192.168.0.1"])},
+        )
+
+        # a lease that is not part of the options keeps the default value
+        # of one hour, as there's nothing to take the time from
+        self.assertEqual(self.server.lease, 3600)
+
+        self.server.options = {}
+        self.server._build(dict(invalid=dict(value="dummy"), lease=dict(time=60)))
+
+        # an option whose name is not a known one is skipped, only the
+        # ones that map to an integer taking part in the result
+        self.assertEqual(self.server.options, {netius.common.LEASE_DHCP: dict(time=60)})
+        self.assertEqual(self.server.lease, 60)
+
+    def test__reserve(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        request = self._make_request(type=0x01, mac="00:00:00:00:00:01")
+
+        addr = self.server._reserve(request)
+
+        self.assertEqual(addr, "192.168.0.61")
+        self.assertEqual(self.pool.is_owner("00:00:00:00:00:01", addr), True)
+
+        # a second client takes the address that follows, as the first
+        # one is already leased and so no longer available
+        request = self._make_request(type=0x01, mac="00:00:00:00:00:02")
+
+        self.assertEqual(self.server._reserve(request), "192.168.0.62")
+
+    def test__confirm(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        addr = self.pool.reserve(owner="00:00:00:00:00:01", lease=1)
+        target = self.pool.map[addr]
+        request = self._make_request(type=0x03, mac="00:00:00:00:00:01")
+
+        self.assertEqual(self.server._confirm(request), addr)
+
+        # the confirmation renews the lease of the address, extending it
+        # from the single second of the reserve to the one of the server
+        self.assertEqual(self.pool.map[addr] > target, True)
+        self.assertEqual(self.pool.is_valid(addr), True)
+
+        # an address that is not part of the pool is given back unchanged,
+        # as there's no lease of it that may be renewed
+        request = self._make_request(
+            type=0x03, mac="00:00:00:00:00:02", requested="10.0.0.1"
+        )
+
+        self.assertEqual(self.server._confirm(request), "10.0.0.1")
+        self.assertEqual(self.pool.exists("10.0.0.1"), False)
+
+    def _make_request(self, type=0x01, mac="00:00:00:00:00:00", requested=None):
+        request = mock.MagicMock()
+        request.get_type.return_value = type
+        request.get_mac.return_value = mac
+        request.get_requested.return_value = requested
+        return request

--- a/src/netius/test/extra/filea.py
+++ b/src/netius/test/extra/filea.py
@@ -1,0 +1,265 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import netius
+import netius.extra
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+
+class FileAsyncServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base_path = tempfile.mkdtemp()
+        self.hello_path = os.path.join(self.base_path, "hello.txt")
+        self._write(self.hello_path, b"Hello World")
+        self.large_path = os.path.join(self.base_path, "large.bin")
+        self._write(self.large_path, b"L" * (netius.extra.filea.BUFFER_SIZE + 1))
+        self.server = netius.extra.FileAsyncServer(base_path=self.base_path)
+        self.connections = []
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self._close_files()
+        self.server.cleanup()
+        shutil.rmtree(self.base_path)
+
+    def test_on_connection_d(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = mock.MagicMock()
+        file = mock.MagicMock()
+        connection.file = file
+
+        with mock.patch.object(self.server, "fclose") as fclose:
+            self.server.on_connection_d(connection)
+
+        # the closing of the file is handed to the file pool, so that the
+        # event loop is not blocked by it, and never run in place
+        self.assertEqual(fclose.call_args[0][0], file)
+        self.assertEqual(file.close.call_count, 0)
+        self.assertEqual(connection.file, None)
+        self.assertEqual(connection.range, None)
+        self.assertEqual(connection.bytes_p, None)
+        self.assertEqual(connection.queue, None)
+
+    def test_on_connection_d_no_file(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = mock.MagicMock()
+        connection.file = None
+
+        with mock.patch.object(self.server, "fclose") as fclose:
+            self.server.on_connection_d(connection)
+
+        # a connection that carries no file has nothing to be released,
+        # meaning that the pool is never reached for it
+        self.assertEqual(fclose.call_count, 0)
+        self.assertEqual(connection.file, None)
+
+    def test_on_stream_d(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        stream = mock.MagicMock()
+        file = mock.MagicMock()
+        stream.file = file
+
+        with mock.patch.object(self.server, "fclose") as fclose:
+            self.server.on_stream_d(stream)
+
+        self.assertEqual(fclose.call_args[0][0], file)
+        self.assertEqual(file.close.call_count, 0)
+        self.assertEqual(stream.file, None)
+        self.assertEqual(stream.range, None)
+        self.assertEqual(stream.bytes_p, None)
+        self.assertEqual(stream.queue, None)
+
+    def test_on_stream_d_no_file(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        stream = mock.MagicMock()
+        stream.file = None
+
+        with mock.patch.object(self.server, "fclose") as fclose:
+            self.server.on_stream_d(stream)
+
+        self.assertEqual(fclose.call_count, 0)
+        self.assertEqual(stream.file, None)
+
+    def test__file_send(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_file_connection(self.hello_path, (0, 10))
+
+        callback = self._file_send(connection)
+
+        callback(b"Hello World")
+
+        args, kwargs = connection.send_part.call_args
+
+        # the whole file fits a single buffer and so the sending is final,
+        # the finish callback releasing the file and flushing the connection
+        self.assertEqual(args[0], b"Hello World")
+        self.assertEqual(kwargs["final"], False)
+        self.assertEqual(kwargs["callback"], self.server._file_finish)
+        self.assertEqual(connection.bytes_p, 0)
+
+    def test__file_send_buffer(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        size = netius.extra.filea.BUFFER_SIZE + 1
+        connection = self._make_file_connection(self.large_path, (0, size - 1))
+
+        with mock.patch.object(self.server, "fread") as fread:
+            self.server._file_send(connection)
+
+        # the amount that is asked from the pool is bound by the buffer,
+        # which is a multiple of the one of the blocking server
+        self.assertEqual(fread.call_args[0][1], netius.extra.filea.BUFFER_SIZE)
+
+        callback = fread.call_args[1]["data"]
+
+        callback(b"L" * netius.extra.filea.BUFFER_SIZE)
+
+        args, kwargs = connection.send_part.call_args
+
+        # there are bytes left to be sent, so the next part is scheduled
+        # through the very same callback, instead of the finish one
+        self.assertEqual(kwargs["callback"], self.server._file_send)
+        self.assertEqual(connection.bytes_p, 1)
+
+    def test__file_send_empty(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_file_connection(self.hello_path, (0, 10))
+
+        callback = self._file_send(connection)
+
+        callback(b"")
+
+        args, kwargs = connection.send_part.call_args
+
+        # a reading that gives nothing back closes the sending, as there's
+        # no more data to be taken from the file
+        self.assertEqual(args[0], b"")
+        self.assertEqual(kwargs["callback"], self.server._file_finish)
+        self.assertEqual(connection.bytes_p, 11)
+
+    def test__file_send_closed(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_file_connection(self.hello_path, (0, 10))
+
+        callback = self._file_send(connection)
+
+        connection.file.close()
+        connection.file = None
+
+        callback(b"Hello World")
+
+        # the file of the connection was released while the reading was
+        # pending, so the data that arrives late must be dropped
+        self.assertEqual(connection.send_part.call_count, 0)
+
+    def test__file_send_error(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_file_connection(self.hello_path, (0, 10))
+
+        callback = self._file_send(connection)
+
+        callback(netius.NetiusError("Invalid file"))
+
+        # a reading that failed gives an exception in the place of the
+        # data, which must not be sent to the client
+        self.assertEqual(connection.send_part.call_count, 0)
+        self.assertEqual(connection.bytes_p, 11)
+
+    def _file_send(self, connection):
+        with mock.patch.object(self.server, "fread") as fread:
+            self.server._file_send(connection)
+
+        args, kwargs = fread.call_args
+
+        self.assertEqual(args[0], connection.file)
+
+        return kwargs["data"]
+
+    def _make_connection(self):
+        connection = mock.MagicMock()
+        # removes the dynamic attributes that the server checks through
+        # hasattr, otherwise they would always be reported as present
+        del connection.file
+        del connection.queue
+        self.connections.append(connection)
+        return connection
+
+    def _make_file_connection(self, path, range):
+        connection = self._make_connection()
+        connection.file = open(path, "rb")
+        connection.file.seek(range[0])
+        connection.range = range
+        connection.bytes_p = range[1] - range[0] + 1
+        return connection
+
+    def _close_files(self):
+        # the file of a connection is only released once the sending of the
+        # response is finished, so an interrupted one has to be closed by
+        # hand, otherwise the removal of the directory fails under Windows
+        for connection in self.connections:
+            file = getattr(connection, "file", None)
+            if not file:
+                continue
+            file.close()
+
+    def _write(self, path, data):
+        file = open(path, "wb")
+        try:
+            file.write(data)
+        finally:
+            file.close()

--- a/src/netius/test/extra/smtp_a.py
+++ b/src/netius/test/extra/smtp_a.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius
+import netius.extra
+
+
+class ActivityRelaySMTPServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.server = netius.extra.ActivityRelaySMTPServer()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+
+    def test_init(self):
+        # the tracking is an optional feature, so a server that is built
+        # with no endpoint at all carries none of the values for it
+        self.assertEqual(self.server.activity_url, None)
+        self.assertEqual(self.server.activity_secret, None)
+
+    def test_on_serve_env(self):
+        self.server.env = True
+
+        with netius.conf_override("SMTP_ACTIVITY_URL", "https://activity.example.com"):
+            with netius.conf_override("SMTP_ACTIVITY_SECRET", "secret"):
+                self.server.on_serve()
+
+        # the endpoint of the tracking is named by the environment, which is
+        # what enables the feature for a deployment
+        self.assertEqual(self.server.activity_url, "https://activity.example.com")
+        self.assertEqual(self.server.activity_secret, "secret")
+
+    def test__decode_header(self):
+        # a header that carries no encoded word at all is served as it is,
+        # so that the common case is left untouched
+        self.assertEqual(self.server._decode_header("Hello World"), "Hello World")
+
+    def test__decode_header_encoded(self):
+        # an encoded word is decoded into the text that it names, both for
+        # the base 64 and for the quoted printable of the specification
+        self.assertEqual(
+            self.server._decode_header("=?utf-8?B?T2zDoSBNdW5kbw==?="), "Olá Mundo"
+        )
+        self.assertEqual(
+            self.server._decode_header("=?utf-8?Q?Ol=C3=A1_Mundo?="), "Olá Mundo"
+        )
+
+    def test__decode_header_invalid(self):
+        # a value that cannot be decoded falls back to the original one, so
+        # that a malformed header never breaks the handling of a message
+        self.assertEqual(
+            self.server._decode_header("=?utf-8?B?not base 64?="),
+            "=?utf-8?B?not base 64?=",
+        )

--- a/src/netius/test/extra/smtp_a.py
+++ b/src/netius/test/extra/smtp_a.py
@@ -33,6 +33,11 @@ import unittest
 import netius
 import netius.extra
 
+DECODED = b"Ol\xc3\xa1 Mundo".decode("utf-8")
+""" The text that the encoded words of the tests carry, built from
+the byte sequence of it so that the value is a unicode one under
+both of the interpreters that are supported """
+
 
 class ActivityRelaySMTPServerTest(unittest.TestCase):
 
@@ -71,10 +76,10 @@ class ActivityRelaySMTPServerTest(unittest.TestCase):
         # an encoded word is decoded into the text that it names, both for
         # the base 64 and for the quoted printable of the specification
         self.assertEqual(
-            self.server._decode_header("=?utf-8?B?T2zDoSBNdW5kbw==?="), "Olá Mundo"
+            self.server._decode_header("=?utf-8?B?T2zDoSBNdW5kbw==?="), DECODED
         )
         self.assertEqual(
-            self.server._decode_header("=?utf-8?Q?Ol=C3=A1_Mundo?="), "Olá Mundo"
+            self.server._decode_header("=?utf-8?Q?Ol=C3=A1_Mundo?="), DECODED
         )
 
     def test__decode_header_invalid(self):

--- a/src/netius/test/extra/smtp_r.py
+++ b/src/netius/test/extra/smtp_r.py
@@ -30,7 +30,9 @@ __license__ = "Apache License, Version 2.0"
 
 import unittest
 
+import netius.adapters
 import netius.extra
+import netius.servers
 
 PRIVATE_KEY = b"MIICVwIAAoGAgRWSX07LB0VzpDy14taaO1b+juQVhQpyKy/fxaLupohy4UDOxHJU\
 Iz7jzR6B8l93KXWqxG5UZK2CduL6TKJGQZ+jGkTk0YU3d3r5kwPNOX1o+qhICJF8\
@@ -67,10 +69,139 @@ class RelaySMTPServerTest(unittest.TestCase):
     def setUp(self):
         unittest.TestCase.setUp(self)
         self.server = netius.extra.RelaySMTPServer()
+        self.server.adapter = netius.adapters.MemoryAdapter()
+        self.server.locals = ("local.com",)
+        self.relayed = []
 
     def tearDown(self):
         unittest.TestCase.tearDown(self)
         self.server.cleanup()
+
+    def test_on_header_smtp(self):
+        connection = self._make_connection()
+
+        self.server.on_header_smtp(
+            connection, ["FROM:<joe@local.com>"], ["TO:<mary@remote.com>"]
+        )
+
+        # the recipients that are not served locally are the ones that have
+        # to be relayed, and the buffer that gathers the message starts empty
+        self.assertEqual(connection.remotes, ["mary@remote.com"])
+        self.assertEqual(connection.relay, [])
+
+    def test_on_header_smtp_local(self):
+        connection = self._make_connection()
+
+        self.server.on_header_smtp(
+            connection, ["FROM:<joe@local.com>"], ["TO:<mary@local.com>"]
+        )
+
+        # a recipient that is served locally is delivered rather than
+        # relayed, so nothing is gathered for a relay operation
+        self.assertEqual(connection.remotes, [])
+
+    def test_on_data_smtp(self):
+        connection = self._make_connection(remotes=["mary@remote.com"])
+
+        self.server.on_data_smtp(connection, b"payload")
+
+        # the payload is gathered for the relay, as it has to be sent onward
+        # to the server that serves the recipient
+        self.assertEqual(connection.relay, [b"payload"])
+
+    def test_on_data_smtp_no_remotes(self):
+        connection = self._make_connection()
+
+        self.server.on_data_smtp(connection, b"payload")
+
+        # with no recipient to relay to there is nothing to gather, the
+        # message being delivered locally alone
+        self.assertEqual(connection.relay, [])
+
+    def test_on_message_smtp(self):
+        connection = self._make_connection(remotes=["mary@remote.com"])
+        connection.from_l = ["FROM:<joe@local.com>"]
+        connection.relay = [b"Header: Value\r\n\r\nHello World\r\n.\r\n"]
+        self._patch_relay()
+
+        self.server.on_message_smtp(connection)
+
+        # the termination sequence is stripped from the contents that are
+        # relayed, as it belongs to the framing and not to the message
+        self.assertEqual(len(self.relayed), 1)
+        _connection, froms, tos, contents = self.relayed[0]
+        self.assertEqual(froms, ["joe@local.com"])
+        self.assertEqual(tos, ["mary@remote.com"])
+        self.assertEqual(contents, b"Header: Value\r\n\r\nHello World")
+
+    def test_on_message_smtp_no_remotes(self):
+        connection = self._make_connection()
+        self._patch_relay()
+
+        self.server.on_message_smtp(connection)
+
+        # a message with no recipient to relay to never reaches the relay,
+        # so that no session is opened towards another server
+        self.assertEqual(self.relayed, [])
+
+    def test_relay_unauthenticated(self):
+        connection = self._make_connection(remotes=["mary@remote.com"])
+
+        # the relaying of a message towards another server requires an
+        # authenticated user, so an anonymous session is refused instead of
+        # being forwarded, which would make an open relay of the server
+        self.assertRaises(
+            netius.SecurityError,
+            self.server.relay,
+            connection,
+            ["joe@local.com"],
+            ["mary@remote.com"],
+            b"",
+        )
+
+    def test_relay_not_allowed(self):
+        connection = self._make_connection(remotes=["mary@remote.com"])
+        connection.username = "joe"
+        connection.auth_meta = dict(allowed_froms=["other@local.com"])
+
+        # a user that is bound to a set of senders may not relay from one
+        # that is outside of it, which would otherwise let it send as
+        # somebody that it is not
+        self.assertRaises(
+            netius.SecurityError,
+            self.server.relay,
+            connection,
+            ["joe@local.com"],
+            ["mary@remote.com"],
+            b"",
+        )
+
+    def test_date(self):
+        result = self.server.date()
+
+        # the date follows the format that the specification names for a
+        # message, ending in the numeric offset of the zone
+        self.assertEqual(result.endswith(" +0000"), True)
+        self.assertEqual(len(result.split(" ")), 6)
+
+    def test_message_id(self):
+        result = self.server.message_id(email="joe@remote.com")
+
+        # the identifier is enclosed in angle brackets and is bound to the
+        # domain of the address that it is built for
+        self.assertEqual(result.startswith("<"), True)
+        self.assertEqual(result.endswith("@remote.com>"), True)
+
+    def test_message_id_connection(self):
+        connection = self._make_connection()
+        connection.identifier = "abc"
+
+        # a connection that carries an identifier of its own names the
+        # message, so that the two may be correlated afterwards
+        self.assertEqual(
+            self.server.message_id(connection=connection, email="joe@remote.com"),
+            "<abc@remote.com>",
+        )
 
     def test_dkim(self):
         self.server.dkim = REGISTRY
@@ -79,3 +210,48 @@ class RelaySMTPServerTest(unittest.TestCase):
         )
 
         self.assertEqual(result, RESULT)
+
+    def test_dkim_absent(self):
+        self.server.dkim = REGISTRY
+
+        # a domain that carries no register is left unsigned, the contents
+        # being served exactly as they were provided
+        result = self.server.dkim_contents(MESSAGE, email="joe@other.com")
+        self.assertEqual(result, MESSAGE)
+
+    def test_dkim_no_key(self):
+        self.server.dkim = dict(other=dict(selector="selector", domain="other.com"))
+
+        # a register that names no key at all cannot sign anything, which is
+        # reported instead of a message that travels unsigned
+        self.assertRaises(
+            netius.SecurityError,
+            self.server.dkim_contents,
+            MESSAGE,
+            email="joe@other",
+        )
+
+    def _make_connection(self, remotes=None):
+        # builds a connection stand-in that carries the state that the relay
+        # looks at, without any of the socket that it would otherwise hold
+        connection = netius.servers.smtp.SMTPConnection.__new__(
+            netius.servers.smtp.SMTPConnection
+        )
+        connection.owner = self.server
+        connection.keys = []
+        connection.from_l = []
+        connection.to_l = []
+        connection.tail = b"\r\n"
+        connection.identifier = None
+        connection.remotes = [] if remotes == None else remotes
+        connection.relay = []
+        return connection
+
+    def _patch_relay(self):
+        # replaces the relaying by one that records the messages that reach
+        # it, so that no session is opened towards another server
+        self.server.relay = (
+            lambda connection, froms, tos, contents: self.relayed.append(
+                (connection, froms, tos, contents)
+            )
+        )

--- a/src/netius/test/pool/file.py
+++ b/src/netius/test/pool/file.py
@@ -1,0 +1,363 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import netius
+import netius.pool
+
+from netius.pool import file
+
+
+class FileThreadTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base = tempfile.mkdtemp()
+        self.pool = netius.pool.FilePool()
+        self.thread = netius.pool.FileThread(0, owner=self.pool)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        shutil.rmtree(self.base)
+
+    def test_execute(self):
+        path = self._store("simple.txt", b"hello world")
+
+        self.thread.execute((file.FILE_WORK, file.OPEN_ACTION, path, "rb", "data"))
+
+        action, result, data = self.pool.pop_event()
+
+        self.assertEqual(action, file.OPEN_ACTION)
+        self.assertEqual(data, "data")
+
+        result.close()
+
+        # an exception raised by the action is turned into an error event
+        # carrying it, so that the owner is able to react to the failure
+        self.thread.execute(
+            (
+                file.FILE_WORK,
+                file.OPEN_ACTION,
+                os.path.join(self.base, "missing.txt"),
+                "rb",
+                "data",
+            )
+        )
+
+        action, result, data = self.pool.pop_event()
+
+        self.assertEqual(action, file.ERROR_ACTION)
+        self.assertEqual(isinstance(result, IOError), True)
+        self.assertEqual(data, "data")
+
+        # a work of a type other than the file one is refused, as the
+        # thread is only able to handle the file kind of work
+        self.assertRaises(
+            netius.NotImplemented,
+            self.thread.execute,
+            (file.FILE_WORK + 1, file.OPEN_ACTION, path, "rb", None),
+        )
+
+    def test_open(self):
+        path = self._store("simple.txt", b"hello world")
+
+        self.thread.open(path, "rb", None)
+
+        action, result, data = self.pool.pop_event()
+
+        self.assertEqual(action, file.OPEN_ACTION)
+        self.assertEqual(result.read(), b"hello world")
+        self.assertEqual(data, None)
+
+        result.close()
+
+        # the mode is the one that the caller asked for, so that a file
+        # may also be opened for writing and not only for reading
+        path = os.path.join(self.base, "target.txt")
+
+        self.thread.open(path, "wb", None)
+
+        action, result, data = self.pool.pop_event()
+
+        self.assertEqual(action, file.OPEN_ACTION)
+        self.assertEqual(result.mode, "wb")
+
+        result.write(b"hello world")
+        result.close()
+
+        self.assertEqual(self._read("target.txt"), b"hello world")
+
+    def test_close(self):
+        path = self._store("simple.txt", b"hello world")
+        handle = open(path, "rb")
+
+        self.thread.close(handle, "data")
+
+        action, result, data = self.pool.pop_event()
+
+        self.assertEqual(action, file.CLOSE_ACTION)
+        self.assertEqual(result.closed, True)
+        self.assertEqual(data, "data")
+
+    def test_read(self):
+        path = self._store("simple.txt", b"hello world")
+        handle = open(path, "rb")
+
+        try:
+            self.thread.read(handle, 5, "data")
+
+            action, result, data = self.pool.pop_event()
+
+            self.assertEqual(action, file.READ_ACTION)
+            self.assertEqual(result, b"hello")
+            self.assertEqual(data, "data")
+
+            # a count of minus one reads the complete remainder of the
+            # file, starting from where the previous read has stopped
+            self.thread.read(handle, -1, None)
+
+            action, result, data = self.pool.pop_event()
+
+            self.assertEqual(result, b" world")
+
+            # a read that reaches the end of the file gives an empty
+            # sequence, instead of raising for the exhausted file
+            self.thread.read(handle, -1, None)
+
+            action, result, data = self.pool.pop_event()
+
+            self.assertEqual(result, b"")
+        finally:
+            handle.close()
+
+    def test_write(self):
+        path = os.path.join(self.base, "target.txt")
+        handle = open(path, "wb")
+
+        try:
+            self.thread.write(handle, b"hello world", "data")
+
+            action, result, data = self.pool.pop_event()
+
+            # the event carries the number of bytes that were written and
+            # not the buffer itself, as the caller already owns it
+            self.assertEqual(action, file.WRITE_ACTION)
+            self.assertEqual(result, 11)
+            self.assertEqual(data, "data")
+        finally:
+            handle.close()
+
+        self.assertEqual(self._read("target.txt"), b"hello world")
+
+    def test__execute(self):
+        path = self._store("simple.txt", b"hello world")
+
+        # every one of the actions must be routed to the method of the
+        # same name, the open one giving back a file for the path
+        self.thread._execute((file.FILE_WORK, file.OPEN_ACTION, path, "rb", None))
+
+        action, handle, data = self.pool.pop_event()
+
+        self.assertEqual(action, file.OPEN_ACTION)
+
+        self.thread._execute((file.FILE_WORK, file.READ_ACTION, handle, -1, None))
+
+        action, result, data = self.pool.pop_event()
+
+        self.assertEqual(action, file.READ_ACTION)
+        self.assertEqual(result, b"hello world")
+
+        self.thread._execute((file.FILE_WORK, file.CLOSE_ACTION, handle, None))
+
+        action, result, data = self.pool.pop_event()
+
+        self.assertEqual(action, file.CLOSE_ACTION)
+        self.assertEqual(result.closed, True)
+
+        # the write action must reach the write method, so that the
+        # buffer is stored and the number of bytes reported back
+        handle = open(os.path.join(self.base, "target.txt"), "wb")
+
+        try:
+            self.thread._execute(
+                (file.FILE_WORK, file.WRITE_ACTION, handle, b"hello world", None)
+            )
+
+            action, result, data = self.pool.pop_event()
+
+            self.assertEqual(action, file.WRITE_ACTION)
+            self.assertEqual(result, 11)
+        finally:
+            handle.close()
+
+        self.assertEqual(self._read("target.txt"), b"hello world")
+
+        # an action that is not one of the defined ones is refused, as
+        # there's no method to which it may be routed
+        self.assertRaises(
+            netius.NotImplemented,
+            self.thread._execute,
+            (file.FILE_WORK, file.WRITE_ACTION + 1, handle, None),
+        )
+
+    def _store(self, name, contents):
+        path = os.path.join(self.base, name)
+        handle = open(path, "wb")
+        try:
+            handle.write(contents)
+        finally:
+            handle.close()
+        return path
+
+    def _read(self, name):
+        handle = open(os.path.join(self.base, name), "rb")
+        try:
+            return handle.read()
+        finally:
+            handle.close()
+
+
+class FilePoolTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base = tempfile.mkdtemp()
+        self.pool = netius.pool.FilePool()
+        self.thread = netius.pool.FileThread(0, owner=self.pool)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        shutil.rmtree(self.base)
+
+    def test_open(self):
+        path = self._store("simple.txt", b"hello world")
+
+        self.pool.open(path, mode="rb", data="data")
+
+        # the work that is queued carries the action and every one of the
+        # arguments that the thread needs to run it
+        self.assertEqual(
+            self.pool.peek(), (file.FILE_WORK, file.OPEN_ACTION, path, "rb", "data")
+        )
+
+        self.thread.execute(self.pool.pop())
+
+        action, result, data = self.pool.pop_event()
+
+        self.assertEqual(action, file.OPEN_ACTION)
+        self.assertEqual(result.read(), b"hello world")
+        self.assertEqual(data, "data")
+
+        result.close()
+
+    def test_close(self):
+        path = self._store("simple.txt", b"hello world")
+        handle = open(path, "rb")
+
+        self.pool.close(handle, data="data")
+
+        self.assertEqual(
+            self.pool.peek(), (file.FILE_WORK, file.CLOSE_ACTION, handle, "data")
+        )
+
+        self.thread.execute(self.pool.pop())
+
+        action, result, data = self.pool.pop_event()
+
+        self.assertEqual(action, file.CLOSE_ACTION)
+        self.assertEqual(result.closed, True)
+        self.assertEqual(data, "data")
+
+    def test_read(self):
+        path = self._store("simple.txt", b"hello world")
+        handle = open(path, "rb")
+
+        try:
+            self.pool.read(handle, count=5, data="data")
+
+            self.assertEqual(
+                self.pool.peek(), (file.FILE_WORK, file.READ_ACTION, handle, 5, "data")
+            )
+
+            self.thread.execute(self.pool.pop())
+
+            action, result, data = self.pool.pop_event()
+
+            self.assertEqual(action, file.READ_ACTION)
+            self.assertEqual(result, b"hello")
+            self.assertEqual(data, "data")
+        finally:
+            handle.close()
+
+    def test_write(self):
+        path = os.path.join(self.base, "target.txt")
+        handle = open(path, "wb")
+
+        try:
+            self.pool.write(handle, b"hello world", data="data")
+
+            self.assertEqual(
+                self.pool.peek(),
+                (file.FILE_WORK, file.WRITE_ACTION, handle, b"hello world", "data"),
+            )
+
+            self.thread.execute(self.pool.pop())
+
+            action, result, data = self.pool.pop_event()
+
+            # the buffer must reach the file, meaning that the work is
+            # routed to the write method and not to the read one
+            self.assertEqual(action, file.WRITE_ACTION)
+            self.assertEqual(result, 11)
+            self.assertEqual(data, "data")
+        finally:
+            handle.close()
+
+        self.assertEqual(self._read("target.txt"), b"hello world")
+
+    def _store(self, name, contents):
+        path = os.path.join(self.base, name)
+        handle = open(path, "wb")
+        try:
+            handle.write(contents)
+        finally:
+            handle.close()
+        return path
+
+    def _read(self, name):
+        handle = open(os.path.join(self.base, name), "rb")
+        try:
+            return handle.read()
+        finally:
+            handle.close()

--- a/src/netius/test/servers/ws.py
+++ b/src/netius/test/servers/ws.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import logging
+import unittest
+
+import netius
+import netius.servers
+
+from netius.servers import ws
+
+REQUEST = (
+    b"GET /chat HTTP/1.1\r\n"
+    b"Host: localhost\r\n"
+    b"Upgrade: websocket\r\n"
+    b"Connection: Upgrade\r\n"
+    b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+    b"Sec-WebSocket-Version: 13\r\n\r\n"
+)
+""" The upgrade request of the example of the RFC 6455, whose key
+is the one that the specification uses to demonstrate the accept
+key that a server has to answer with """
+
+ACCEPT_KEY = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+""" The accept key that the RFC 6455 names as the answer to the
+key of the request above, used as the vector of the handshake """
+
+
+class WSConnectionTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.server = netius.servers.WSServer(level=logging.CRITICAL)
+        self.connection = self._make_connection()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+
+    def test_send_ws(self):
+        self.connection.send_ws(b"Hello World")
+
+        # the payload that a server sends is never masked, as the masking
+        # is only applied to the frames that travel towards it
+        decoded, remaining = netius.common.decode_ws(self._data())
+        self.assertEqual(decoded, b"Hello World")
+        self.assertEqual(remaining, b"")
+
+    def test_add_buffer(self):
+        self.connection.add_buffer(b"first")
+        self.connection.add_buffer(b"second")
+
+        # the buffer joins the reads that it gathers and is emptied by the
+        # reading of it, so that the data is only handled once
+        self.assertEqual(self.connection.get_buffer(), b"firstsecond")
+        self.assertEqual(self.connection.get_buffer(), b"")
+
+    def test_get_buffer_keep(self):
+        self.connection.add_buffer(b"first")
+
+        # the reading may keep the buffer in place, which the handshake
+        # needs so that the data is still there for a second attempt
+        self.assertEqual(self.connection.get_buffer(delete=False), b"first")
+        self.assertEqual(self.connection.get_buffer(), b"first")
+
+    def test_do_handshake(self):
+        self.connection.add_buffer(REQUEST)
+
+        self.connection.do_handshake()
+
+        # the request line and the headers of the upgrade are gathered, the
+        # names of the headers being lowered so that they may be resolved
+        self.assertEqual(self.connection.handshake, True)
+        self.assertEqual(self.connection.method, "GET")
+        self.assertEqual(self.connection.path, "/chat")
+        self.assertEqual(self.connection.version, "HTTP/1.1")
+        self.assertEqual(self.connection.headers["upgrade"], "websocket")
+        self.assertEqual(
+            self.connection.headers["sec-websocket-key"], "dGhlIHNhbXBsZSBub25jZQ=="
+        )
+
+    def test_do_handshake_remaining(self):
+        frame = netius.common.encode_ws(b"Hello World")
+        self.connection.add_buffer(REQUEST + frame)
+
+        self.connection.do_handshake()
+
+        # the bytes that follow the headers belong to the frames that come
+        # after the handshake, so they are kept for the parsing that follows
+        self.assertEqual(self.connection.get_buffer(), frame)
+
+    def test_do_handshake_partial(self):
+        self.connection.add_buffer(REQUEST[:40])
+
+        # a handshake whose headers have not been completely received yet
+        # cannot be performed, which is reported so that it may be retried
+        self.assertRaises(netius.DataError, self.connection.do_handshake)
+
+    def test_do_handshake_repeated(self):
+        self.connection.add_buffer(REQUEST)
+        self.connection.do_handshake()
+
+        # the handshake of a connection happens once alone, so a second
+        # attempt at it is refused instead of resetting the state
+        self.assertRaises(netius.NetiusError, self.connection.do_handshake)
+
+    def test_accept_key(self):
+        self.connection.add_buffer(REQUEST)
+        self.connection.do_handshake()
+
+        # the accept key is the one that the specification names for the
+        # key of the request, which is the vector of the handshake
+        self.assertEqual(self.connection.accept_key(), ACCEPT_KEY)
+
+    def test_accept_key_missing(self):
+        self.connection.add_buffer(b"GET /chat HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        self.connection.do_handshake()
+
+        # a request that names no key cannot be answered, as there is
+        # nothing from which the accept key may be built
+        self.assertRaises(netius.NetiusError, self.connection.accept_key)
+
+    def _make_connection(self):
+        # builds a connection without the underlying socket, replacing the
+        # sending by one that gathers the payload that would reach the client
+        connection = ws.WSConnection(
+            owner=self.server, socket=None, address=("127.0.0.1", 9090)
+        )
+        connection.data = []
+        connection.send = lambda data, **kwargs: connection.data.append(
+            netius.legacy.bytes(data)
+        )
+        return connection
+
+    def _data(self):
+        return b"".join(self.connection.data)
+
+
+class WSServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.server = netius.servers.WSServer(level=logging.CRITICAL)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+
+    def test__handshake_response(self):
+        result = self.server._handshake_response(ACCEPT_KEY)
+
+        # the answer of the handshake names the upgrade that was accepted
+        # together with the key that proves it, ending in an empty line
+        self.assertEqual(result.startswith("HTTP/1.1 101"), True)
+        self.assertEqual("Upgrade: websocket\r\n" in result, True)
+        self.assertEqual("Sec-WebSocket-Accept: " + ACCEPT_KEY in result, True)
+        self.assertEqual(result.endswith("\r\n\r\n"), True)


### PR DESCRIPTION
Steps 1, 5, 6, 7 and 8 of #102.

## What this carries

Five of the twelve steps of #102, the ratchet that stops the figure from sliding back and the four phases that cover the modules which had no test file of their own.

Seven defects that the tests found along the way are fixed with them.

## The floor

The `Combine coverage data` step of the coverage job now ends in `--fail-under=64`, so a change that lowers the coverage of the package fails the build instead of passing quietly. The floor is meant to be raised by every change that adds coverage.

It is seeded below the measured figure, as the job combines three platforms and only the Linux and the macOS ones were measured here, the Windows leg being expected to add a little rather than to take any away.

## Phase 6, the protocol codecs

| Module | Before | After |
| --- | --- | --- |
| `common/dhcp.py` | 34.2% | 99.1% |
| `common/ftp.py` | 17.7% | 100.0% |
| `common/geo.py` | 21.7% | 81.9% |
| `common/pop.py` | 19.1% | 100.0% |
| `common/structures.py` | 44.4% | 100.0% |
| `common/tls.py` | 20.5% | 97.6% |
| **together** | **~24%** | **94.5%** |

What is left uncovered in `common/geo.py` is the body that needs the `maxminddb` package, which is an optional dependency that the workflow does not install, the download that reaches the network, and the `__main__` block.

## Phase 7, the SMTP relay

| Module | Before | After |
| --- | --- | --- |
| `common/smtp.py` | 17.7% | 100.0% |
| `extra/smtp_r.py` | 28.1% | 63.1% |
| `extra/smtp_a.py` | 20.9% | 37.4% |
| **together** | **24.0%** | **62.9%** |

`common/smtp.py` is the same shape as the FTP and the POP parsers, so it is covered in full by the same set of cases. For the two relays what is covered is the gathering of a message for relay, the stripping of the termination sequence from it, the identifiers and the date that a relayed message carries, the signing of one and the two refusals that keep the server from being an open relay. What is left is the body of `relay`, of `relay_postmaster` and of `_post_activity`, which open sessions towards another server and towards an HTTP endpoint.

## Phase 5, the WebSocket stack

| Module | Before | After |
| --- | --- | --- |
| `common/ws.py` | 64.4% | 100.0% |
| `servers/ws.py` | 17.5% | 73.8% |
| `clients/ws.py` | 17.5% | 63.7% |
| **together** | **~24%** | **76.1%** |

The handshake of the two sides is pinned against the vector of RFC 6455, the key of the example answering with the accept key that the specification names, together with the refusal of an answer that carries no accept key and of one whose key does not follow from the request.

What is left uncovered is the connecting of a client and the dispatch of a server, both of which open a socket.

## Phase 8, the authentication handlers and the file pool

| Module | Before | After |
| --- | --- | --- |
| `auth/base.py` | 37.8% | 100.0% |
| `auth/passwd.py` | 23.5% | 100.0% |
| `pool/file.py` | 35.3% | 100.0% |
| `extra/dhcp_s.py` | 21.0% | 88.9% |
| `extra/filea.py` | 24.5% | 91.8% |
| **together** | **30.2%** | **96.6%** |

The three modules that reach the whole of it are covered end to end, the file pool through the queue that the pool fills and the thread that drains it, so that both halves of a work are exercised by the same case.

What is left uncovered in the two `extra` modules is the `__main__` block of each and the fall through of `get_type` and of `get_yiaddr`, which no message is able to reach as the server refuses any type other than a discovery or a request before those are called.

The package as a whole moves from 61.4% to 64.8%, measured with the Linux and the macOS data combined.

## The seven defects

**The file pool never wrote anything.** The branch of the write action called `self.read` in the place of `self.write`, so a write reached the file object as a read of the buffer, which raises. Every write submitted to the pool came back as an error event and no byte ever reached the disk. Measured before the fix:

```
write of b'payload' -> ERROR, UnsupportedOperation('read'), file is b''
```

**The file pool ignored the mode of an open.** `FileThread.open` took a mode and then called `open(path)`, so every file was opened for reading whatever was asked for. An open for writing of a file that does not exist failed outright, and one of a file that does exist gave back a handle that cannot be written to.

**The file pool swallowed a work it did not know.** The two guards built a `netius.NotImplemented` and dropped it on the floor instead of raising it, where the base class of the thread raises the very same exception. An action that is not one of the four did nothing at all, pushing no event, so the caller waited for an answer that was never going to arrive.

**`decode_ws` swallowed the frame that followed an unmasked one.** The payload of an unmasked frame was returned as everything that follows the header, ignoring the length that the frame announces, where the masked branch bounds it correctly and returns the remainder. RFC 6455 requires the frames that travel from a server to a client to be unmasked, and `WSProtocol.on_data` drives its loop from that remainder, so two frames arriving in a single segment corrupted the first message and lost the second. Measured before the fix:

```
two unmasked frames -> (b'AA\x81\x02BB', b'')     the second is swallowed
two masked frames   -> (b'AA', b'\x81\x82...')    correct
```

**`geo._try_db` discarded the database that it had just downloaded.** The test of the existence of the file was written as `exists = not os.path.exists(path)`, so the two outcomes were inverted. A download that produced the file returned nothing, and one that produced nothing returned the path of a file that is not there.

**The POP parser reported the message of a bare line as a byte sequence.** A line that carries no argument fell to `values.append(b"")` where the FTP and the SMTP parsers, which are the same shape, append `""`.

**`Auth.unpack` broke on a plain password that carries the separator.** The local that holds the plain value was only assigned in the branch that sees no separator, so a stored password such as `plain:secret` reached the return with the variable unbound and raised an `UnboundLocalError`. It is now assigned up front and cleared for the types that are not plain, which is what the guard right below it already expressed.

All seven are covered by tests that fail without the fix.

## Validation

Suite status: 1347 passed and 7 skipped on Linux with Python 3.14, 1346 passed and 8 skipped on macOS, 149 of the tests being new. The suite was also run under Python 2.7, where it reports 1049 passed and 305 skipped, as that interpreter is still part of the matrix and two of the assertions of this branch had to be written differently for it. `black --check` is clean and `mypy.stubtest` reports no issues in 132 modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication unpacking, WebSocket framing, async file I/O, and GeoIP download paths used at runtime, though changes are small and heavily tested.
> 
> **Overview**
> Adds broad unit tests for protocol codecs, WebSocket client/server, auth, SMTP relay, DHCP, and the async **file pool**, and makes the coverage job fail when combined coverage drops below **64%** (`--fail-under=64`).
> 
> Alongside the tests, **seven production fixes** land: **`decode_ws`** bounds unmasked payloads by frame length so back-to-back frames are not merged or dropped; **`GeoResolver._try_db`** uses the correct post-download existence check; **`FileThread`** honors open **mode**, routes **WRITE** to **`write`**, and **raises** on unknown work types; **`Auth.unpack`** handles plain passwords containing **`:`**; POP bare-line messages use an empty **string** message.
> 
> **CHANGELOG** records the CI change and fixes; the rest of the diff is new/expanded tests (including relay security and RFC 6455 handshake vectors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ee011135d11006774c209084425a9927b2efaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->