### PR TITLE
test(proxy,middleware): cover the proxy and middleware tail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           pip install coverage
           coverage combine
-          coverage report --sort=-miss --fail-under=66
+          coverage report --sort=-miss --fail-under=67
       - name: Publish coverage summary
         run: |
           echo "## Coverage" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A configuration file that is imported by another is now loaded into the context that asked for it
 * A file opened through the asynchronous file pool now honours the mode that was asked for
 * A file written through the asynchronous file pool now reaches the disk instead of failing
+* A flood avoidance middleware can now be started, instead of failing on the limit of a minute
+* A host that floods is now blocked, as the count of a minute is no longer reset by every connection
+* A host suffix of the Docker proxy is now registered where it was asked to be
 * A stored password that carries a separator no longer breaks the authentication
 * An asynchronous file operation that is not a known one is now refused instead of being ignored
 * Two WebSocket frames that arrive together are now both handled instead of the second being swallowed

--- a/src/netius/extra/proxy_d.py
+++ b/src/netius/extra/proxy_d.py
@@ -218,8 +218,8 @@ class DockerProxyServer(proxy_r.ReverseProxyServer):
     def _build_suffixes(self, alias=True, redirect=True):
         for host_suffix in self.host_suffixes:
             self.info("Registering %s host suffix", host_suffix)
-            for alias, value in netius.legacy.items(self.alias):
-                fqn = alias + "." + str(host_suffix)
+            for key, value in netius.legacy.items(self.alias):
+                fqn = key + "." + str(host_suffix)
                 self.alias[fqn] = value
             for name, value in netius.legacy.items(self.hosts):
                 fqn = name + "." + str(host_suffix)

--- a/src/netius/middleware/flood.py
+++ b/src/netius/middleware/flood.py
@@ -53,7 +53,7 @@ class FloodMiddleware(Middleware):
 
     def __init__(self, owner, conns_per_min=600, whitelist=None):
         Middleware.__init__(self, owner)
-        self.blacklist = conns_per_min
+        self.conns_per_min = conns_per_min
         self.whitelist = whitelist or []
 
     def start(self):
@@ -81,7 +81,7 @@ class FloodMiddleware(Middleware):
 
     def _update_flood(self, host):
         minute = int(time.time() // 60)
-        if minute == self.minute:
+        if not minute == self.minute:
             self.conn_map.clear()
         self.minute = minute
         count = self.conn_map.get(host, 0)

--- a/src/netius/test/extra/proxy_d.py
+++ b/src/netius/test/extra/proxy_d.py
@@ -1,0 +1,363 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius
+import netius.extra
+
+
+class DockerProxyServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.names = []
+        self.servers = []
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        for name in self.names:
+            netius.config.conf_r(name)
+        for server in self.servers:
+            server.cleanup()
+
+    def test_init(self):
+        self._conf(NETIUS_D_PORT="tcp://first:80", NETIUS_D_NAME="/netius_d")
+
+        server = self._make_server()
+
+        # the building of the configuration is run by the constructor, so
+        # the linked container is already registered by then
+        self.assertEqual(server.hosts["netius_d"], "http://first:80")
+        self.assertEqual(server.host_suffixes, [])
+
+    def test_init_suffixes(self):
+        server = self._make_server(host_suffixes=["local"])
+
+        self.assertEqual(server.host_suffixes, ["local"])
+
+    def test_on_serve(self):
+        self._conf(NETIUS_D_REDIRECT_SSL="1")
+
+        server = self._make_server(host_suffixes=["local"])
+        server.env = False
+        server.alias = dict(other="netius_d")
+        server.redirect = {}
+
+        server.on_serve()
+
+        # the serving registers the suffixed names and the redirections
+        # towards the secure scheme, which the constructor cannot know
+        self.assertEqual(server.alias["other.local"], "netius_d")
+        self.assertEqual(server.redirect["netius_d"], ("netius_d", "https"))
+
+    def test_on_serve_env(self):
+        self._conf(HOST_SUFFIXES="first;second")
+
+        server = self._make_server()
+        server.env = True
+        server.alias = dict(other="netius_d")
+
+        server.on_serve()
+
+        # with the environment in use the suffixes are taken from it,
+        # replacing the ones that the constructor was given
+        self.assertEqual(server.host_suffixes, ["first", "second"])
+        self.assertEqual(server.alias["other.first"], "netius_d")
+        self.assertEqual(server.alias["other.second"], "netius_d")
+
+    def test__build_regex(self):
+        server = self._make_server()
+        server.regex = []
+
+        self._conf(
+            NETIUS_D_REGEX="^/first.*$http://first:80",
+            NETIUS_D_BROKEN_REGEX="no-token-at-all",
+            NETIUS_D_INVALID_REGEX="^/second.*$not-a-url",
+        )
+
+        server._build_regex()
+
+        # only the value that carries both a rule and a valid target is
+        # registered, the other two being dropped
+        self.assertEqual(len(server.regex), 1)
+        self.assertEqual(server.regex[0][0].pattern, "^/first.*")
+        self.assertEqual(server.regex[0][1], "http://first:80")
+
+    def test__build_regex_sort(self):
+        server = self._make_server()
+        server.regex = []
+
+        self._conf(
+            NETIUS_D_SECOND_REGEX="^/second$http://second:80",
+            NETIUS_D_FIRST_REGEX="^/first$http://first:80",
+        )
+
+        server._build_regex()
+
+        # the names are walked in order, so that the rules are registered
+        # in a way that does not depend on the order of the configuration
+        targets = [target for _regex, target in server.regex]
+        self.assertEqual(
+            targets.index("http://first:80") < targets.index("http://second:80"), True
+        )
+
+        server.regex = []
+        server._build_regex(sort=False)
+
+        # without the sorting the rules are still every one of them, only
+        # the order in which they are walked is no longer settled
+        self.assertEqual(len(server.regex), 2)
+
+    def test__build_hosts(self):
+        server = self._make_server()
+
+        self._conf(NETIUS_D_PORT="tcp://first:80", NETIUS_D_NAME="/netius_d")
+
+        server.hosts = {}
+        server._build_hosts()
+
+        # the scheme of the link is replaced by an HTTP one, as that is
+        # the protocol that the proxy speaks with the container
+        self.assertEqual(server.hosts["netius_d"], "http://first:80")
+
+        # the name of the link has an underscore, so a dashed alias of it
+        # is registered together with the host
+        self.assertEqual(server.alias["netius-d"], "netius_d")
+
+    def test__build_hosts_alias(self):
+        server = self._make_server()
+
+        self._conf(NETIUS_D_PORT="tcp://first:80", NETIUS_D_NAME="/netius_d")
+
+        server.hosts = {}
+        server.alias = {}
+        server._build_hosts(alias=False)
+
+        # with the alias turned off the dashed version becomes a host of
+        # its own, instead of pointing at the underscored one
+        self.assertEqual(server.hosts["netius-d"], "http://first:80")
+        self.assertEqual("netius-d" in server.alias, False)
+
+    def test__build_hosts_invalid(self):
+        server = self._make_server()
+
+        self._conf(
+            NETIUS_DA_PORT="tcp://first:80",
+            NETIUS_DB_PORT="tcp://second:80",
+            NETIUS_DB_NAME="/netius_db",
+            NETIUS_DC_ENV_PORT="tcp://third:80",
+            NETIUS_DC_ENV_NAME="/netius_dc_env",
+            NETIUS_DD_ENV_EXTRA_PORT="tcp://fourth:80",
+            NETIUS_DD_ENV_EXTRA_NAME="/netius_dd_env_extra",
+            NETIUS_DE_PORT="not-a-url",
+            NETIUS_DE_NAME="/netius_de",
+        )
+
+        server.hosts = {}
+        server._build_hosts()
+
+        # a link with no name of its own is not a service, the ones that
+        # carry the environment marker are not either
+        self.assertEqual("netius_da" in server.hosts, False)
+        self.assertEqual("netius_dc_env" in server.hosts, False)
+        self.assertEqual("netius_dd_env_extra" in server.hosts, False)
+
+        # a value that is not a URL names nothing that may be reached, so
+        # it is dropped as well
+        self.assertEqual("netius_de" in server.hosts, False)
+
+        self.assertEqual(server.hosts["netius_db"], "http://second:80")
+
+    def test__build_hosts_plain(self):
+        server = self._make_server()
+
+        self._conf(NETIUSD_PORT="tcp://first:80", NETIUSD_NAME="/netiusd")
+
+        server.hosts = {}
+        server.alias = {}
+        server._build_hosts()
+
+        # a name that carries no underscore has no dashed version of its
+        # own, so there is no alias to be registered for it
+        self.assertEqual(server.hosts["netiusd"], "http://first:80")
+        self.assertEqual(server.alias, {})
+
+    def test__build_hosts_digit(self):
+        server = self._make_server()
+
+        self._conf(NETIUS_D1_PORT="tcp://first:80", NETIUS_D1_NAME="/netius_d1")
+
+        server.hosts = {}
+        server._build_hosts()
+
+        # a numbered link whose name is numbered as well is one of the
+        # replicas of a service and not the service itself
+        self.assertEqual("netius_d1" in server.hosts, False)
+
+    def test__build_alias(self):
+        server = self._make_server()
+
+        self._conf(NETIUS_D_ALIAS="netius.com")
+
+        server.alias = {}
+        server._build_alias()
+
+        # both the underscored name and the dashed version of it point at
+        # the very same host, so that either may be used
+        self.assertEqual(server.alias["netius_d"], "netius.com")
+        self.assertEqual(server.alias["netius-d"], "netius.com")
+
+    def test__build_passwords(self):
+        server = self._make_server()
+
+        self._conf(NETIUS_D_PASSWORD="secret")
+
+        server.auth = {}
+        server._build_passwords()
+
+        # the two names share the very same authentication handler, which
+        # is a simple one built around the password
+        self.assertEqual(isinstance(server.auth["netius_d"], netius.SimpleAuth), True)
+        self.assertEqual(server.auth["netius_d"], server.auth["netius-d"])
+        self.assertEqual(server.auth["netius_d"].auth_i(None, "secret"), True)
+        self.assertEqual(server.auth["netius_d"].auth_i(None, "other"), False)
+
+    def test__build_redirect(self):
+        server = self._make_server()
+
+        self._conf(NETIUS_D_REDIRECT="netius.com")
+
+        server.redirect = {}
+        server._build_redirect()
+
+        self.assertEqual(server.redirect["netius_d"], "netius.com")
+        self.assertEqual(server.redirect["netius-d"], "netius.com")
+
+    def test__build_error_urls(self):
+        server = self._make_server()
+
+        self._conf(NETIUS_D_ERROR_URL="http://netius.com/error")
+
+        server.error_urls = {}
+        server._build_error_urls()
+
+        self.assertEqual(server.error_urls["netius_d"], "http://netius.com/error")
+        self.assertEqual(server.error_urls["netius-d"], "http://netius.com/error")
+
+    def test__build_redirect_ssl(self):
+        server = self._make_server()
+
+        self._conf(NETIUS_D_REDIRECT_SSL="1")
+
+        server.redirect = {}
+        server.alias = dict(other="netius_d")
+        server._build_redirect_ssl()
+
+        # the redirection is towards the very same name under the secure
+        # scheme, which is what the tuple carries
+        self.assertEqual(server.redirect["netius_d"], ("netius_d", "https"))
+        self.assertEqual(server.redirect["netius-d"], ("netius-d", "https"))
+
+        # the alias that points at the name is redirected as well, so that
+        # it is not left behind on the insecure scheme
+        self.assertEqual(server.redirect["other"], ("other", "https"))
+
+    def test__build_redirect_ssl_alias(self):
+        server = self._make_server()
+
+        self._conf(NETIUS_D_REDIRECT_SSL="1")
+
+        server.redirect = {}
+        server.alias = dict(other="netius_d", unrelated="another")
+        server._build_redirect_ssl(alias=False)
+
+        # with the alias turned off only the name itself is redirected,
+        # the ones that point at it being left as they are
+        self.assertEqual(server.redirect["netius_d"], ("netius_d", "https"))
+        self.assertEqual("other" in server.redirect, False)
+
+        server.redirect = {}
+        server._build_redirect_ssl()
+
+        # an alias that points elsewhere is never redirected, whatever
+        # the value of the flag
+        self.assertEqual("unrelated" in server.redirect, False)
+
+    def test__build_suffixes(self):
+        server = self._make_server(host_suffixes=["local"])
+
+        server.alias = dict(other="netius_d")
+        server.hosts = dict(netius_d="http://first:80")
+        server._build_suffixes()
+
+        # every name gains a fully qualified version of itself under the
+        # suffix, the one of a host pointing back at it
+        self.assertEqual(server.alias["other.local"], "netius_d")
+        self.assertEqual(server.alias["netius_d.local"], "netius_d")
+        self.assertEqual("netius_d.local" in server.hosts, False)
+
+    def test__build_suffixes_alias(self):
+        server = self._make_server(host_suffixes=["local"])
+
+        server.alias = dict(other="netius_d")
+        server.hosts = dict(netius_d="http://first:80")
+        server._build_suffixes(alias=False)
+
+        # with the alias turned off the qualified name of a host is a
+        # host of its own, which the aliases that exist must not change
+        self.assertEqual(server.hosts["netius_d.local"], "http://first:80")
+        self.assertEqual("netius_d.local" in server.alias, False)
+        self.assertEqual(server.alias["other.local"], "netius_d")
+
+    def test__valid_url(self):
+        server = self._make_server()
+
+        self.assertEqual(server._valid_url("http://netius.com"), True)
+        self.assertEqual(server._valid_url("tcp://first:80"), True)
+
+        # a value that carries no scheme or no host names nothing that
+        # may be reached, so neither of them qualifies
+        self.assertEqual(server._valid_url("netius.com"), False)
+        self.assertEqual(server._valid_url("http://"), False)
+
+        # the value is turned into a string before being parsed, so one
+        # that is not a string is refused instead of raising
+        self.assertEqual(server._valid_url(1), False)
+
+    def _make_server(self, **kwargs):
+        server = netius.extra.DockerProxyServer(**kwargs)
+        self.servers.append(server)
+        return server
+
+    def _conf(self, **kwargs):
+        for name, value in netius.legacy.iteritems(kwargs):
+            netius.conf_s(name, value)
+            self.names.append(name)

--- a/src/netius/test/extra/proxy_r.py
+++ b/src/netius/test/extra/proxy_r.py
@@ -65,6 +65,122 @@ class ReverseProxyServerTest(unittest.TestCase):
         unittest.TestCase.tearDown(self)
         self.server.cleanup()
 
+    def test_dns_callback(self):
+        server = netius.extra.ReverseProxyServer(hosts=dict(host="http://host.com"))
+
+        try:
+            parsed = netius.legacy.urlparse("http://host.com:8080/path")
+            resolved = [[]]
+            callback = server.dns_callback(
+                "host.com", "http://host.com:8080/path", parsed, resolved=resolved
+            )
+
+            Response = collections.namedtuple("Response", "answers")
+
+            callback(
+                Response(
+                    answers=[
+                        (None, "A", None, None, "1.1.1.1"),
+                        (None, "AAAA", None, None, "2.2.2.2"),
+                        (None, "MX", None, None, "mail.host.com"),
+                    ]
+                )
+            )
+
+            # only the answers that carry an address take part in the
+            # resolution, the port and the path of the origin being kept
+            self.assertEqual(
+                server.hosts["host.com"],
+                ("http://1.1.1.1:8080/path", "http://2.2.2.2:8080/path"),
+            )
+        finally:
+            server.cleanup()
+
+    def test_dns_callback_empty(self):
+        server = netius.extra.ReverseProxyServer(hosts=dict(host="http://host.com"))
+
+        try:
+            parsed = netius.legacy.urlparse("http://host.com")
+            callback = server.dns_callback(
+                "host.com", "http://host.com", parsed, resolved=[[]]
+            )
+
+            Response = collections.namedtuple("Response", "answers")
+
+            callback(None)
+            callback(Response(answers=[]))
+
+            # neither a resolution that failed nor one that carries no
+            # answer changes the hosts that are registered
+            self.assertEqual("host.com" in server.hosts, False)
+            self.assertEqual(server.hosts["host"], "http://host.com")
+        finally:
+            server.cleanup()
+
+    def test__echo(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        server = netius.extra.ReverseProxyServer(
+            regex=[(re.compile("^/first$"), "http://first")],
+            hosts=dict(second="http://second", first="http://first"),
+            alias=dict(alias="first"),
+            redirect=dict(old="new"),
+            error_urls=dict(first="http://first/error"),
+        )
+
+        try:
+            with mock.patch.object(server, "info") as info:
+                server._echo()
+        finally:
+            server.cleanup()
+
+        pairs = self._pairs(info)
+
+        # every one of the registrations is named by the dump, so that
+        # the running configuration may be read from the log alone
+        self.assertEqual(("http://second", None) in pairs, False)
+        self.assertEqual(("second", "http://second") in pairs, True)
+        self.assertEqual(("first", "http://first") in pairs, True)
+        self.assertEqual(("alias", "first") in pairs, True)
+        self.assertEqual(("old", "new") in pairs, True)
+        self.assertEqual(("first", "http://first/error") in pairs, True)
+
+        # the hosts are dumped in order, so that the same configuration
+        # always reads the same way whatever the order of the map
+        hosts = [pair for pair in pairs if pair[1] in ("http://first", "http://second")]
+        self.assertEqual(
+            hosts.index(("first", "http://first"))
+            < hosts.index(("second", "http://second")),
+            True,
+        )
+
+    def test__echo_sort(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        server = netius.extra.ReverseProxyServer(
+            hosts=dict(second="http://second", first="http://first")
+        )
+
+        try:
+            with mock.patch.object(server, "info") as info:
+                server._echo(sort=False)
+        finally:
+            server.cleanup()
+
+        pairs = self._pairs(info)
+
+        # without the sorting every registration is still named, only the
+        # order in which they are walked is no longer settled
+        self.assertEqual(("first", "http://first") in pairs, True)
+        self.assertEqual(("second", "http://second") in pairs, True)
+
+    def _pairs(self, info):
+        # gathers the pairs of the registration lines that were dumped,
+        # leaving out the headers that carry no value of their own
+        return [tuple(call[0][1:]) for call in info.call_args_list if len(call[0]) == 3]
+
     def test_alias(self):
         Parser = collections.namedtuple("Parser", "headers")
         parser = Parser(headers=dict(host="alias.host.com"))

--- a/src/netius/test/middleware/flood.py
+++ b/src/netius/test/middleware/flood.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius
+import netius.middleware
+
+
+class FloodMiddlewareTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.server = netius.Server(poll=netius.Poll)
+        self.server.poll.open()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+
+    def test_init(self):
+        instance = netius.middleware.FloodMiddleware(self.server)
+
+        # the limit is kept under a name of its own, as the blacklist is
+        # only built once the middleware is started
+        self.assertEqual(instance.conns_per_min, 600)
+        self.assertEqual(instance.whitelist, [])
+
+        instance = netius.middleware.FloodMiddleware(
+            self.server, conns_per_min=10, whitelist=["10.0.0.1"]
+        )
+
+        self.assertEqual(instance.conns_per_min, 10)
+        self.assertEqual(instance.whitelist, ["10.0.0.1"])
+
+    def test_start(self):
+        instance = self._register(conns_per_min=2)
+
+        # the starting builds the structures that the counting needs and
+        # keeps the limit that the constructor was given
+        self.assertEqual(instance.conns_per_min, 2)
+        self.assertEqual(instance.blacklist, [])
+        self.assertEqual(instance.conn_map, {})
+
+        # the handler is bound to the owner, so that every connection
+        # that is created reaches the counting
+        self.assertEqual(
+            instance.on_connection_c in self.server.events["connection_c"], True
+        )
+
+    def test_start_conf(self):
+        with netius.conf_override("CONNS_PER_MIN", "5"):
+            instance = self._register(conns_per_min=2)
+
+        # the configuration answers for the limit, taking precedence over
+        # the value that the constructor was given
+        self.assertEqual(instance.conns_per_min, 5)
+
+    def test_stop(self):
+        instance = self._register(conns_per_min=2)
+
+        instance.stop()
+
+        # the stopping releases the handler, so that no connection is
+        # counted once the middleware is gone
+        self.assertEqual(
+            instance.on_connection_c in self.server.events["connection_c"], False
+        )
+
+    def test_on_connection_c(self):
+        instance = self._register(conns_per_min=2)
+
+        connection = self._make_connection("10.0.0.1")
+
+        # the opening of a connection is what drives the counting, as the
+        # handler is bound to the event of the owner
+        self.assertEqual(instance.conn_map["10.0.0.1"], 1)
+
+        # one that is within the limit is left alone, as there is nothing
+        # to be defended against yet
+        self.assertEqual(connection.is_closed(), False)
+
+        self._make_connection("10.0.0.1")
+        connection = self._make_connection("10.0.0.1")
+
+        # the limit is passed by the third one, which is dropped together
+        # with the ones that follow it
+        self.assertEqual("10.0.0.1" in instance.blacklist, True)
+        self.assertEqual(connection.is_closed(), True)
+
+    def test_on_connection_c_whitelist(self):
+        instance = self._register(conns_per_min=1, whitelist=["10.0.0.1"])
+
+        for _index in range(3):
+            connection = self._make_connection("10.0.0.1")
+
+        # a host of the whitelist is never dropped, however many of the
+        # connections it makes and whatever the blacklist says
+        self.assertEqual("10.0.0.1" in instance.blacklist, True)
+        self.assertEqual(connection.is_closed(), False)
+
+    def test_on_connection_c_all(self):
+        instance = self._register(conns_per_min=2)
+        instance.blacklist.append("*")
+
+        connection = self._make_connection("10.0.0.2")
+
+        # the wildcard stands for every host, so one that was never seen
+        # before is dropped as well
+        self.assertEqual(connection.is_closed(), True)
+
+    def test__update_flood(self):
+        instance = self._register(conns_per_min=2)
+
+        instance._update_flood("10.0.0.1")
+        instance._update_flood("10.0.0.1")
+
+        # the connections of the same minute add up, which is what allows
+        # the limit to be reached at all
+        self.assertEqual(instance.conn_map["10.0.0.1"], 2)
+        self.assertEqual(instance.blacklist, [])
+
+        instance._update_flood("10.0.0.1")
+
+        self.assertEqual("10.0.0.1" in instance.blacklist, True)
+
+        # the counting is the one of a minute, so the one that follows it
+        # starts from nothing instead of carrying the previous count
+        instance.minute -= 1
+        instance._update_flood("10.0.0.2")
+
+        self.assertEqual(instance.conn_map, dict({"10.0.0.2": 1}))
+
+    def _register(self, **kwargs):
+        return self.server.register_middleware(
+            netius.middleware.FloodMiddleware, **kwargs
+        )
+
+    def _make_connection(self, host):
+        connection = netius.Connection(owner=self.server, address=(host, 8080))
+        connection.open()
+        return connection

--- a/src/netius/test/middleware/proxy.py
+++ b/src/netius/test/middleware/proxy.py
@@ -34,6 +34,11 @@ import unittest
 import netius.common
 import netius.middleware
 
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
 
 class ProxyMiddlewareTest(unittest.TestCase):
 
@@ -45,6 +50,53 @@ class ProxyMiddlewareTest(unittest.TestCase):
     def tearDown(self):
         unittest.TestCase.tearDown(self)
         self.server.cleanup()
+
+    def test_stop(self):
+        instance = self.server.register_middleware(netius.middleware.ProxyMiddleware)
+
+        instance.stop()
+
+        # the stopping releases the handler, so that a connection that is
+        # created afterwards is no longer handed a starter
+        self.assertEqual(
+            instance.on_connection_c in self.server.events["connection_c"], False
+        )
+
+        connection = netius.Connection(owner=self.server)
+        connection.open()
+
+        self.assertEqual(hasattr(connection, "_proxy_pending"), False)
+
+    def test_on_connection_c_base(self):
+        self.server.register_middleware(netius.middleware.ProxyMiddleware)
+
+        connection = netius.Connection(owner=self.server)
+        connection._base = True
+        connection.open()
+
+        # a connection that stands for the base of another one carries no
+        # header of its own, so no starter is added to it
+        self.assertEqual(hasattr(connection, "_proxy_pending"), False)
+
+    def test_on_connection_c_skip(self):
+        self.server.register_middleware(netius.middleware.ProxyMiddleware)
+
+        connection = netius.Connection(owner=self.server)
+        connection._skip_proxy = True
+        connection.open()
+
+        # the skipping is asked for by the connection itself, which is
+        # enough for the handshake never to be scheduled
+        self.assertEqual(hasattr(connection, "_proxy_pending"), False)
+
+    def test_on_connection_c_version(self):
+        self.server.register_middleware(netius.middleware.ProxyMiddleware, version=3)
+
+        connection = netius.Connection(owner=self.server)
+
+        # only the two versions of the protocol are known, so a value
+        # that names neither of them is refused
+        self.assertRaises(netius.RuntimeError, connection.open)
 
     def test_ipv4_v1(self):
         instance = self.server.register_middleware(netius.middleware.ProxyMiddleware)
@@ -108,6 +160,53 @@ class ProxyMiddlewareTest(unittest.TestCase):
         self.assertEqual(connection.restored_s, 18)
         self.assertEqual(len(connection.restored), 2)
 
+    def test_starter_v1_eof(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        instance = self.server.register_middleware(netius.middleware.ProxyMiddleware)
+
+        connection = netius.Connection(owner=self.server)
+        connection.open()
+
+        with mock.patch.object(self.server, "exec_safe", return_value=b""):
+            instance._proxy_handshake_v1(connection)
+
+        # an empty read is the peer that is gone, so the connection is
+        # closed instead of being waited for any longer
+        self.assertEqual(connection.is_closed(), True)
+
+    def test_starter_v1_buffer(self):
+        instance = self.server.register_middleware(netius.middleware.ProxyMiddleware)
+
+        connection = netius.Connection(owner=self.server)
+        connection.open()
+
+        # the part of the header that was already read is kept in the
+        # buffer of the connection, which the next run takes up again
+        connection._proxy_buffer = bytearray(b"PROXY TCP4 192.168.1.1 ")
+        connection.restore(b"192.168.1.2 32598 8080\r\n")
+        connection.run_starter()
+
+        self.assertEqual(connection.address, ("192.168.1.1", 32598))
+
+    def test_starter_v1_blocked(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        instance = self.server.register_middleware(netius.middleware.ProxyMiddleware)
+
+        connection = netius.Connection(owner=self.server)
+        connection.open()
+
+        with mock.patch.object(self.server, "exec_safe", return_value=False):
+            instance._proxy_handshake_v1(connection)
+
+        # a read that was blocked gives neither data nor failure, so the
+        # handshake steps back and waits to be run again
+        self.assertEqual(connection.is_closed(), False)
+        self.assertEqual(connection._proxy_pending, True)
+
     def test_starter_v2(self):
         self.server.register_middleware(netius.middleware.ProxyMiddleware, version=2)
 
@@ -138,6 +237,87 @@ class ProxyMiddlewareTest(unittest.TestCase):
         self.assertEqual(connection.address, ("192.168.1.1", 32598))
         self.assertEqual(connection.restored_s, 0)
         self.assertEqual(len(connection.restored), 0)
+
+    def test_starter_v2_eof(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        instance = self.server.register_middleware(
+            netius.middleware.ProxyMiddleware, version=2
+        )
+
+        connection = netius.Connection(owner=self.server)
+        connection.open()
+
+        with mock.patch.object(self.server, "exec_safe", return_value=b""):
+            instance._proxy_handshake_v2(connection)
+
+        # the reading of the header ends the very same way, the peer
+        # being gone before it was ever complete
+        self.assertEqual(connection.is_closed(), True)
+
+    def test_starter_v2_ipv6(self):
+        self.server.register_middleware(netius.middleware.ProxyMiddleware, version=2)
+
+        connection = netius.Connection(owner=self.server)
+        connection.open()
+
+        body = struct.pack(
+            "!QQQQHH",
+            0xFE80000000000000,
+            0x787FF63F3176D61B,
+            0xFE80000000000000,
+            0x787FF63F3176D61C,
+            32598,
+            8080,
+        )
+
+        connection.restore(self._header_v2(len(body), address=self._AF_INET6))
+        connection.restore(body)
+        connection.run_starter()
+
+        # the address of the six family travels as four words, which are
+        # joined back into the two addresses that the message carries
+        self.assertEqual(
+            connection.address, ("fe80:0000:0000:0000:787f:f63f:3176:d61b", 32598)
+        )
+        self.assertEqual(len(connection.restored), 0)
+
+    def test_starter_v2_family(self):
+        instance = self.server.register_middleware(
+            netius.middleware.ProxyMiddleware, version=2
+        )
+
+        connection = netius.Connection(owner=self.server)
+        connection.open()
+
+        connection.restore(self._header_v2(12, address=0x0F))
+        connection.restore(b"x" * 12)
+
+        # a family that is neither of the two known ones names an address
+        # that cannot be read, so the message is refused
+        self.assertRaises(
+            netius.RuntimeError, lambda: instance._proxy_handshake_v2(connection)
+        )
+
+    def test_starter_v2_blocked(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        instance = self.server.register_middleware(
+            netius.middleware.ProxyMiddleware, version=2
+        )
+
+        connection = netius.Connection(owner=self.server)
+        connection.open()
+
+        with mock.patch.object(self.server, "exec_safe", return_value=False):
+            instance._proxy_handshake_v2(connection)
+
+        # the header is never read in full, so neither the buffer nor the
+        # header of the connection carry anything yet
+        self.assertEqual(connection.is_closed(), False)
+        self.assertEqual(hasattr(connection, "_proxy_header"), False)
 
     def test_pending_flag_v1(self):
         self.server.register_middleware(netius.middleware.ProxyMiddleware)
@@ -250,3 +430,18 @@ class ProxyMiddlewareTest(unittest.TestCase):
         connection.open()
 
         self.assertFalse(hasattr(connection, "_proxy_pending"))
+
+    _AF_INET6 = netius.middleware.ProxyMiddleware.AF_INET6_v2
+
+    def _header_v2(self, body_size, address=None):
+        # builds the header of a version two message for the provided body
+        # size, defaulting the family to the four based one
+        cls = netius.middleware.ProxyMiddleware
+        address = cls.AF_INET_v2 if address == None else address
+        return struct.pack(
+            "!12sBBH",
+            cls.HEADER_MAGIC_V2,
+            (2 << 4) + cls.TYPE_PROXY_V2,
+            (address << 4) + cls.PROTO_STREAM_v2,
+            body_size,
+        )


### PR DESCRIPTION
Step 4 of #102.

## What this carries

The proxy and middleware tail, four of the six modules that #102 names, together with the ratchet raised to the figure that they reach.

Three defects that the tests found along the way are fixed with them.

## Phase 4, the proxy and middleware tail

Every figure below is measured on Python 3.14, which is the interpreter that the coverage job runs on all three platforms.

| Module | Before | After |
| --- | --- | --- |
| `middleware/flood.py` | 28.8% | 100.0% |
| `extra/proxy_d.py` | 13.2% | 98.4% |
| `middleware/proxy.py` | 79.6% | 96.5% |
| `extra/proxy_r.py` | 68.3% | 82.8% |
| `servers/proxy.py` | 79.8% | 81.6% |
| `extra/proxy_c.py` | 82.3% | 82.3% |
| **together** | **71.9%** | **84.8%** |

The package as a whole moves from 67.4% to 68.6% as the coverage job reports it over the three platforms, so its floor goes from 66 to 67.

The two modules that are still short of the target carry the work that is left of this step. What remains uncovered in them is the Consul discovery of `extra/proxy_c.py`, which speaks HTTP to a catalogue over a background thread, and the connection handling of `servers/proxy.py`, which is driven by a live socket. Neither of them lends itself to the shape of the cases used so far, so they are better taken on their own.

## The three defects

**The flood avoidance was unable to start.** The constructor stored the limit of connections per minute under the name of the blacklist, leaving the limit itself never set, so the very first thing that `start` does raised over it:

```
AttributeError: 'FloodMiddleware' object has no attribute 'conns_per_min'
```

Registering the middleware on a server is what starts it, so the component could not be used at all.

**The flood avoidance never counted past one.** The map of the connections of a minute was cleared while the minute held, instead of when it turned, so every connection reset the count of the host that made it. With the limit never reached the blacklist stayed empty for ever, which is the whole of what the middleware is for. Measured before the fix, with a limit of two:

```
connections made   : 5
conn_map           : {'10.0.0.1': 1}
blacklist          : []
```

**The Docker proxy ignored the alias flag of a host suffix.** The loop over the aliases took the name of the flag that decides where a suffixed host is registered, so once any alias existed the flag was read as that leftover name, which is a non empty string. A suffixed host was then registered as an alias whatever the caller asked for. Measured before the fix, with one alias already there:

```
alias=True  -> alias: ['first.local', 'other', 'other.local']   hosts: ['first']
alias=False -> alias: ['first.local', 'other', 'other.local']   hosts: ['first']
```

All three are covered by tests that fail without the fix, the flood ones by every case of their module, as none of them was able to reach a started middleware.

## What else stays uncovered

`extra/proxy_d.py` keeps only its `__main__` block, and `middleware/proxy.py` keeps the guard of a handshake timeout that no case reaches.

## Validation

Suite status: 1500 passed and 7 skipped on Linux with Python 3.14, 1499 passed and 8 skipped on macOS, 51 of the tests being new. The suite was also run under Python 2.7, where it reports 1182 passed and 321 skipped. `black --check` is clean over 356 files and `mypy.stubtest` reports no issues in 132 modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes change live connection throttling and Docker proxy host/alias registration; behavior is more strict once flood limits apply, but the prior logic was broken or inert.
> 
> **Overview**
> Adds broad unit coverage for **Docker proxy**, **reverse proxy**, **flood avoidance**, and **PROXY protocol** middleware, and raises the CI coverage floor from **66% to 67%** to match the new total.
> 
> **Production fixes (three bugs found by the new tests):**
> 
> **FloodMiddleware** — The constructor stored the per-minute limit on `self.blacklist` instead of `self.conns_per_min`, so `start()` crashed on register. **Per-minute counting** cleared `conn_map` on every connection in the same minute instead of only when the minute rolled over, so limits were never hit and hosts were never blocked.
> 
> **DockerProxyServer** — In `_build_suffixes`, the alias loop reused the name `alias`, shadowing the `alias=` flag and forcing suffixed hosts into aliases even when callers passed `alias=False`.
> 
> **Tests** — New suites for `DockerProxyServer` configuration builders and `FloodMiddleware` lifecycle; expanded `ReverseProxyServer` DNS/`_echo` tests and `ProxyMiddleware` stop, skip paths, v1/v2 handshake edge cases (EOF, blocked read, IPv6, invalid family).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c608cf8985f9dea055775c6334c487bcbeec4f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->