### PR TITLE
test(torrent,dht): cover the peer messages and the iterative lookup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           pip install coverage
           coverage combine
-          coverage report --sort=-miss --fail-under=67
+          coverage report --sort=-miss --fail-under=68
       - name: Publish coverage summary
         run: |
           echo "## Coverage" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A flood avoidance middleware can now be started, instead of failing on the limit of a minute
 * A host that floods is now blocked, as the count of a minute is no longer reset by every connection
 * A host suffix of the Docker proxy is now registered where it was asked to be
+* A ping of a DHT node now reaches the node that was named instead of the local default
 * A stored password that carries a separator no longer breaks the authentication
 * An asynchronous file operation that is not a known one is now refused instead of being ignored
+* The port that a torrent peer announces is now read whatever the size of the message
 * Two WebSocket frames that arrive together are now both handled instead of the second being swallowed
 
 ## [1.63.0] - 2026-08-29

--- a/src/netius/clients/dht.py
+++ b/src/netius/clients/dht.py
@@ -315,7 +315,9 @@ class DHTClient(netius.DatagramClient):
     """
 
     def ping(self, host, port, peer_id, *args, **kwargs):
-        return self.query(type="ping", *args, **kwargs)
+        return self.query(
+            host=host, port=port, peer_id=peer_id, type="ping", *args, **kwargs
+        )
 
     def find_node(self, *args, **kwargs):
         return self.query(type="find_node", *args, **kwargs)

--- a/src/netius/clients/dht.py
+++ b/src/netius/clients/dht.py
@@ -315,9 +315,7 @@ class DHTClient(netius.DatagramClient):
     """
 
     def ping(self, host, port, peer_id, *args, **kwargs):
-        return self.query(
-            host=host, port=port, peer_id=peer_id, type="ping", *args, **kwargs
-        )
+        return self.query(host, port, peer_id, "ping", *args, **kwargs)
 
     def find_node(self, *args, **kwargs):
         return self.query(type="find_node", *args, **kwargs)

--- a/src/netius/clients/torrent.py
+++ b/src/netius/clients/torrent.py
@@ -201,7 +201,7 @@ class TorrentConnection(netius.Connection):
         self.trigger("piece", self, data, index, begin)
 
     def port_t(self, data):
-        (port,) = struct.unpack("!H", data[:8])
+        (port,) = struct.unpack("!H", data[:2])
         self.task.set_dht(self.address, port)
 
     def extended_t(self, data):

--- a/src/netius/test/clients/dht.py
+++ b/src/netius/test/clients/dht.py
@@ -316,6 +316,20 @@ class DHTClientTest(unittest.TestCase):
         self.assertEqual(self.client.queries[0]["peer_id"], b"a" * 20)
         self.assertEqual(self.client.queries[0]["type"], "ping")
 
+    def test_ping_callback(self):
+        def handler(response):
+            pass
+
+        self.client.ping("1.2.3.4", 6881, b"a" * 20, handler)
+
+        # the callback may be given right after the contact, the values
+        # that follow it reaching the query in the very same order
+        self.assertEqual(self.client.queries[0]["host"], "1.2.3.4")
+        self.assertEqual(self.client.queries[0]["port"], 6881)
+        self.assertEqual(self.client.queries[0]["peer_id"], b"a" * 20)
+        self.assertEqual(self.client.queries[0]["type"], "ping")
+        self.assertEqual(self.client.queries[0]["callback"], handler)
+
     def test_find_node(self):
         self.client.find_node(host="1.2.3.4", port=6881, target=b"b" * 20)
 
@@ -552,8 +566,19 @@ class _MockDHTClient(netius.clients.DHTClient):
         self.queries = []
         self._routing = None
 
-    def query(self, host="127.0.0.1", port=9090, peer_id=None, type="ping", **kwargs):
-        query = dict(host=host, port=port, peer_id=peer_id, type=type)
+    def query(
+        self,
+        host="127.0.0.1",
+        port=9090,
+        peer_id=None,
+        type="ping",
+        callback=None,
+        *args,
+        **kwargs
+    ):
+        query = dict(
+            host=host, port=port, peer_id=peer_id, type=type, callback=callback
+        )
         query.update(kwargs)
         self.queries.append(query)
 

--- a/src/netius/test/clients/dht.py
+++ b/src/netius/test/clients/dht.py
@@ -28,11 +28,18 @@ __copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
+import socket
 import struct
 import unittest
 
+import netius
 import netius.common
 import netius.clients
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
 
 
 class DHTRequestTest(unittest.TestCase):
@@ -48,6 +55,60 @@ class DHTRequestTest(unittest.TestCase):
         self.assertEqual(info["y"], "q")
         self.assertEqual(info["q"], "get_peers")
         self.assertEqual(info["a"]["info_hash"], "b" * 20)
+
+    def test_contact(self):
+        contact = netius.clients.DHTRequest.contact("1.2.3.4", 6881)
+
+        # a contact is the address and the port of a node packed into the
+        # six bytes that the specification names
+        self.assertEqual(len(contact), 6)
+        self.assertEqual(contact, struct.pack("!LH", 0x01020304, 6881))
+
+    def test_request_invalid(self):
+        request = netius.clients.DHTRequest(
+            b"a" * 20, host="1.2.3.4", port=6881, type="invalid"
+        )
+
+        # a type that names no query of the protocol is refused, as there
+        # is no payload that may be built for it
+        self.assertRaises(netius.ParserError, request.request)
+
+    def test_find_node(self):
+        request = netius.clients.DHTRequest(
+            b"a" * 20, host="1.2.3.4", port=6881, type="find_node", target=b"b" * 20
+        )
+
+        self.assertEqual(request.find_node(), dict(id=b"a" * 20, target=b"b" * 20))
+
+    def test_get_peers(self):
+        request = netius.clients.DHTRequest(
+            b"a" * 20, host="1.2.3.4", port=6881, type="get_peers", info_hash=b"b" * 20
+        )
+
+        self.assertEqual(request.get_peers(), dict(id=b"a" * 20, info_hash=b"b" * 20))
+
+    def test_announce_peer(self):
+        request = netius.clients.DHTRequest(
+            b"a" * 20,
+            host="1.2.3.4",
+            port=6881,
+            type="announce_peer",
+            implied_port=1,
+            info_hash=b"b" * 20,
+            port_v=6881,
+            token=b"token",
+        )
+        request.kwargs["port"] = 6881
+
+        payload = request.announce_peer()
+
+        # the announcement carries the token that the peers query gave
+        # back, which is what the node uses to accept it
+        self.assertEqual(payload["id"], b"a" * 20)
+        self.assertEqual(payload["info_hash"], b"b" * 20)
+        self.assertEqual(payload["implied_port"], 1)
+        self.assertEqual(payload["port"], 6881)
+        self.assertEqual(payload["token"], b"token")
 
     def test_peer_id_length(self):
         request = netius.clients.DHTRequest(
@@ -215,6 +276,16 @@ class DHTRoutingTableTest(unittest.TestCase):
         self.assertEqual(result[0].host, "2.2.2.2")
         self.assertEqual(result[1].host, "1.1.1.1")
 
+    def test_add_self(self):
+        routing = netius.clients.DHTRoutingTable(b"\x00" * 20)
+        node = netius.clients.DHTNode(b"\x00" * 20, host="1.2.3.4", port=6881)
+
+        routing.add(node)
+
+        # a node whose identifier is the one of the table itself is at no
+        # distance from it, which is the first of the buckets
+        self.assertEqual(routing.closest(b"\x00" * 20), [node])
+
     def test_closest_count(self):
         routing = netius.clients.DHTRoutingTable(b"\x00" * 20)
 
@@ -234,6 +305,28 @@ class DHTClientTest(unittest.TestCase):
     def setUp(self):
         unittest.TestCase.setUp(self)
         self.client = _MockDHTClient()
+
+    def test_ping(self):
+        self.client.ping("1.2.3.4", 6881, b"a" * 20)
+
+        # the contact that is given is the one that is queried, instead of
+        # the defaults of the query being used in its place
+        self.assertEqual(self.client.queries[0]["host"], "1.2.3.4")
+        self.assertEqual(self.client.queries[0]["port"], 6881)
+        self.assertEqual(self.client.queries[0]["peer_id"], b"a" * 20)
+        self.assertEqual(self.client.queries[0]["type"], "ping")
+
+    def test_find_node(self):
+        self.client.find_node(host="1.2.3.4", port=6881, target=b"b" * 20)
+
+        self.assertEqual(self.client.queries[0]["type"], "find_node")
+        self.assertEqual(self.client.queries[0]["target"], b"b" * 20)
+
+    def test_get_peers(self):
+        self.client.get_peers(host="1.2.3.4", port=6881, info_hash=b"b" * 20)
+
+        self.assertEqual(self.client.queries[0]["type"], "get_peers")
+        self.assertEqual(self.client.queries[0]["info_hash"], b"b" * 20)
 
     def test_routing(self):
         routing = self.client.routing(b"\x00" * 20)
@@ -273,6 +366,75 @@ class DHTClientTest(unittest.TestCase):
         self.assertEqual(self.client.queries[0]["type"], "get_peers")
         self.assertEqual(self.client.queries[0]["info_hash"], b"\x01" * 20)
 
+    def test_lookup_response(self):
+        peers = self.client.lookup(
+            b"\x00" * 20, b"\x01" * 20, nodes=(("1.2.3.4", 6881),)
+        )
+        callback = self.client.queries[0]["callback"]
+
+        response = netius.clients.DHTResponse(b"")
+        response.info = dict(
+            r=dict(nodes=_contact(b"b" * 20, "5.6.7.8", 1234), values=["peer"])
+        )
+        response.request = netius.clients.DHTRequest(
+            b"\x00" * 20, host="1.2.3.4", port=6881, type="find_node"
+        )
+
+        callback(response)
+
+        # the peers of the answer are gathered and the nodes that came
+        # with it are queried in turn, which is what drives the lookup
+        self.assertEqual(peers, ["peer"])
+        self.assertEqual(len(self.client.queries), 2)
+        self.assertEqual(self.client.queries[1]["host"], "5.6.7.8")
+
+        # the node of the answer is folded into the routing table, so
+        # that it may be reached again without another lookup
+        routing = self.client.routing(b"\x00" * 20)
+        self.assertEqual(len(routing.closest(b"\x01" * 20)), 1)
+
+    def test_lookup_response_invalid(self):
+        self.client.lookup(b"\x00" * 20, b"\x01" * 20, nodes=(("1.2.3.4", 6881),))
+        callback = self.client.queries[0]["callback"]
+
+        callback(None)
+
+        # an answer that never came carries nothing to be gathered, so
+        # no further node is queried for it
+        self.assertEqual(len(self.client.queries), 1)
+
+    def test_lookup_response_callback(self):
+        received = []
+
+        self.client.lookup(
+            b"\x00" * 20,
+            b"\x01" * 20,
+            nodes=(("1.2.3.4", 6881),),
+            callback=lambda response: received.append(response),
+        )
+        callback = self.client.queries[0]["callback"]
+
+        response = netius.clients.DHTResponse(b"")
+        response.info = dict(r=dict())
+        response.request = netius.clients.DHTRequest(
+            b"\x00" * 20, host="1.2.3.4", port=6881, type="find_node"
+        )
+
+        callback(response)
+
+        # the callback of the caller is handed every answer, so that the
+        # progress of the lookup may be followed by it
+        self.assertEqual(received, [response])
+
+    def test_lookup_invalid(self):
+        nodes = (("0.0.0.0", 6881), ("1.2.3.4", 0))
+
+        self.client.lookup(b"\x00" * 20, b"\x01" * 20, nodes=nodes)
+
+        # neither the unspecified address nor a port outside of the range
+        # names a contact that a datagram may be sent to
+        self.assertEqual(self.client.queries, [])
+
     def test_lookup_unique(self):
         nodes = (("1.2.3.4", 6881), ("1.2.3.4", 6881))
 
@@ -281,6 +443,107 @@ class DHTClientTest(unittest.TestCase):
         # verifies that the same host is only queried once even when
         # it is present more than once in the initial set of nodes
         self.assertEqual(len(self.client.queries), 1)
+
+
+class DHTClientDataTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.client = _SendDHTClient(poll=netius.Poll, auto_close=False)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.client.cleanup()
+
+    def test_query(self):
+        self.client.query(host="1.2.3.4", port=6881, peer_id=b"a" * 20, type="ping")
+
+        data, address = self.client.sent[0]
+        info = netius.common.bdecode(data)
+
+        # the query travels towards the contact that was named and is kept
+        # as pending, so that the answer to it may be matched later on
+        self.assertEqual(address, ("1.2.3.4", 6881))
+        self.assertEqual(info["q"], "ping")
+        self.assertEqual(len(self.client.requests), 1)
+
+    def test_on_data(self):
+        self.client.query(host="1.2.3.4", port=6881, peer_id=b"a" * 20, type="ping")
+
+        request = self.client.requests[0]
+        received = []
+        request.callback = lambda response: received.append(response)
+
+        message = dict(t=str(request.id), y="r", r=dict(id=b"b" * 20))
+        self.client.on_data(("1.2.3.4", 6881), netius.common.bencode(message))
+
+        # the answer is matched against the request that it answers, whose
+        # callback is then handed the response
+        self.assertEqual(len(received), 1)
+        self.assertEqual(len(self.client.requests), 0)
+
+    def test_on_data_malformed(self):
+        self.client.on_data(("1.2.3.4", 6881), b"d1:ad2:id20:")
+
+        # a datagram that cannot be read is dropped in silence, as it may
+        # be a foreign one that reached the socket by chance
+        self.assertEqual(len(self.client.requests), 0)
+
+    def test__bootstrap_nodes(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        def gethostbyname(host):
+            if host == netius.clients.dht.BOOTSTRAP_NODES[0][0]:
+                raise socket.error("unable to resolve")
+            return "1.2.3.4"
+
+        with mock.patch("socket.gethostbyname", gethostbyname):
+            nodes = self.client._bootstrap_nodes()
+
+        # the well known nodes are named by host and have to be resolved,
+        # the ones that cannot be are skipped instead of breaking the rest
+        self.assertEqual(len(nodes), len(netius.clients.dht.BOOTSTRAP_NODES) - 1)
+        self.assertEqual(nodes[0][0], "1.2.3.4")
+
+    def test_on_data_dht_unknown(self):
+        response = netius.clients.DHTResponse(b"")
+        response.info = dict(t="42")
+
+        self.client.on_data_dht(("1.2.3.4", 6881), response)
+
+        # an answer that matches no request of the client is dropped, as
+        # there is nobody waiting to be told about it
+        self.assertEqual(len(self.client.requests), 0)
+
+    def test_on_data_dht_silent(self):
+        self.client.query(host="1.2.3.4", port=6881, peer_id=b"a" * 20, type="ping")
+
+        request = self.client.requests[0]
+        request.callback = None
+
+        response = netius.clients.DHTResponse(b"")
+        response.info = dict(t=str(request.id))
+
+        self.client.on_data_dht(("1.2.3.4", 6881), response)
+
+        # a request that carries no callback is still cleared, so that the
+        # answer to it is never handled a second time
+        self.assertEqual(len(self.client.requests), 0)
+
+
+class _SendDHTClient(netius.clients.DHTClient):
+    """
+    Variant of the client that keeps the datagrams that it
+    sends instead of handing them to a socket.
+    """
+
+    def __init__(self, *args, **kwargs):
+        netius.clients.DHTClient.__init__(self, *args, **kwargs)
+        self.sent = []
+
+    def send(self, data, address, *args, **kwargs):
+        self.sent.append((data, address))
 
 
 class _MockDHTClient(netius.clients.DHTClient):

--- a/src/netius/test/clients/torrent.py
+++ b/src/netius/test/clients/torrent.py
@@ -38,6 +38,214 @@ import netius.clients
 
 class TorrentConnectionTest(unittest.TestCase):
 
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.client = netius.clients.TorrentClient(poll=netius.Poll, auto_close=False)
+        self.client.poll.open()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.client.cleanup()
+
+    def test_init(self):
+        connection = self._make_connection()
+
+        # a connection starts in the handshake state and choked, with no
+        # request of its own and nothing downloaded yet
+        self.assertEqual(connection.state, netius.clients.torrent.HANDSHAKE_STATE)
+        self.assertEqual(connection.choked, netius.clients.torrent.CHOKED)
+        self.assertEqual(connection.max_requests, 50)
+        self.assertEqual(connection.pend_requests, 0)
+        self.assertEqual(connection.requests, [])
+        self.assertEqual(connection.messages, 0)
+        self.assertEqual(connection.downloaded, 0)
+        self.assertEqual(connection.metadata, [])
+
+    def test_open(self):
+        connection = self._make_connection()
+
+        connection.open()
+
+        # the opening builds the parser of the protocol, which is what
+        # turns the bytes of the peer into the messages of it
+        self.assertEqual(connection.is_open(), True)
+        self.assertEqual(
+            isinstance(connection.parser, netius.common.TorrentParser), True
+        )
+
+    def test_close(self):
+        connection = self._make_connection()
+        connection.open()
+        connection.parser = _MockTorrentParser()
+
+        connection.close()
+
+        # the parser is released together with the connection, so that
+        # nothing of it is left behind
+        self.assertEqual(connection.is_closed(), True)
+        self.assertEqual(connection.parser.destroyed, True)
+
+    def test_on_close(self):
+        connection = self._make_connection()
+        connection.requests = [(0, 0), (1, 16384)]
+        connection.pend_requests = 2
+
+        connection.on_close(connection)
+
+        # the closing gives the blocks that were asked for back to the
+        # task, as this peer is no longer going to serve them
+        self.assertEqual(connection.task.pushed, [(0, 0), (1, 16384)])
+        self.assertEqual(connection.requests, [])
+
+    def test_parse(self):
+        connection = self._make_connection()
+        connection.open()
+        connection.parser = _MockTorrentParser()
+
+        connection.parse(b"data")
+
+        # the parsing is handed to the parser of the connection, which is
+        # the one that knows the shape of the protocol
+        self.assertEqual(connection.parser.parsed, [b"data"])
+
+    def test_on_handshake(self):
+        connection = _MockTorrentConnection()
+
+        connection.on_handshake(b"BitTorrent protocol", 0, b"i" * 20, b"p" * 20)
+
+        # the peer is remembered and the connection leaves the handshake,
+        # announcing the interest and the unchoking of the peer
+        self.assertEqual(connection.peer_id, b"p" * 20)
+        self.assertEqual(connection.state, netius.clients.torrent.NORMAL_STATE)
+        self.assertEqual(len(connection.sent), 2)
+
+    def test_on_handshake_extended(self):
+        connection = _MockTorrentConnection()
+
+        connection.on_handshake(
+            b"BitTorrent protocol",
+            netius.clients.torrent.EXTENDED_RESERVED,
+            b"i" * 20,
+            b"p" * 20,
+        )
+
+        # a peer that announces the extension protocol is answered with the
+        # extended handshake, as the metadata of the task is not there yet
+        self.assertEqual(len(connection.sent), 3)
+
+    def test_on_message(self):
+        connection = _MockTorrentConnection()
+
+        connection.on_message(2, "bitfield", b"\xff")
+
+        # the message is routed to the handler of its type and counted, as
+        # the count is what tells a connection that is alive apart
+        self.assertEqual(connection.bitfield, [True] * 8)
+        self.assertEqual(connection.messages, 1)
+
+    def test_handle(self):
+        connection = _MockTorrentConnection()
+
+        connection.handle("bitfield", b"\x80")
+
+        self.assertEqual(connection.bitfield[0], True)
+
+        # a type that names no handler of the connection is dropped, so
+        # that an unknown message never breaks the parsing
+        connection.handle("unknown", b"data")
+
+        self.assertEqual(connection.sent, [])
+
+    def test_bitfield_t(self):
+        connection = _MockTorrentConnection()
+
+        connection.bitfield_t(b"\xa0")
+
+        # every bit of the field stands for a piece that the peer holds,
+        # the most significant one being the first of them
+        self.assertEqual(
+            connection.bitfield, [True, False, True, False, False, False, False, False]
+        )
+
+    def test_choke_t(self):
+        connection = _MockTorrentConnection()
+        connection.choked = netius.clients.torrent.UNCHOKED
+        connection.requests = [(0, 0)]
+        connection.pend_requests = 1
+
+        connection.choke_t(b"")
+
+        # the choking gives the blocks that were asked for back to the
+        # task, as they are no longer going to be served
+        self.assertEqual(connection.choked, netius.clients.torrent.CHOKED)
+        self.assertEqual(connection.requests, [])
+        self.assertEqual(connection.task.pushed, [(0, 0)])
+        self.assertEqual(connection.triggered[0][0], "choked")
+
+    def test_choke_t_repeated(self):
+        connection = _MockTorrentConnection()
+        connection.choked = netius.clients.torrent.CHOKED
+
+        connection.choke_t(b"")
+
+        # a peer that is already choking is not choked again, so that no
+        # event is triggered for a state that did not change
+        self.assertEqual(connection.triggered, [])
+
+    def test_unchoke_t(self):
+        connection = _MockTorrentConnection()
+        connection.choked = netius.clients.torrent.CHOKED
+
+        connection.unchoke_t(b"")
+
+        # the unchoking clears the requests that were pending and asks the
+        # task for the blocks that are going to be requested next
+        self.assertEqual(connection.choked, netius.clients.torrent.UNCHOKED)
+        self.assertEqual(connection.requests, [])
+        self.assertEqual(connection.triggered[0][0], "unchoked")
+
+    def test_unchoke_t_repeated(self):
+        connection = _MockTorrentConnection()
+        connection.choked = netius.clients.torrent.UNCHOKED
+
+        connection.unchoke_t(b"")
+
+        self.assertEqual(connection.triggered, [])
+
+    def test_piece_t(self):
+        connection = _MockTorrentConnection()
+        connection.requests = [(1, 16384)]
+        connection.pend_requests = 1
+
+        data = struct.pack("!LL", 1, 16384) + b"payload"
+        connection.piece_t(data)
+
+        # the block reaches the task at the offset that the message names
+        # and the request that it answers is no longer pending
+        self.assertEqual(connection.task.data, [(b"payload", 1, 16384)])
+        self.assertEqual(connection.downloaded, 7)
+        self.assertEqual(connection.requests, [])
+        self.assertEqual(connection.pend_requests, 0)
+        self.assertEqual(connection.triggered[0][0], "piece")
+
+    def test_port_t(self):
+        connection = _MockTorrentConnection()
+
+        connection.port_t(struct.pack("!H", 6881))
+
+        # the port of the DHT node of the peer is handed to the task, so
+        # that the node may be reached later on
+        self.assertEqual(connection.task.dht, (connection.address, 6881))
+
+    def test_port_t_extra(self):
+        connection = _MockTorrentConnection()
+
+        # only the two bytes of the port are read, so a message that
+        # carries more than that is still understood
+        connection.port_t(struct.pack("!H", 6881) + b"extra")
+
+        self.assertEqual(connection.task.dht, (connection.address, 6881))
+
     def test_extended_t(self):
         connection = _MockTorrentConnection()
         connection.extensions = dict(ut_metadata=1)
@@ -124,6 +332,155 @@ class TorrentConnectionTest(unittest.TestCase):
         self.assertEqual(connection.metadata, [None])
         self.assertEqual(connection.task.metadata, None)
 
+    def test_next(self):
+        connection = _MockTorrentConnection()
+        connection.choked = netius.clients.torrent.UNCHOKED
+        connection.max_requests = 3
+        connection.task.metadata = True
+        connection.task.blocks = [(0, 0, 16384), (0, 16384, 16384)]
+
+        connection.next()
+
+        # a block is asked for the peer for as long as the task has them,
+        # each of them being counted as a request that is pending
+        self.assertEqual(len(connection.sent), 2)
+        self.assertEqual(connection.requests, [(0, 0), (0, 16384)])
+        self.assertEqual(connection.pend_requests, 2)
+
+    def test_next_choked(self):
+        connection = _MockTorrentConnection()
+        connection.choked = netius.clients.torrent.CHOKED
+        connection.task.metadata = True
+        connection.task.blocks = [(0, 0, 16384)]
+
+        connection.next()
+
+        # a peer that is choking serves nothing, so no block is ever
+        # asked for while that is the case
+        self.assertEqual(connection.sent, [])
+
+    def test_next_metadata(self):
+        connection = _MockTorrentConnection()
+        connection.choked = netius.clients.torrent.UNCHOKED
+        connection.task.blocks = [(0, 0, 16384)]
+
+        connection.next()
+
+        # without the metadata of the task there is no piece to be asked
+        # for, as the shape of the content is still unknown
+        self.assertEqual(connection.sent, [])
+
+    def test_add_request(self):
+        connection = _MockTorrentConnection()
+
+        connection.add_request((0, 0))
+
+        self.assertEqual(connection.requests, [(0, 0)])
+        self.assertEqual(connection.pend_requests, 1)
+
+    def test_remove_request(self):
+        connection = _MockTorrentConnection()
+        connection.requests = [(0, 0)]
+        connection.pend_requests = 1
+
+        connection.remove_request((0, 0))
+
+        self.assertEqual(connection.requests, [])
+        self.assertEqual(connection.pend_requests, 0)
+
+        # a block that was never asked for is not removed, so that the
+        # count of the pending ones is not thrown off by it
+        connection.remove_request((1, 0))
+
+        self.assertEqual(connection.pend_requests, 0)
+
+    def test_reset(self):
+        connection = _MockTorrentConnection()
+        connection.requests = [(0, 0), (0, 16384)]
+        connection.pend_requests = 2
+
+        connection.reset()
+
+        self.assertEqual(connection.requests, [])
+        self.assertEqual(connection.pend_requests, 0)
+
+    def test_release(self):
+        connection = _MockTorrentConnection()
+        connection.requests = [(0, 0), (1, 16384)]
+        connection.pend_requests = 2
+
+        connection.release()
+
+        # the blocks that were asked for are given back to the task, so
+        # that another peer may be asked for them instead
+        self.assertEqual(connection.task.pushed, [(0, 0), (1, 16384)])
+        self.assertEqual(connection.requests, [])
+
+    def test_handshake(self):
+        connection = _MockTorrentConnection()
+
+        connection.handshake()
+
+        data = connection.sent[0]
+
+        # the handshake names the protocol, the reserved bits, the hash of
+        # the task and the identifier of the local peer, in that order
+        self.assertEqual(len(data), 68)
+        self.assertEqual(data[0:1], struct.pack("!B", 19))
+        self.assertEqual(data[1:20], b"BitTorrent protocol")
+        self.assertEqual(
+            data[20:28], struct.pack("!Q", netius.clients.torrent.EXTENDED_RESERVED)
+        )
+        self.assertEqual(data[28:48], b"i" * 20)
+        self.assertEqual(data[48:68], b"netius-peer-id-00000")
+
+    def test_keep_alive(self):
+        connection = _MockTorrentConnection()
+
+        connection.keep_alive()
+
+        # the message that keeps a connection alive carries no payload at
+        # all, only the length of zero that names it
+        self.assertEqual(connection.sent, [struct.pack("!L", 0)])
+
+    def test_choke(self):
+        connection = _MockTorrentConnection()
+
+        connection.choke()
+        connection.unchoke()
+        connection.interested()
+        connection.not_interested()
+
+        # the four messages of the state of a peer share a shape, only the
+        # identifier of each of them telling them apart
+        self.assertEqual(
+            connection.sent,
+            [
+                struct.pack("!LB", 1, 0),
+                struct.pack("!LB", 1, 1),
+                struct.pack("!LB", 1, 2),
+                struct.pack("!LB", 1, 3),
+            ],
+        )
+
+    def test_have(self):
+        connection = _MockTorrentConnection()
+
+        connection.have(3)
+
+        self.assertEqual(connection.sent, [struct.pack("!LBL", 5, 4, 3)])
+
+    def test_request(self):
+        connection = _MockTorrentConnection()
+
+        connection.request(1, begin=16384, length=8192)
+
+        # the request names the piece, the offset inside it and the amount
+        # of data that is being asked for
+        self.assertEqual(
+            connection.sent, [struct.pack("!LBLLL", 13, 6, 1, 16384, 8192)]
+        )
+
     def test_extended_handshake(self):
         connection = _MockTorrentConnection()
 
@@ -181,28 +538,214 @@ class TorrentConnectionTest(unittest.TestCase):
         connection.metadata_size = 40000
         self.assertEqual(connection._metadata_pieces(), 3)
 
+    def test_is_alive(self):
+        connection = self._make_connection(cls=_RecordTorrentConnection)
+        connection.open()
+
+        connection.messages = 1
+        clojure = connection.is_alive(timeout=1.0)
+
+        # a connection that keeps both the messages and the rate above the
+        # limits is kept alive, being neither closed nor given up on
+        connection.messages = 2
+        connection.downloaded = int(netius.clients.torrent.SPEED_LIMIT) + 1
+        clojure()
+
+        self.assertEqual(connection.closes, [])
+
+    def test_is_alive_silent(self):
+        connection = self._make_connection(cls=_RecordTorrentConnection)
+        connection.open()
+
+        clojure = connection.is_alive(timeout=1.0)
+
+        # a connection that carries no new message is a stale one, so it
+        # is asked to close once the data that is pending is flushed
+        clojure()
+
+        self.assertEqual(connection.closes, [dict(flush=True)])
+
+    def test_is_alive_slow(self):
+        connection = self._make_connection(cls=_RecordTorrentConnection)
+        connection.open()
+
+        clojure = connection.is_alive(timeout=1.0)
+
+        # the messages did move, but the amount of data that came with
+        # them is below the limit, which closes the connection as well
+        connection.messages = 1
+        connection.downloaded = 1
+        clojure()
+
+        self.assertEqual(connection.closes, [dict(flush=True)])
+
+    def test_is_alive_closed(self):
+        connection = self._make_connection(cls=_RecordTorrentConnection)
+        connection.open()
+
+        clojure = connection.is_alive(timeout=1.0)
+
+        connection.close()
+        clojure()
+
+        # a connection that is already closed is left alone, as there is
+        # nothing left of it to be kept alive
+        self.assertEqual(connection.is_closed(), True)
+        self.assertEqual(len(connection.closes), 1)
+
+    def _make_connection(self, cls=None):
+        cls = cls or netius.clients.TorrentConnection
+        connection = cls(owner=self.client, address=("10.0.0.1", 6881))
+        connection.task = _MockTorrentTask()
+        return connection
+
+
+class TorrentClientTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.client = netius.clients.TorrentClient(poll=netius.Poll, auto_close=False)
+        self.client.poll.open()
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.client.cleanup()
+
+    def test_peer(self):
+        connection = netius.clients.TorrentConnection(
+            owner=self.client, address=("10.0.0.1", 6881)
+        )
+        task = _MockTorrentTask()
+
+        result = self.client.peer(task, "10.0.0.1", 6881, connection=connection)
+
+        # the connection that is given is the one that is used, having the
+        # task of it associated so that the blocks may be reached
+        self.assertEqual(result, connection)
+        self.assertEqual(connection.task, task)
+
+    def test_on_acquire(self):
+        connection = _MockTorrentConnection()
+
+        self.client.on_acquire(connection)
+
+        # the acquiring of a connection is what sends the handshake, as
+        # that is the first thing a peer expects to receive
+        self.assertEqual(len(connection.sent), 1)
+        self.assertEqual(connection.sent[0][1:20], b"BitTorrent protocol")
+
+    def test_on_data(self):
+        connection = _MockTorrentConnection()
+        connection.parser = _MockTorrentParser()
+
+        self.client.on_data(connection, b"data")
+
+        # the data of the peer is handed to the connection, which passes
+        # it along to the parser of the protocol
+        self.assertEqual(connection.parser.parsed, [b"data"])
+
+    def test_build_connection(self):
+        connection = self.client.build_connection(None, ("10.0.0.1", 6881))
+
+        # the connections that the client builds are the ones of the
+        # torrent protocol, carrying the client as their owner
+        self.assertEqual(isinstance(connection, netius.clients.TorrentConnection), True)
+        self.assertEqual(connection.owner, self.client)
+        self.assertEqual(connection.address, ("10.0.0.1", 6881))
+
+
+class _RecordTorrentConnection(netius.clients.TorrentConnection):
+    """
+    Variant of the connection that keeps the closings that
+    are asked of it, together with the way they were asked.
+    """
+
+    def __init__(self, *args, **kwargs):
+        netius.clients.TorrentConnection.__init__(self, *args, **kwargs)
+        self.closes = []
+
+    def close(self, *args, **kwargs):
+        self.closes.append(dict(kwargs))
+        netius.clients.TorrentConnection.close(self, *args, **kwargs)
+
+
+class _MockTorrentParser(object):
+    """
+    Stand in for the parser of the protocol that keeps the
+    data that reaches it and the release of itself.
+    """
+
+    def __init__(self):
+        self.parsed = []
+        self.destroyed = False
+
+    def parse(self, data):
+        self.parsed.append(data)
+
+    def destroy(self):
+        self.destroyed = True
+
 
 class _MockTorrentConnection(netius.clients.TorrentConnection):
 
     def __init__(self):
         self.sent = []
+        self.triggered = []
         self.extensions = {}
         self.metadata_size = 0
         self.metadata = []
+        self.address = ("10.0.0.1", 6881)
+        self.peer_id = None
+        self.state = netius.clients.torrent.HANDSHAKE_STATE
+        self.choked = netius.clients.torrent.CHOKED
+        self.bitfield = b""
+        self.messages = 0
+        self.downloaded = 0
+        self.max_requests = 50
+        self.pend_requests = 0
+        self.requests = []
         self.task = _MockTorrentTask()
 
     def send(self, data):
         self.sent.append(data)
         return data
 
+    def trigger(self, name, *args, **kwargs):
+        self.triggered.append((name, args))
+
 
 class _MockTorrentTask(object):
 
     def __init__(self):
         self.metadata = None
+        self.blocks = []
+        self.pushed = []
+        self.data = []
+        self.dht = None
+        self.info_hash = b"i" * 20
+        self.owner = _MockTorrentOwner()
 
     def has_metadata(self):
-        return False
+        return True if self.metadata else False
 
     def set_metadata(self, metadata):
         self.metadata = metadata
+
+    def set_data(self, data, index, begin):
+        self.data.append((data, index, begin))
+
+    def set_dht(self, address, port):
+        self.dht = (address, port)
+
+    def pop_block(self, bitfield):
+        if not self.blocks:
+            return None
+        return self.blocks.pop(0)
+
+    def push_block(self, index, begin):
+        self.pushed.append((index, begin))
+
+
+class _MockTorrentOwner(object):
+
+    peer_id = "netius-peer-id-00000"


### PR DESCRIPTION
Step 9 of #102.

## What this carries

The torrent and DHT clients, the two modules that #102 names, together with the ratchet raised to the figure that they reach.

Two defects that the tests found along the way are fixed with them.

## Phase 9, the torrent and DHT clients

Every figure below is measured on Python 3.14, which is the interpreter that the coverage job runs on all three platforms.

| Module | Before | After |
| --- | --- | --- |
| `clients/torrent.py` | 38.7% | 85.6% |
| `clients/dht.py` | 63.2% | 83.8% |
| **together** | **50.2%** | **84.8%** |

The package as a whole moves from 68.6% to 69.5% as the coverage job reports it over the three platforms, so its floor goes from 67 to 68.

Both modules carry a large `__main__` block that stands for the better part of what is still missed. Of the 37 statements that `clients/dht.py` leaves uncovered every single one of them is inside that block, and of the 38 of `clients/torrent.py` all but seven are. Set against the code that is not a demonstration the two read at 100% and around 97%.

## The two defects

**A torrent peer that announced its DHT port was refused.** The handler of the port message unpacked a single unsigned short, which is two bytes, out of a slice of eight, so any message that carried more than the two bytes of the port ended in a `struct.error` that broke the handling of the peer. The sibling handler of a piece takes a slice of the very size that its own format names, which is what this one now does as well:

```
exactly two bytes    -> port 6881
a longer payload     -> struct.error: unpack requires a buffer of 2 bytes
```

**A ping of a DHT node went to the local default.** `DHTClient.ping` takes the host, the port and the identifier of the peer and passed none of the three to the query that it builds, so every ping was sent to `127.0.0.1:9090` carrying no identifier at all. The two sibling operations take no named arguments and forward what they are given, which is why only the ping was affected:

```
ping("1.2.3.4", 6881, peer_id) -> {'host': '127.0.0.1', 'port': 9090, 'peer_id': None}
find_node(host=..., port=...)  -> {'host': '1.2.3.4', 'port': 6881, 'peer_id': b'aaa...'}
```

Both are covered by tests that fail without the fix.

## Validation

Suite status: 1556 passed and 7 skipped on Linux with Python 3.14, 1555 passed and 8 skipped on macOS, 60 of the tests being new. The suite was also run under Python 2.7, where it reports 1239 passed and 324 skipped. `black --check` is clean and `mypy.stubtest` reports no issues in 132 modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes peer-protocol and DHT routing behavior used for decentralized discovery, but the edits are small and backed by new regression tests.
> 
> **Overview**
> Adds broad unit coverage for the BitTorrent **torrent** and **DHT** clients (wire messages, iterative lookup, datagram I/O) and raises the combined coverage gate from **67% to 68%** in CI.
> 
> Two protocol bugs are fixed alongside the tests:
> 
> **`DHTClient.ping`** now passes `host`, `port`, and `peer_id` into `query`, so pings go to the named node instead of the default `127.0.0.1:9090` with no peer id.
> 
> **`TorrentConnection.port_t`** unpacks the announced DHT port from the first **two** bytes of the payload (`!H`), matching the message format; the previous eight-byte slice caused `struct.error` on normal port messages.
> 
> **CHANGELOG** documents both fixes. New tests lock in the corrected behavior (including port messages with extra trailing bytes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfd1d9fe0acc48b614ec2787ea28d47d9bf48940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->