### PR TITLE
test(clients,servers): cover the four small ones that had no test file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           pip install coverage
           coverage combine
-          coverage report --sort=-miss --fail-under=68
+          coverage report --sort=-miss --fail-under=69
       - name: Publish coverage summary
         run: |
           echo "## Coverage" >> $GITHUB_STEP_SUMMARY

--- a/src/netius/test/clients/apn.py
+++ b/src/netius/test/clients/apn.py
@@ -1,0 +1,225 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import json
+import struct
+import unittest
+
+import netius.clients
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+TOKEN = "00" * 32
+""" The token of a device, which travels as a sequence of
+hexadecimal digits and is thirty two bytes wide """
+
+
+class APNProtocolTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.protocol = _MockAPNProtocol()
+
+    def test_init(self):
+        # a protocol starts with no notification of its own and with the
+        # sandbox as the environment that it targets
+        self.assertEqual(self.protocol.host, None)
+        self.assertEqual(self.protocol.port, None)
+        self.assertEqual(self.protocol.token, None)
+        self.assertEqual(self.protocol.message, None)
+        self.assertEqual(self.protocol.badge, 0)
+        self.assertEqual(self.protocol.sandbox, True)
+
+    def test_send_notification(self):
+        self.protocol.send_notification(TOKEN, "Hello World")
+
+        data = self.protocol.sent[0][0]
+        command, token_length = struct.unpack("!BH", data[:3])
+
+        # the message starts with the simplified command and the length
+        # of the token, which is the one of a device
+        self.assertEqual(command, 0)
+        self.assertEqual(token_length, 32)
+        self.assertEqual(data[3:35], b"\x00" * 32)
+
+        (payload_length,) = struct.unpack("!H", data[35:37])
+        payload = json.loads(data[37:].decode("utf-8"))
+
+        # the payload is the JSON of the alert, together with the sound
+        # and the badge that come with it
+        self.assertEqual(payload_length, len(data) - 37)
+        self.assertEqual(payload["aps"]["alert"], "Hello World")
+        self.assertEqual(payload["aps"]["sound"], "default")
+        self.assertEqual(payload["aps"]["badge"], 0)
+
+    def test_send_notification_values(self):
+        self.protocol.send_notification(TOKEN, "Hello World", sound="chime", badge=3)
+
+        data = self.protocol.sent[0][0]
+        payload = json.loads(data[37:].decode("utf-8"))
+
+        self.assertEqual(payload["aps"]["sound"], "chime")
+        self.assertEqual(payload["aps"]["badge"], 3)
+
+    def test_send_notification_close(self):
+        self.protocol.send_notification(TOKEN, "Hello World")
+
+        # without the closing being asked for the sending carries no
+        # callback, so the connection is left as it is
+        self.assertEqual(self.protocol.sent[0][1], None)
+
+        self.protocol.send_notification(TOKEN, "Hello World", close=True)
+
+        # with it the callback that comes with the sending is the one
+        # that closes the connection once the message is out
+        callback = self.protocol.sent[1][1]
+
+        self.assertNotEqual(callback, None)
+
+        callback(None)
+
+        self.assertEqual(self.protocol.closed, 1)
+
+    def test_set(self):
+        self.protocol.set(
+            TOKEN,
+            "Hello World",
+            sound="chime",
+            badge=3,
+            sandbox=False,
+            key_file="key.pem",
+            cer_file="cer.pem",
+            _close=False,
+        )
+
+        # the values of the notification are kept for the moment that the
+        # connection is made, which is when the message is sent
+        self.assertEqual(self.protocol.token, TOKEN)
+        self.assertEqual(self.protocol.message, "Hello World")
+        self.assertEqual(self.protocol.sound, "chime")
+        self.assertEqual(self.protocol.badge, 3)
+        self.assertEqual(self.protocol.sandbox, False)
+        self.assertEqual(self.protocol.key_file, "key.pem")
+        self.assertEqual(self.protocol.cer_file, "cer.pem")
+        self.assertEqual(self.protocol._close, False)
+
+    def test_connection_made(self):
+        self.protocol.set(TOKEN, "Hello World", _close=False)
+
+        self.protocol.connection_made(None)
+
+        # the making of the connection is what sends the notification,
+        # built from the values that were set before it
+        data = self.protocol.sent[0][0]
+        payload = json.loads(data[37:].decode("utf-8"))
+
+        self.assertEqual(payload["aps"]["alert"], "Hello World")
+
+    def test_notify(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch("netius.connect_stream") as connect_stream:
+            loop, protocol = self.protocol.notify(TOKEN, message="Hello World")
+
+        # the sandbox is the environment that a notification targets
+        # unless the caller asks for the production one
+        self.assertEqual(self.protocol.host, netius.clients.APNProtocol.SANDBOX_HOST)
+        self.assertEqual(self.protocol.port, netius.clients.APNProtocol.SANDBOX_PORT)
+        self.assertEqual(self.protocol.message, "Hello World")
+        self.assertEqual(protocol, self.protocol)
+        self.assertEqual(loop, connect_stream.return_value)
+
+        # the connection towards the gateway is a secure one, as the
+        # service is never spoken to in the clear
+        self.assertEqual(connect_stream.call_args[1]["ssl"], True)
+        self.assertEqual(
+            connect_stream.call_args[1]["host"],
+            netius.clients.APNProtocol.SANDBOX_HOST,
+        )
+
+    def test_notify_production(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch("netius.connect_stream"):
+            self.protocol.notify(TOKEN, sandbox=False, key_file="key.pem")
+
+        # with the sandbox turned off the gateway of production is the
+        # one that the notification is sent to
+        self.assertEqual(self.protocol.host, netius.clients.APNProtocol.HOST)
+        self.assertEqual(self.protocol.port, netius.clients.APNProtocol.PORT)
+        self.assertEqual(self.protocol.key_file, "key.pem")
+
+
+class APNClientTest(unittest.TestCase):
+
+    def test_protocol(self):
+        # the client answers with the protocol of the notifications,
+        # which is the one that speaks to the gateway
+        self.assertEqual(netius.clients.APNClient.protocol, netius.clients.APNProtocol)
+
+    def test_notify_s(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch("netius.connect_stream"):
+            _loop, protocol = netius.clients.APNClient.notify_s(
+                TOKEN, message="Hello World"
+            )
+
+        # the client builds a protocol of its own for the notification,
+        # which carries the values that it was given
+        self.assertEqual(isinstance(protocol, netius.clients.APNProtocol), True)
+        self.assertEqual(protocol.message, "Hello World")
+
+
+class _MockAPNProtocol(netius.clients.APNProtocol):
+    """
+    Stand in for the protocol that keeps the messages that
+    it sends instead of handing them to a transport.
+    """
+
+    def __init__(self, *args, **kwargs):
+        netius.clients.APNProtocol.__init__(self, *args, **kwargs)
+        self.sent = []
+        self.closed = 0
+
+    def connection_made(self, transport):
+        netius.clients.APNProtocol.connection_made(self, transport)
+
+    def send(self, data, callback=None):
+        self.sent.append((data, callback))
+
+    def close(self, *args, **kwargs):
+        self.closed += 1

--- a/src/netius/test/clients/mjpg.py
+++ b/src/netius/test/clients/mjpg.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius.clients
+
+MULTIPART = b"Content-Type: image/jpeg\r\n" b"Content-Length: 10\r\n" b"\r\n"
+""" The head of a part of the stream, which comes before the
+data of the image and is not part of it """
+
+
+class MJPGProtocolTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.protocol = netius.clients.MJPGProtocol("GET", "http://mjpg.local/")
+        self.frames = []
+        self.protocol.bind("frame", self._on_frame)
+
+    def test_init(self):
+        # the buffer of a protocol starts empty, as no part of an image
+        # has been received through it yet
+        self.assertEqual(self.protocol.buffer_l, [])
+
+    def test_add_buffer(self):
+        self.protocol.add_buffer(b"first")
+        self.protocol.add_buffer(b"second")
+
+        self.assertEqual(self.protocol.buffer_l, [b"first", b"second"])
+
+    def test_get_buffer(self):
+        self.assertEqual(self.protocol.get_buffer(), b"")
+
+        self.protocol.add_buffer(b"first")
+        self.protocol.add_buffer(b"second")
+
+        # the parts of the buffer are joined into a single sequence and
+        # the buffer is emptied, so that none of them is given twice
+        self.assertEqual(self.protocol.get_buffer(), b"firstsecond")
+        self.assertEqual(self.protocol.buffer_l, [])
+
+    def test_get_buffer_keep(self):
+        self.protocol.add_buffer(b"first")
+
+        # with the deletion turned off the parts are kept in place, so
+        # that the very same value may be read again
+        self.assertEqual(self.protocol.get_buffer(delete=False), b"first")
+        self.assertEqual(self.protocol.buffer_l, [b"first"])
+
+    def test_on_partial(self):
+        cls = netius.clients.MJPGProtocol
+        image = cls.MAGIC_JPEG + b"body" + cls.EOI_JPEG
+
+        self.protocol.on_partial(MULTIPART + image)
+
+        # the head of the part is not part of the image, so it is dropped
+        # from the frame that reaches the ones bound to the event
+        self.assertEqual(self.frames, [image])
+        self.assertEqual(self.protocol.buffer_l, [b""])
+
+    def test_on_partial_split(self):
+        cls = netius.clients.MJPGProtocol
+        image = cls.MAGIC_JPEG + b"body" + cls.EOI_JPEG
+
+        self.protocol.on_partial(MULTIPART + image[:6])
+
+        # the end of the image was not reached yet, so the data is kept
+        # in the buffer instead of being given as a frame
+        self.assertEqual(self.frames, [])
+        self.assertEqual(self.protocol.get_buffer(delete=False), MULTIPART + image[:6])
+
+        self.protocol.on_partial(image[6:])
+
+        # the remainder completes the image, which is then joined from
+        # the parts that were gathered along the way
+        self.assertEqual(self.frames, [image])
+
+    def test_on_partial_remaining(self):
+        cls = netius.clients.MJPGProtocol
+        image = cls.MAGIC_JPEG + b"body" + cls.EOI_JPEG
+
+        self.protocol.on_partial(MULTIPART + image + b"remaining")
+
+        # what comes after the end of an image is already part of the one
+        # that follows it, so it is kept for the next frame
+        self.assertEqual(self.frames, [image])
+        self.assertEqual(self.protocol.buffer_l, [b"remaining"])
+
+    def test_on_frame_mjpg(self):
+        self.protocol.on_frame_mjpg(b"frame")
+
+        self.assertEqual(self.frames, [b"frame"])
+
+    def _on_frame(self, protocol, data):
+        self.frames.append(data)

--- a/src/netius/test/clients/ssdp.py
+++ b/src/netius/test/clients/ssdp.py
@@ -148,28 +148,42 @@ class SSDPProtocolTest(unittest.TestCase):
 class SSDPClientTest(unittest.TestCase):
 
     def test_discover_s(self):
-        loop, protocol = netius.clients.SSDPClient.discover_s(
-            "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
-        )
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
 
-        try:
-            # the discovery builds both the loop that is going to carry it
-            # and the protocol that speaks for it
-            self.assertNotEqual(loop, None)
-            self.assertEqual(isinstance(protocol, netius.clients.SSDPProtocol), True)
-        finally:
-            loop.close()
+        with mock.patch("netius.build_datagram") as build_datagram:
+            loop, protocol = netius.clients.SSDPClient.discover_s(
+                "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
+            )
+
+        # the discovery answers with the loop that is going to carry it
+        # and with the protocol that speaks for it
+        self.assertEqual(loop, build_datagram.return_value)
+        self.assertEqual(isinstance(protocol, netius.clients.SSDPProtocol), True)
+
+        # the endpoint is built towards the address that the specification
+        # reserves for the discovery of a device
+        self.assertEqual(
+            build_datagram.call_args[1]["remote_addr"], ("239.255.255.250", 1900)
+        )
 
     def test_method_s(self):
-        loop, protocol = netius.clients.SSDPClient.method_s(
-            "NOTIFY", "urn:target", "ssdp:alive", host="127.0.0.1", port=1901
-        )
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
 
-        try:
-            self.assertNotEqual(loop, None)
-            self.assertEqual(isinstance(protocol, netius.clients.SSDPProtocol), True)
-        finally:
-            loop.close()
+        with mock.patch("netius.build_datagram") as build_datagram:
+            loop, protocol = netius.clients.SSDPClient.method_s(
+                "NOTIFY", "urn:target", "ssdp:alive", host="127.0.0.1", port=1901
+            )
+
+        self.assertEqual(loop, build_datagram.return_value)
+        self.assertEqual(isinstance(protocol, netius.clients.SSDPProtocol), True)
+
+        # the endpoint is built towards the contact that the caller named,
+        # instead of the one that a discovery would use
+        self.assertEqual(
+            build_datagram.call_args[1]["remote_addr"], ("127.0.0.1", 1901)
+        )
 
     def test_method_s_connect(self):
         if mock == None:

--- a/src/netius/test/clients/ssdp.py
+++ b/src/netius/test/clients/ssdp.py
@@ -1,0 +1,209 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import unittest
+
+import netius.clients
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+RESPONSE = (
+    b"HTTP/1.1 200 OK\r\n"
+    b"CACHE-CONTROL: max-age=1800\r\n"
+    b"ST: urn:schemas-upnp-org:device:InternetGatewayDevice:1\r\n"
+    b"USN: uuid:device::urn:schemas-upnp-org:device:InternetGatewayDevice:1\r\n"
+    b"\r\n"
+)
+""" The raw contents of the answer that a device sends back
+to a discovery, as the specification defines it """
+
+
+class SSDPProtocolTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.protocol = _MockSSDPProtocol()
+        self.headers = []
+        self.protocol.bind("headers", self._on_headers)
+
+    def test_on_data(self):
+        self.protocol.on_data(("192.168.1.1", 1900), RESPONSE)
+
+        # the answer of a device is read as an HTTP response, the headers
+        # of it reaching the ones that are bound to the event
+        self.assertEqual(len(self.headers), 1)
+        self.assertEqual(
+            self.headers[0]["St"], "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
+        )
+        self.assertEqual(self.headers[0]["Cache-Control"], "max-age=1800")
+        self.assertEqual(
+            self.headers[0]["Usn"],
+            "uuid:device::urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+        )
+
+    def test_on_data_partial(self):
+        self.protocol.on_data(("192.168.1.1", 1900), b"HTTP/1.1 200 OK\r\n")
+
+        # an answer that never completes carries no headers of its own,
+        # so nothing is handed to the ones that wait for them
+        self.assertEqual(self.headers, [])
+
+    def test_discover(self):
+        self.protocol.discover("urn:schemas-upnp-org:device:InternetGatewayDevice:1")
+
+        data, address = self.protocol.sent[0]
+
+        # the discovery is a search of the protocol towards the address
+        # that the specification reserves for it
+        self.assertEqual(address, ("239.255.255.250", 1900))
+        self.assertEqual(data.startswith("M-SEARCH * HTTP/1.1\r\n"), True)
+        self.assertEqual('Man: "ssdp:discover"\r\n' in data, True)
+        self.assertEqual(
+            "St: urn:schemas-upnp-org:device:InternetGatewayDevice:1\r\n" in data, True
+        )
+        self.assertEqual("Mx: 3\r\n" in data, True)
+        self.assertEqual("Host: 239.255.255.250:1900\r\n" in data, True)
+        self.assertEqual(data.endswith("\r\n\r\n"), True)
+
+    def test_method(self):
+        self.protocol.method(
+            "NOTIFY",
+            "urn:target",
+            "ssdp:alive",
+            mx=5,
+            path="/control",
+            headers=dict(NTS="ssdp:alive"),
+            host="192.168.1.1",
+            port=1901,
+            version="HTTP/1.0",
+        )
+
+        data, address = self.protocol.sent[0]
+
+        # every one of the values that the caller names takes the place of
+        # the default of it, the headers being cased as the protocol asks
+        self.assertEqual(address, ("192.168.1.1", 1901))
+        self.assertEqual(data.startswith("NOTIFY /control HTTP/1.0\r\n"), True)
+        self.assertEqual("Mx: 5\r\n" in data, True)
+        self.assertEqual("Nts: ssdp:alive\r\n" in data, True)
+        self.assertEqual("Host: 192.168.1.1:1901\r\n" in data, True)
+
+    def test_method_list(self):
+        self.protocol.method(
+            "M-SEARCH",
+            "urn:target",
+            "ssdp:discover",
+            headers=dict(Ext=["first", "second"]),
+        )
+
+        data, _address = self.protocol.sent[0]
+
+        # a header that carries more than one value is written once for
+        # each of them, instead of the sequence being written as it is
+        self.assertEqual("Ext: first\r\n" in data, True)
+        self.assertEqual("Ext: second\r\n" in data, True)
+
+    def test_method_data(self):
+        self.protocol.method("M-SEARCH", "urn:target", "ssdp:discover", data=b"payload")
+
+        # the payload travels in a datagram of its own, the one that comes
+        # before it carrying only the head of the message
+        self.assertEqual(len(self.protocol.sent), 2)
+        self.assertEqual(self.protocol.sent[1][0], b"payload")
+
+    def _on_headers(self, protocol, parser, headers):
+        self.headers.append(headers)
+
+
+class SSDPClientTest(unittest.TestCase):
+
+    def test_discover_s(self):
+        loop, protocol = netius.clients.SSDPClient.discover_s(
+            "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
+        )
+
+        try:
+            # the discovery builds both the loop that is going to carry it
+            # and the protocol that speaks for it
+            self.assertNotEqual(loop, None)
+            self.assertEqual(isinstance(protocol, netius.clients.SSDPProtocol), True)
+        finally:
+            loop.close()
+
+    def test_method_s(self):
+        loop, protocol = netius.clients.SSDPClient.method_s(
+            "NOTIFY", "urn:target", "ssdp:alive", host="127.0.0.1", port=1901
+        )
+
+        try:
+            self.assertNotEqual(loop, None)
+            self.assertEqual(isinstance(protocol, netius.clients.SSDPProtocol), True)
+        finally:
+            loop.close()
+
+    def test_method_s_connect(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        protocol = _MockSSDPProtocol()
+
+        with mock.patch.object(
+            netius.clients.SSDPClient, "protocol", lambda: protocol
+        ), mock.patch("netius.build_datagram") as build_datagram:
+            netius.clients.SSDPClient.method_s(
+                "M-SEARCH", "urn:target", "ssdp:discover", host="127.0.0.1", port=1901
+            )
+
+        callback = build_datagram.call_args[1]["callback"]
+        callback((None, protocol))
+
+        data, address = protocol.sent[0]
+
+        # the message is only sent once the endpoint of the datagram is
+        # in place, which is what the callback of the building stands for
+        self.assertEqual(address, ("127.0.0.1", 1901))
+        self.assertEqual(data.startswith("M-SEARCH * HTTP/1.1\r\n"), True)
+
+
+class _MockSSDPProtocol(netius.clients.SSDPProtocol):
+    """
+    Stand in for the protocol that keeps the datagrams that
+    it sends instead of handing them to a transport.
+    """
+
+    def __init__(self, *args, **kwargs):
+        netius.clients.SSDPProtocol.__init__(self, *args, **kwargs)
+        self.sent = []
+
+    def send(self, data, address, callback=None):
+        self.sent.append((data, address))

--- a/src/netius/test/servers/mjpg.py
+++ b/src/netius/test/servers/mjpg.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import collections
+import unittest
+
+import netius.servers
+
+
+class MJPGServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.servers = []
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        for server in self.servers:
+            server.cleanup()
+
+    def test_init(self):
+        server = self._make_server()
+
+        # the boundary of the stream falls back to the one of the module,
+        # which is what separates the parts of it
+        self.assertEqual(server.boundary, netius.servers.mjpg.BOUNDARY)
+
+        server = self._make_server(boundary="custom")
+
+        self.assertEqual(server.boundary, "custom")
+
+    def test_on_data_http(self):
+        server = self._make_server()
+        connection = _MockConnection()
+
+        server.on_data_http(connection, self._make_parser())
+
+        headers = connection.headers[0]
+
+        # the answer announces a stream whose parts replace one another,
+        # separated by the boundary, and is never cached
+        self.assertEqual(
+            headers["headers"]["Content-type"],
+            "multipart/x-mixed-replace; boundary=%s" % server.boundary,
+        )
+        self.assertEqual(headers["headers"]["Cache-Control"], "no-cache")
+        self.assertEqual(headers["code"], 200)
+        self.assertEqual(headers["version"], "HTTP/1.1")
+
+        data, kwargs = connection.parts[0]
+
+        # the part carries the boundary, the head of the image and the
+        # image itself, and is never the final one of the answer
+        self.assertEqual(data.startswith(b"--mjpegboundary\r\n"), True)
+        self.assertEqual(b"Content-Type: image/jpeg\r\n" in data, True)
+        self.assertEqual(data.endswith(b"\r\n"), True)
+        self.assertEqual(kwargs["final"], False)
+
+    def test_on_data_http_next(self):
+        server = self._make_server()
+        connection = _MockConnection()
+
+        server.on_data_http(connection, self._make_parser())
+
+        _data, kwargs = connection.parts[0]
+
+        # the answering of a part is what schedules the one that follows
+        # it, after the delay that the server asks for
+        kwargs["callback"](connection)
+        server.delayed[0][0]()
+
+        self.assertEqual(server.delayed[0][1], 1)
+        self.assertEqual(len(connection.parts), 2)
+
+    def test_on_data_http_empty(self):
+        server = self._make_server(cls=_EmptyMJPGServer)
+        connection = _MockConnection()
+
+        server.on_data_http(connection, self._make_parser())
+
+        data, _kwargs = connection.parts[0]
+
+        # a provider that gives no image is warned about, the part being
+        # sent with no body instead of the answer being broken
+        self.assertEqual(b"Content-Length: 0\r\n" in data, True)
+
+    def test_on_send_mjpg(self):
+        server = self._make_server()
+
+        # the hook of the sending carries no behaviour of its own, being
+        # meant to be taken over by the implementations
+        self.assertEqual(server.on_send_mjpg(_MockConnection()), None)
+
+    def test_get_delay(self):
+        server = self._make_server()
+
+        self.assertEqual(server.get_delay(_MockConnection()), 1)
+
+    def test_get_image(self):
+        server = self._make_server()
+        connection = _MockConnection()
+
+        first = server.get_image(connection)
+
+        # the images that are served come from the ones that the package
+        # carries, so both of them are proper JPEG files
+        self.assertEqual(first.startswith(b"\xff\xd8"), True)
+        self.assertEqual(connection.index, 1)
+
+        second = server.get_image(connection)
+
+        # the provider walks the images in turn, so the one that follows
+        # is a different one from the first
+        self.assertNotEqual(second, first)
+        self.assertEqual(connection.index, 2)
+
+        # the walking wraps around, which brings the first image back
+        self.assertEqual(server.get_image(connection), first)
+
+    def _make_server(self, cls=None, **kwargs):
+        cls = cls or _MockMJPGServer
+        server = cls(**kwargs)
+        self.servers.append(server)
+        return server
+
+    def _make_parser(self, version_s="HTTP/1.1"):
+        Parser = collections.namedtuple("Parser", "version_s")
+        return Parser(version_s=version_s)
+
+
+class _MockMJPGServer(netius.servers.MJPGServer):
+    """
+    Variant of the server that keeps the callables that are
+    delayed instead of handing them to the event loop.
+    """
+
+    def __init__(self, *args, **kwargs):
+        netius.servers.MJPGServer.__init__(self, *args, **kwargs)
+        self.delayed = []
+
+    def delay(self, callable, timeout=None, *args, **kwargs):
+        self.delayed.append((callable, timeout))
+
+
+class _EmptyMJPGServer(_MockMJPGServer):
+    """
+    Variant of the server whose provider of images is never
+    able to give one back.
+    """
+
+    def get_image(self, connection):
+        return None
+
+
+class _MockConnection(object):
+    """
+    Stand in for a connection that keeps both the header and
+    the parts that are sent through it.
+    """
+
+    def __init__(self):
+        self.headers = []
+        self.parts = []
+
+    def resolve_encoding(self, parser):
+        pass
+
+    def send_header(self, headers=None, version=None, code=200, code_s=None):
+        self.headers.append(
+            dict(headers=headers, version=version, code=code, code_s=code_s)
+        )
+
+    def send_part(self, data, final=True, callback=None):
+        self.parts.append((data, dict(final=final, callback=callback)))


### PR DESCRIPTION
Step 10 of #102.

## What this carries

The four small clients and servers that #102 names, none of which had a test file of its own, together with the ratchet raised to the figure that they reach.

No defect was found in any of them, so this step carries tests only.

## Phase 10, the remaining small clients and servers

Every figure below is measured on Python 3.14, which is the interpreter that the coverage job runs on all three platforms.

| Module | Before | After |
| --- | --- | --- |
| `servers/mjpg.py` | 27.0% | 95.9% |
| `clients/apn.py` | 33.3% | 88.2% |
| `clients/ssdp.py` | 28.8% | 87.7% |
| `clients/mjpg.py` | 28.2% | 63.5% |
| **together** | **29.5%** | **83.4%** |

The package as a whole moves from 69.5% to 70.1% as the coverage job reports it over the three platforms, crossing seventy for the first time, so its floor goes from 68 to 69.

### What is left is a demonstration

Every one of the 45 statements that these four modules still leave uncovered sits inside an `if __name__ == "__main__":` block, which #102 already names as code that stays uncovered. Set against the code that is not a demonstration the four of them are complete.

That is what the figure of `clients/mjpg.py` stands for. Its demonstration saves frames to disk and is 26 of the 73 statements of the module, better than a third of it, so the module reads at 63.5% while none of what it actually implements is left untested.

The only other thing that is missed is a branch of `clients/apn.py` that encodes a payload which is already a byte sequence, which no supported interpreter reaches, as the JSON of the notification is always a string one.

## What is covered

The discovery of a device and the search that is built for it, down to the casing of the headers and the address that the specification reserves. The framing of a motion JPEG stream on both sides of it, from the partial chunks that carry an image across several reads to the parts that a server writes with the boundary between them. The notification of a device, from the shape of the message that travels to the gateway to the choice between the sandbox and the production one.

Neither the network nor the wall clock is touched. Where an operation opens a connection of its own the building of it is stood in for, so that the callback which follows may be run and asserted.

## Validation

Suite status: 1591 passed and 7 skipped on Linux with Python 3.14, 1590 passed and 8 skipped on macOS, 34 of the tests being new. The suite was also run under Python 2.7, where it reports 1270 passed and 328 skipped. `black --check` is clean and `mypy.stubtest` reports no issues in 132 modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus a CI coverage threshold bump; no runtime behavior changes.
> 
> **Overview**
> Adds **unit tests** for four small modules that previously had no dedicated test files: **Apple Push Notification** (`clients/apn`), **SSDP/UPnP discovery** (`clients/ssdp`), **MJPG stream client** (`clients/mjpg`), and **MJPG HTTP server** (`servers/mjpg`). Assertions cover binary APN framing and JSON payloads, sandbox vs production gateways (with `connect_stream` mocked), SSDP M-SEARCH/NOTIFY formatting and response parsing, multipart JPEG reassembly across partial reads, and server multipart responses with scheduled follow-up frames.
> 
> The **coverage job** minimum is raised from **68% to 69%** in `.github/workflows/main.yml` so CI matches the package-wide gain from the new tests. **No production code** is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b731cc31dc89952f7d154190ade324e85d1e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->