### PR TITLE
test(proxy): finish the two modules that step 4 left short

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           pip install coverage
           coverage combine
-          coverage report --sort=-miss --fail-under=70
+          coverage report --sort=-miss --fail-under=71
       - name: Publish coverage summary
         run: |
           echo "## Coverage" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * A header that is set by its position now replaces the one that is there
 * A string that carries no null byte is now given back whole instead of raising
+* The connections of a proxy can now be listed before it is started, instead of failing
+* The service catalogue of a Consul proxy is now read under Python 3.5, instead of being dropped
 * The test of primality no longer takes a base that shares a factor for a prime one
 
 ## [1.63.1] - 2026-08-31

--- a/src/netius/extra/proxy_c.py
+++ b/src/netius/extra/proxy_c.py
@@ -392,6 +392,9 @@ class ConsulProxyServer(proxy_r.ReverseProxyServer):
                 self.info("Consul returned %d for %s", result["code"], url)
                 return None
             data = result.get("data", b"")
+            # the payload is decoded before being parsed as the loading of
+            # a byte sequence is only supported from Python 3.6 onwards
+            data = netius.legacy.str(data, encoding="utf-8")
             return json.loads(data)
         except Exception as exception:
             self.info("Failed to retrieve Consul data from %s: %s", url, exception)

--- a/src/netius/servers/proxy.py
+++ b/src/netius/servers/proxy.py
@@ -308,7 +308,10 @@ class ProxyServer(http2.HTTP2Server):
         return info
 
     def connections_dict(self, full=False, parent=False):
-        if parent:
+        # the container delegates this operation back into the base that owns
+        # it, so a container that is not yet running (no owner set) would
+        # otherwise send the two of them into an infinite recursion
+        if parent or not self.container.owner:
             return http2.HTTP2Server.connections_dict(self, full=full)
         return self.container.connections_dict(full=full)
 

--- a/src/netius/test/extra/proxy_c.py
+++ b/src/netius/test/extra/proxy_c.py
@@ -33,6 +33,7 @@ import unittest
 import collections
 
 import netius.extra
+import netius.clients
 
 try:
     import unittest.mock as mock
@@ -83,6 +84,58 @@ class ConsulProxyServerTest(unittest.TestCase):
         self.assertEqual(server.consul_poll_interval, 60.0)
         self.assertEqual(server.host_suffixes, ["example.com"])
         server.cleanup()
+
+    def test_on_serve(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.env = False
+
+        with mock.patch.object(self.server, "_consul_tick") as consul_tick:
+            self.server.on_serve()
+
+        # the serving is what starts the polling of the catalogue, at the
+        # interval that the server carries for it
+        self.assertEqual(consul_tick.call_args[1]["timeout"], 30.0)
+
+    def test_on_serve_env(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.env = True
+
+        with netius.conf_override(
+            "CONSUL_URL", "http://consul.local:8500"
+        ), netius.conf_override("CONSUL_TOKEN", "my-token"), netius.conf_override(
+            "CONSUL_TAG", "web.proxy=true"
+        ), netius.conf_override(
+            "CONSUL_POLL_INTERVAL", "60.0"
+        ), netius.conf_override(
+            "HOST_SUFFIXES", "example.com"
+        ), mock.patch.object(
+            self.server, "_consul_tick"
+        ) as consul_tick:
+            self.server.on_serve()
+
+        # the environment answers for the catalogue that is polled, for
+        # the credential of it and for the shape of what is discovered
+        self.assertEqual(self.server.consul_url, "http://consul.local:8500")
+        self.assertEqual(self.server.consul_token, "my-token")
+        self.assertEqual(self.server.consul_tag, "web.proxy=true")
+        self.assertEqual(self.server.consul_poll_interval, 60.0)
+        self.assertEqual(self.server.host_suffixes, ["example.com"])
+        self.assertEqual(consul_tick.call_args[1]["timeout"], 60.0)
+
+    def test_on_config(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.server, "_consul_tick") as consul_tick:
+            self.server.on_config()
+
+        # the configuring asks for a single gathering, so that the hosts
+        # are known before anything is served, and books no tick after it
+        self.assertEqual(consul_tick.call_args[1]["timeout"], 0)
 
     def test_build_hosts(self):
         entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], ["proxy.enable=true"])]
@@ -347,6 +400,226 @@ class ConsulProxyServerTest(unittest.TestCase):
 
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0][2], ["http://10.99.0.1:8080"])
+
+    def test_consul_tick(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        entries = [("myapp", "myapp", ["http://10.0.0.1:8080"], ["proxy.enable=true"])]
+
+        with mock.patch.object(
+            self.server, "_consul_fetch", return_value=entries
+        ), mock.patch.object(self.server, "ensure") as ensure, mock.patch.object(
+            self.server, "delay_s"
+        ) as delay_s, mock.patch.object(
+            self.server, "delay"
+        ) as delay:
+            self.server._consul_tick(timeout=30.0)
+
+            # the gathering of the entries reaches the network, so it is
+            # handed to a thread instead of being run in the loop
+            self.assertEqual(ensure.call_args[1]["thread"], True)
+
+            ensure.call_args[0][0]()
+
+            # what comes back is applied in the loop, so that the changing
+            # of the configuration needs no lock of its own
+            delay_s.call_args[0][0]()
+
+        # the entries reach the hosts and the tick that follows is booked
+        # for the interval that was asked for
+        self.assertEqual(self.server.hosts["myapp"], "http://10.0.0.1:8080")
+        self.assertEqual(delay.call_args[1]["timeout"], 30.0)
+
+    def test_consul_tick_failed(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.hosts["myapp"] = "http://10.0.0.1:8080"
+
+        def _fetch():
+            raise netius.NetiusError("Unable to reach the catalogue")
+
+        with mock.patch.object(self.server, "_consul_fetch", _fetch), mock.patch.object(
+            self.server, "ensure"
+        ) as ensure, mock.patch.object(
+            self.server, "delay_s"
+        ) as delay_s, mock.patch.object(
+            self.server, "delay"
+        ) as delay:
+            self.server._consul_tick(timeout=30.0)
+            ensure.call_args[0][0]()
+            delay_s.call_args[0][0]()
+
+        # a gathering that failed keeps the configuration that is in place
+        # rather than emptying it, and the next tick is still booked
+        self.assertEqual(self.server.hosts["myapp"], "http://10.0.0.1:8080")
+        self.assertEqual(delay.called, True)
+
+    def test_consul_tick_once(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(
+            self.server, "_consul_fetch", return_value=[]
+        ), mock.patch.object(self.server, "ensure") as ensure, mock.patch.object(
+            self.server, "delay_s"
+        ) as delay_s, mock.patch.object(
+            self.server, "delay"
+        ) as delay:
+            self.server._consul_tick(timeout=0)
+            ensure.call_args[0][0]()
+            delay_s.call_args[0][0]()
+
+        # a timeout of zero asks for a single gathering, so no tick that
+        # follows it is ever booked
+        self.assertEqual(delay.called, False)
+
+    def test_consul_services(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(
+            self.server, "_consul_get", return_value=dict(myapp=["proxy.enable=true"])
+        ) as consul_get:
+            result = self.server._consul_services()
+
+        # the catalogue of the services is the one that is asked for,
+        # under the address that the server was given
+        self.assertEqual(
+            consul_get.call_args[0][0], "http://localhost:8500/v1/catalog/services"
+        )
+        self.assertEqual(result, dict(myapp=["proxy.enable=true"]))
+
+    def test_consul_services_missing(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.server, "_consul_get", return_value=None):
+            result = self.server._consul_services()
+
+        # a request that gave nothing back leaves no service at all,
+        # instead of the absence of one reaching the caller
+        self.assertEqual(result, dict())
+
+    def test_consul_health(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(
+            self.server, "_consul_get", return_value=[dict(Node=dict())]
+        ) as consul_get:
+            result = self.server._consul_health("my app")
+
+        # the health of the instances is skipped by default, so every one
+        # of them is asked for, and the name travels quoted in the address
+        self.assertEqual(
+            consul_get.call_args[0][0],
+            "http://localhost:8500/v1/health/service/my%20app",
+        )
+        self.assertEqual(len(result), 1)
+
+    def test_consul_health_passing(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.consul_skip_health = False
+
+        with mock.patch.object(
+            self.server, "_consul_get", return_value=[]
+        ) as consul_get:
+            self.server._consul_health("myapp")
+
+        # with the health of them taken into account only the instances
+        # that pass their checks are the ones that are asked for
+        self.assertEqual(
+            consul_get.call_args[0][0],
+            "http://localhost:8500/v1/health/service/myapp?passing=true",
+        )
+
+    def test_consul_health_missing(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.server, "_consul_get", return_value=None):
+            result = self.server._consul_health("myapp")
+
+        self.assertEqual(result, [])
+
+    def test_consul_get(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.server.consul_token = "my-token"
+        result = dict(error=False, code=200, data=b'{"myapp": ["proxy.enable=true"]}')
+
+        with mock.patch.object(
+            netius.clients.HTTPClient, "get_s", return_value=result
+        ) as get_s:
+            value = self.server._consul_get("http://localhost:8500/v1/catalog/services")
+
+        # the token of the catalogue travels as a header of the request,
+        # which is what a secured one asks for
+        self.assertEqual(get_s.call_args[1]["headers"]["X-Consul-Token"], "my-token")
+
+        # the request is a blocking one, as the gathering runs in a thread
+        # of its own rather than in the loop
+        self.assertEqual(get_s.call_args[1]["asynchronous"], False)
+        self.assertEqual(value, dict(myapp=["proxy.enable=true"]))
+
+    def test_consul_get_anonymous(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = dict(error=False, code=200, data=b"{}")
+
+        with mock.patch.object(
+            netius.clients.HTTPClient, "get_s", return_value=result
+        ) as get_s:
+            self.server._consul_get("http://localhost:8500/v1/catalog/services")
+
+        # without a token there is no header of one, so that a catalogue
+        # that is open is not sent an empty credential
+        self.assertEqual("X-Consul-Token" in get_s.call_args[1]["headers"], False)
+
+    def test_consul_get_error(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = dict(error=True, message="connection refused")
+
+        with mock.patch.object(netius.clients.HTTPClient, "get_s", return_value=result):
+            value = self.server._consul_get("http://localhost:8500/v1/catalog/services")
+
+        # a request that failed names no service, the absence of a value
+        # being what the caller of it reads
+        self.assertEqual(value, None)
+
+    def test_consul_get_code(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = dict(error=False, code=500, data=b"{}")
+
+        with mock.patch.object(netius.clients.HTTPClient, "get_s", return_value=result):
+            value = self.server._consul_get("http://localhost:8500/v1/catalog/services")
+
+        # an answer that is not a successful one carries no catalogue,
+        # whatever the body of it happens to hold
+        self.assertEqual(value, None)
+
+    def test_consul_get_malformed(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        result = dict(error=False, code=200, data=b"not json at all")
+
+        with mock.patch.object(netius.clients.HTTPClient, "get_s", return_value=result):
+            value = self.server._consul_get("http://localhost:8500/v1/catalog/services")
+
+        # a body that cannot be read is caught rather than left to break
+        # the gathering that asked for it
+        self.assertEqual(value, None)
 
     def test_resolve_domain(self):
         tags = ["proxy.enable=true", "proxy.domain=myapp.local"]

--- a/src/netius/test/servers/proxy.py
+++ b/src/netius/test/servers/proxy.py
@@ -78,6 +78,81 @@ class ProxyConnectionTest(unittest.TestCase):
         self.assertEqual(connection.current, netius.common.GZIP_ENCODING)
         self.assertEqual(connection.encodings_a, None)
 
+    def test_set_h2(self):
+        connection = self._make_relay()
+        connection.set_h2()
+
+        # the switch to the binary protocol rebuilds the parser, so the events
+        # that drive the proxy must be bound again or they would be lost
+        for name in ("on_headers", "on_partial", "on_available", "on_unavailable"):
+            self.assertEqual(name in connection.parser.events, True)
+
+    def test_on_headers(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_relay(legacy=True)
+
+        with mock.patch.object(self.server, "on_headers") as on_headers:
+            connection.on_headers()
+
+        # under the legacy protocol the connection and the parser of it are
+        # what reaches the server, there being no stream to stand for them
+        self.assertEqual(on_headers.call_args[0][0], connection)
+        self.assertEqual(on_headers.call_args[0][1], connection.parser)
+
+    def test_on_partial(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_relay(legacy=True)
+
+        with mock.patch.object(self.server, "on_partial") as on_partial:
+            connection.on_partial(b"hello")
+
+        # the payload travels together with the contexts, as it is the server
+        # that decides what is to be done with it
+        self.assertEqual(on_partial.call_args[0][0], connection)
+        self.assertEqual(on_partial.call_args[0][2], b"hello")
+
+    def test_on_available(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_relay()
+        stream = self._make_stream(connection)
+
+        with mock.patch.object(self.server, "on_available") as on_available:
+            connection.on_available()
+
+        # with a stream under way it is the stream that stands for both of the
+        # contexts, so that the throttling is applied to it and not to the
+        # connection that multiplexes it
+        self.assertEqual(on_available.call_args[0][0], stream)
+        self.assertEqual(on_available.call_args[0][1], stream)
+
+    def test_on_unavailable(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_relay()
+        stream = self._make_stream(connection)
+
+        with mock.patch.object(self.server, "on_unavailable") as on_unavailable:
+            connection.on_unavailable()
+
+        self.assertEqual(on_unavailable.call_args[0][0], stream)
+
+        # once the stream is gone the connection takes its place again, which
+        # is what keeps the events of a spent parser from being dropped
+        connection.parser._del_stream(stream.identifier)
+
+        with mock.patch.object(self.server, "on_unavailable") as on_unavailable:
+            connection.on_unavailable()
+
+        self.assertEqual(on_unavailable.call_args[0][0], connection)
+        self.assertEqual(on_unavailable.call_args[0][1], connection.parser)
+
     def _make_connection(self, encoding):
         # builds a proxy connection without the underlying socket, replicating
         # the encoding state that the constructor would otherwise initialize
@@ -91,6 +166,33 @@ class ProxyConnectionTest(unittest.TestCase):
         connection.encodings_a = None
         connection.dynamic = None
         return connection
+
+    def _make_relay(self, legacy=False):
+        # builds a proxy connection without the underlying socket, in the state
+        # that the relaying of the events of the parser reads
+        connection = netius.servers.proxy.ProxyConnection.__new__(
+            netius.servers.proxy.ProxyConnection
+        )
+        connection.owner = self.server
+        connection.legacy = legacy
+        connection.parser = None
+        connection.encoding = netius.common.PLAIN_ENCODING
+        connection.window_o = netius.common.HTTP2_WINDOW
+        if legacy:
+            connection.parser = netius.common.HTTPParser(
+                connection, type=netius.common.REQUEST
+            )
+        else:
+            connection.set_h2()
+        return connection
+
+    def _make_stream(self, connection):
+        # builds an open stream and registers it in the parser, so that it
+        # becomes the context under which the events are relayed
+        stream = netius.common.http2.HTTP2Stream(identifier=1, owner=connection.parser)
+        stream.open()
+        connection.parser._set_stream(stream)
+        return stream
 
     def _make_parser(self, accept_encoding):
         parser = netius.common.HTTPParser(self, type=netius.common.REQUEST)
@@ -110,6 +212,44 @@ class ProxyServerTest(unittest.TestCase):
         unittest.TestCase.tearDown(self)
         self.server.cleanup()
         self.server_a.cleanup()
+
+    def test_stop(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        with mock.patch.object(self.server.container, "stop") as stop:
+            self.server.stop()
+
+        # the loop is the one of the container, so the stopping of the proxy
+        # is the stopping of the container that holds the three of the bases
+        self.assertEqual(stop.called, True)
+
+        # a proxy that has been cleaned up has no container left to be stopped,
+        # and asking for it again must not raise
+        self.server_a.cleanup()
+        self.assertEqual(self.server_a.stop(), None)
+
+    def test_connections_dict(self):
+        # a container that is not running the proxy would delegate the
+        # operation back into it, so the local connections are the ones
+        # reported instead (avoids an infinite recursion)
+        self.assertEqual(self.server.connections_dict(), [])
+        self.assertEqual(self.server.connections_dict(parent=True), [])
+
+        self.server.container.owner = self.server
+
+        # under a running container the connections of every base are reported,
+        # the proxy itself and the two clients that back it
+        result = self.server.connections_dict()
+        self.assertEqual(
+            sorted(result.keys()), ["HTTPClient", "ProxyServer", "RawClient"]
+        )
+        self.assertEqual(result["ProxyServer"], [])
+
+    def test_connection_dict(self):
+        # the lookup spans every base of the container, an identifier that
+        # names none of their connections giving nothing back
+        self.assertEqual(self.server.connection_dict(999), None)
 
     def test_is_upgrade(self):
         Parser = collections.namedtuple("Parser", "headers")
@@ -537,6 +677,313 @@ class ProxyServerTest(unittest.TestCase):
         self.server._apply_accept(headers)
         self.assertEqual(headers["accept-encoding"], "gzip, deflate")
 
+    def test_on_data(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = mock.MagicMock()
+        connection.tunnel_c = None
+        self.server.on_data(connection, b"hello")
+
+        # with no tunnel in place the data belongs to the proxy itself (the
+        # handshake or a plain client proxy), so it is handed to the parser
+        self.assertEqual(connection.parse.call_args[0][0], b"hello")
+
+        connection = self._make_tunnelled()
+        connection.tunnel_c.is_exhausted.return_value = False
+        self.server.on_data(connection, b"hello")
+
+        # once the tunnel is up the data is relayed to the other end of it,
+        # under a callback that resumes this one as the buffer drains
+        self.assertEqual(connection.tunnel_c.send.call_args[0][0], b"hello")
+        self.assertEqual(
+            connection.tunnel_c.send.call_args[1]["callback"], self.server._throttle
+        )
+        self.assertEqual(connection.parse.called, False)
+        self.assertEqual(connection.disable_read.called, False)
+
+        connection = self._make_tunnelled()
+        connection.tunnel_c.is_exhausted.return_value = True
+        self.server.on_data(connection, b"hello")
+
+        # with the buffer of the other end full the reading of this one is
+        # turned off, which is what keeps the two in step
+        self.assertEqual(connection.disable_read.called, True)
+
+    def test_on_connection_d(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = mock.MagicMock()
+        tunnel_c = connection.tunnel_c
+        proxy_c = connection.proxy_c
+
+        self.server.on_connection_d(connection)
+
+        # both of the ends that the connection was paired with are closed and
+        # marked as such, so that the diagnostics may tell them apart from the
+        # ones that were closed by their own peer
+        self.assertEqual(tunnel_c.connection.close_reason, netius.REASON_EXPLICIT)
+        self.assertEqual(tunnel_c.close.called, True)
+        self.assertEqual(proxy_c.connection.close_reason, netius.REASON_EXPLICIT)
+        self.assertEqual(proxy_c.close.called, True)
+
+        # the references are released, as holding them would keep both of the
+        # ends (and their buffers) alive for as long as the connection is
+        self.assertEqual(connection.tunnel_c, None)
+        self.assertEqual(connection.proxy_c, None)
+        self.assertEqual(connection.encoding_b, None)
+
+    def test_on_stream_d(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        stream = mock.MagicMock()
+        proxy_c = stream.proxy_c
+
+        self.server.on_stream_d(stream)
+
+        # under the binary protocol it's the stream that owns the exchange, so
+        # the release must happen for it and not for the connection that
+        # multiplexes it (which outlives the stream)
+        self.assertEqual(proxy_c.connection.close_reason, netius.REASON_EXPLICIT)
+        self.assertEqual(proxy_c.close.called, True)
+        self.assertEqual(stream.tunnel_c, None)
+        self.assertEqual(stream.proxy_c, None)
+        self.assertEqual(stream.encoding_b, None)
+
+    def test_on_headers(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = mock.MagicMock()
+        self.server.on_headers(connection, None)
+
+        # outside of the automatic mode nothing is negotiated with the client,
+        # so the (per request) resolution cost is not paid at all
+        self.assertEqual(connection.resolve_encoding.called, False)
+
+        self.server_a.on_headers(connection, None)
+
+        # under the automatic mode the encoding is resolved as soon as the
+        # request headers are known, ahead of any rewriting of them
+        self.assertEqual(connection.resolve_encoding.called, True)
+
+    def test_on_partial(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_throttled()
+        connection.proxy_c = None
+
+        # a connection with no back-end (a raw tunnel or a proxy that is not
+        # yet established) has nowhere to forward the payload to
+        self.assertEqual(self.server.on_partial(connection, None, b"hello"), None)
+
+        connection = self._make_throttled()
+        self.server.on_partial(connection, None, b"hello")
+
+        # the payload is forced into the back-end, the reading of the front-end
+        # being left on as the buffer of the back-end has room for it
+        self.assertEqual(connection.proxy_c.send_base.call_args[0][0], b"hello")
+        self.assertEqual(connection.disable_read.called, False)
+
+        connection = self._make_throttled(exhausted=True)
+        self.server.on_partial(connection, None, b"hello")
+
+        # with the buffer of the back-end full the reading of the front-end is
+        # turned off, which is what stops the payload from piling up
+        self.assertEqual(connection.disable_read.called, True)
+
+    def test_on_available(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_throttled()
+
+        with mock.patch.object(self.server, "reads") as reads:
+            self.server.on_available(connection, None)
+
+        # the reading of the back-end is turned back on once the buffer of
+        # the front-end has drained, and the poll is told about it
+        self.assertEqual(connection.proxy_c.enable_read.called, True)
+        self.assertEqual(reads.call_args[1]["state"], False)
+
+    def test_on_available_enabled(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_throttled(renable=True)
+
+        self.server.on_available(connection, None)
+
+        # a back-end whose reading was never turned off has nothing to be
+        # turned back on, so it is left as it is
+        self.assertEqual(connection.proxy_c.enable_read.called, False)
+
+    def test_on_available_pending(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_throttled(restored=False)
+
+        self.server.on_available(connection, None)
+
+        # with the buffer of the front-end still holding data the back-end
+        # is kept quiet, as reading more would only add to it
+        self.assertEqual(connection.proxy_c.enable_read.called, False)
+
+    def test_on_unavailable(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_throttled(renable=True, exhausted=True)
+
+        self.server.on_unavailable(connection, None)
+
+        # the buffer of the front-end is full, so the reading of the
+        # back-end is turned off until it drains again
+        self.assertEqual(connection.proxy_c.disable_read.called, True)
+
+    def test_on_unavailable_disabled(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_throttled(exhausted=True)
+
+        self.server.on_unavailable(connection, None)
+
+        # a back-end that is already quiet is left alone, instead of being
+        # turned off a second time
+        self.assertEqual(connection.proxy_c.disable_read.called, False)
+
+    def test_on_unavailable_room(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_throttled(renable=True)
+
+        self.server.on_unavailable(connection, None)
+
+        # with room left in the buffer of the front-end there is nothing to
+        # defend against, so the back-end keeps reading
+        self.assertEqual(connection.proxy_c.disable_read.called, False)
+
+    def test__throttle(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        # a back-end that is already gone asks for nothing of the front-end
+        # that it was mapped to
+        self.assertEqual(self.server._throttle(None), None)
+
+        backend = mock.MagicMock()
+        backend.is_restored.return_value = False
+
+        # a back-end whose buffer still holds data is under back-pressure, so
+        # the throttling of the front-end must remain in place
+        self.assertEqual(self.server._throttle(backend), None)
+
+        backend = mock.MagicMock()
+        backend.is_restored.return_value = True
+
+        # a back-end that is no longer mapped (eg: a connection under a
+        # graceful close) has no front-end left to be resumed
+        self.assertEqual(self.server._throttle(backend), None)
+
+        frontend = mock.MagicMock()
+        frontend.renable = False
+        self.server.conn_map[backend._protocol] = frontend
+
+        with mock.patch.object(self.server, "reads") as reads:
+            self.server._throttle(backend)
+
+        # the protocol is what stands for the back-end under the new
+        # architecture, so it's the key under which the front-end is found
+        self.assertEqual(frontend.enable_read.called, True)
+        self.assertEqual(reads.call_args[1]["state"], False)
+
+        frontend.enable_read.reset_mock()
+        frontend.renable = True
+        self.server._throttle(backend)
+
+        # a front-end whose reading was never turned off has nothing to be
+        # turned back on, so it is left as it is
+        self.assertEqual(frontend.enable_read.called, False)
+
+    def test__prx_throttle(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        # neither a connection that is gone nor one that still holds data asks
+        # for anything of the back-end that faces it
+        self.assertEqual(self.server._prx_throttle(None), None)
+
+        connection = self._make_throttled(restored=False)
+        self.server._prx_throttle(connection)
+
+        self.assertEqual(connection.proxy_c.enable_read.called, False)
+
+        connection = self._make_throttled()
+        connection.proxy_c = None
+
+        # a connection with no back-end has nothing to be resumed, which is
+        # the case of a raw tunnel or of a proxy that is not established
+        self.assertEqual(self.server._prx_throttle(connection), None)
+
+        connection = self._make_throttled()
+
+        with mock.patch.object(self.server, "reads") as reads:
+            self.server._prx_throttle(connection)
+
+        # the reading of the back-end is turned back on once the buffer of the
+        # front-end has drained, and the poll is told about it
+        self.assertEqual(connection.proxy_c.enable_read.called, True)
+        self.assertEqual(reads.call_args[1]["state"], False)
+
+    def test__raw_throttle(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_tunnelled()
+
+        with mock.patch.object(self.server, "reads") as reads:
+            self.server._raw_throttle(connection)
+
+        # the reading of the other side of the tunnel is turned back on
+        # once this one has drained, which is what keeps the two in step
+        self.assertEqual(connection.tunnel_c.enable_read.called, True)
+        self.assertEqual(reads.call_args[1]["state"], False)
+
+    def test__raw_throttle_missing(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        # neither a connection that is gone nor one that still holds data
+        # asks for anything of the side that faces it
+        self.assertEqual(self.server._raw_throttle(None), None)
+
+        connection = self._make_tunnelled(restored=False)
+        self.server._raw_throttle(connection)
+
+        self.assertEqual(connection.tunnel_c.enable_read.called, False)
+
+    def test__raw_throttle_untunnelled(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = self._make_tunnelled()
+        connection.tunnel_c = None
+
+        # a connection that faces no tunnel has no other side to be told
+        # about it, so nothing is done for it
+        self.assertEqual(self.server._raw_throttle(connection), None)
+
+        connection = self._make_tunnelled(renable=True)
+        self.server._raw_throttle(connection)
+
+        self.assertEqual(connection.tunnel_c.enable_read.called, False)
+
     def test_on_raw_connect_data(self):
         if mock == None:
             self.skipTest("Skipping test: mock unavailable")
@@ -576,6 +1023,53 @@ class ProxyServerTest(unittest.TestCase):
         self.assertEqual(connection.send_response.call_args[1]["code"], 200)
         self.assertEqual(backend.send.call_count, 0)
 
+    def test_on_raw_data(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = mock.MagicMock()
+        connection.is_exhausted.return_value = False
+        backend = mock.MagicMock()
+        self.server.conn_map[backend] = connection
+
+        self.server._on_raw_data(self.server.raw_client, backend, b"hello")
+
+        # the data of the back-end is relayed to the front-end under a callback
+        # that resumes the back-end as the buffer of the front-end drains
+        self.assertEqual(connection.send.call_args[0][0], b"hello")
+        self.assertEqual(
+            connection.send.call_args[1]["callback"], self.server._raw_throttle
+        )
+        self.assertEqual(backend.disable_read.called, False)
+
+        connection.is_exhausted.return_value = True
+        self.server._on_raw_data(self.server.raw_client, backend, b"hello")
+
+        # with the buffer of the front-end full the reading of the back-end is
+        # turned off, which is what stops the data from piling up
+        self.assertEqual(backend.disable_read.called, True)
+
+    def test_on_raw_close(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        connection = mock.MagicMock()
+        backend = mock.MagicMock()
+        self.server.conn_map[backend] = connection
+
+        self.server._on_raw_close(self.server.raw_client, backend)
+
+        # the front-end is closed with the pending data flushed and under a
+        # reason that names the back-end as the origin of the closing
+        self.assertEqual(connection.close.call_args[1]["flush"], True)
+        self.assertEqual(
+            connection.close.call_args[1]["reason"], netius.REASON_UPSTREAM_ERROR
+        )
+
+        # the mapping is released, as holding it would keep both of the ends
+        # (and their buffers) alive for the lifetime of the proxy
+        self.assertEqual(backend in self.server.conn_map, False)
+
     def _make_frontend(
         self,
         accept_encoding="gzip, deflate",
@@ -607,3 +1101,21 @@ class ProxyServerTest(unittest.TestCase):
         parser.code_s = code_s
         parser.content_l = content_l
         return parser
+
+    def _make_throttled(self, renable=False, restored=True, exhausted=False):
+        # builds a front-end connection stand-in together with the back-end
+        # one that faces it, in the state that the throttling gates read
+        connection = mock.MagicMock()
+        connection.is_restored.return_value = restored
+        connection.is_exhausted.return_value = exhausted
+        connection.proxy_c.renable = renable
+        connection.proxy_c.is_exhausted.return_value = exhausted
+        return connection
+
+    def _make_tunnelled(self, renable=False, restored=True):
+        # builds a connection stand-in together with the other end of the
+        # tunnel that it is paired with, under the same terms
+        connection = mock.MagicMock()
+        connection.is_restored.return_value = restored
+        connection.tunnel_c.renable = renable
+        return connection


### PR DESCRIPTION
Closes out the two modules that step 4 of #102 left short of the target, `servers/proxy.py` and `extra/proxy_c.py`. What was left of them is the part that step 4 could not shape cases for: the Consul discovery, which speaks HTTP to a catalogue over a background thread, and the event and throttling handling of the proxy server, which is driven by a live socket.

## Coverage

Measured on Python 3.14, which is the interpreter the coverage job runs.

| Module | Before | After |
| --- | ---: | ---: |
| `servers/proxy.py` | 81.6% | **95.4%** |
| `extra/proxy_c.py` | 82.3% | **94.1%** |
| together | 81.9% | **94.8%** |

The package as a whole moves from 70.0% to 70.9% on a single platform, so the floor of the job goes from 70 to 71.

## What is covered

**`servers/proxy.py`**

- the relaying of the events of the parser by `ProxyConnection`, including the rebinding of them across the switch to the binary protocol and the fact that under HTTP/2 it is the stream, and not the connection that multiplexes it, that stands for both of the contexts
- the life cycle and the introspection of the server, `stop`, `connections_dict` and `connection_dict`
- the forwarding of the data of a raw tunnel and the release of both of its ends when a connection or a stream dies
- the four throttling gates, `_throttle`, `_prx_throttle`, `_raw_throttle` and the `on_available` / `on_unavailable` pair, each one probed on both sides of its condition
- the relaying and the closing of the raw tunnel, `_on_raw_data` and `_on_raw_close`

**`extra/proxy_c.py`**

- the tick of the discovery, including the failed gathering and the single shot form
- the catalogue and the health endpoints, the shape of the addresses they are asked for included
- the HTTP layer itself, `_consul_get`, over the token, the anonymous, the failed, the non successful and the malformed cases

## Bugs found

Two, both surfaced by the cases rather than adapted to.

**The connections of an idle proxy could not be listed.** `ProxyServer.connections_dict` delegates to its container, and the container delegates back into the base that owns it. That guard reads `self.owner`, which is only set once the container is started, so on a proxy that is not running the two of them recurse until the interpreter gives up:

```
E   RecursionError: maximum recursion depth exceeded in comparison
!!! Recursion detected (same locals & position)
```

The local connections are now reported when the container has no owner, which is the same answer the parent form gives.

**The Consul catalogue was never read under Python 3.5.** `_consul_get` hands the raw payload to `json.loads`, which only accepts a byte sequence from Python 3.6 onwards. Under 3.5 it raises, the raise is swallowed by the `except` that wraps it, and the discovery quietly settles on an empty host map. The payload is now decoded before being parsed.

The first one is caught by `test_connections_dict`, the second one by `test_consul_get`; both fail against the source as it stands on master.

## Verification

- 1676 passed on Python 3.14, 1666 on 3.5 and 1303 on 2.7 (the rest skipped, `mock` being unavailable there)
- `black --check` and `mypy.stubtest` clean

Part of #102.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are a small guard in diagnostics listing, a decode-before-parse fix for Consul JSON, plus tests and a coverage floor bump—limited blast radius outside proxy/Consul paths.
> 
> **Overview**
> Closes the coverage gap for **`servers/proxy.py`** and **`extra/proxy_c.py`** (#102) with broad unit tests around Consul discovery (`_consul_tick`, catalog/health/`_consul_get`) and proxy behavior (parser event relay, HTTP/2 streams, throttling, raw tunnel relay/close, `stop` / `connections_dict`).
> 
> Two production fixes surfaced by the new tests: **`ProxyServer.connections_dict`** no longer recurses when the container is not running (`owner` unset)—it reports local connections like the `parent=True` path. **`ConsulProxyServer._consul_get`** UTF-8-decodes the HTTP body before **`json.loads`**, so catalogue data works on Python 3.5 instead of being swallowed by the error handler.
> 
> CI coverage **`fail-under`** moves **70 → 71**; **CHANGELOG** documents the proxy fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e6c767f4701cb900adba8275f7b89ba75eb9e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->