### PR TITLE
style(test): move the module helpers below the cases that use them

### DIFF
--- a/src/netius/test/servers/asgi.py
+++ b/src/netius/test/servers/asgi.py
@@ -1799,29 +1799,6 @@ class ASGIServerTest(unittest.TestCase):
         return app
 
 
-class LegacyApp(object):
-    """
-    Application that complies with the legacy (double callable)
-    interface of the specification, used to verify the detection
-    of the interface version of an application.
-    """
-
-    def __init__(self, scope):
-        self.scope = scope
-
-
-class ModernApp(object):
-    """
-    Application that complies with the current (single callable)
-    interface of the specification, used to verify the detection
-    of the interface version of an application.
-    """
-
-    @netius.coroutine
-    def __call__(self, scope, receive, send):
-        yield
-
-
 class ASGIStubTest(unittest.TestCase):
 
     def test_unsupported(self):
@@ -1870,3 +1847,26 @@ class LoadAppTest(unittest.TestCase):
             netius.servers.asgi.load_app,
             "netius.servers.asgi:invalid",
         )
+
+
+class LegacyApp(object):
+    """
+    Application that complies with the legacy (double callable)
+    interface of the specification, used to verify the detection
+    of the interface version of an application.
+    """
+
+    def __init__(self, scope):
+        self.scope = scope
+
+
+class ModernApp(object):
+    """
+    Application that complies with the current (single callable)
+    interface of the specification, used to verify the detection
+    of the interface version of an application.
+    """
+
+    @netius.coroutine
+    def __call__(self, scope, receive, send):
+        yield

--- a/src/netius/test/servers/dhcp.py
+++ b/src/netius/test/servers/dhcp.py
@@ -47,32 +47,6 @@ SIADDR = "11.11.11.2"
 GIADDR = "10.10.10.1"
 
 
-def build_request(mac=MAC, type=0x01):
-    # builds a discover request as it would arrive from the wire, with the
-    # relay address set so that the echoing of it may be verified
-    chaddr = struct.unpack("!QQ", mac + b"\0" * 10)
-    header = struct.pack(
-        HEADER_FORMAT,
-        0x01,
-        0x01,
-        0x06,
-        0x00,
-        0x12345678,
-        0x0000,
-        0x0000,
-        0,
-        0,
-        netius.common.ip4_to_addr(SIADDR),
-        netius.common.ip4_to_addr(GIADDR),
-        chaddr[0],
-        chaddr[1],
-        b"",
-        b"",
-    )
-    options = struct.pack("!BBB", 53, 1, type) + b"\xff"
-    return header + struct.pack("!I", MAGIC) + options
-
-
 class DHCPRequestTest(unittest.TestCase):
 
     def test_parse(self):
@@ -150,3 +124,29 @@ class DHCPRequestTest(unittest.TestCase):
         # the hardware address is echoed untouched, as it's the value that
         # identifies the client that the response is meant for
         self.assertEqual((result[11], result[12]), request.chaddr)
+
+
+def build_request(mac=MAC, type=0x01):
+    # builds a discover request as it would arrive from the wire, with the
+    # relay address set so that the echoing of it may be verified
+    chaddr = struct.unpack("!QQ", mac + b"\0" * 10)
+    header = struct.pack(
+        HEADER_FORMAT,
+        0x01,
+        0x01,
+        0x06,
+        0x00,
+        0x12345678,
+        0x0000,
+        0x0000,
+        0,
+        0,
+        netius.common.ip4_to_addr(SIADDR),
+        netius.common.ip4_to_addr(GIADDR),
+        chaddr[0],
+        chaddr[1],
+        b"",
+        b"",
+    )
+    options = struct.pack("!BBB", 53, 1, type) + b"\xff"
+    return header + struct.pack("!I", MAGIC) + options

--- a/src/netius/test/servers/torrent.py
+++ b/src/netius/test/servers/torrent.py
@@ -135,6 +135,27 @@ class TorrentTaskTest(unittest.TestCase):
         self.assertEqual(task.peers[0]["ip"], "1.2.3.4")
 
 
+class _MockOwner(object):
+
+    def __init__(self):
+        self.max_peers = netius.servers.torrent.MAX_PEERS
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+
+class _MockResponse(object):
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def get_payload(self):
+        return self.payload
+
+
 def _build_task(info_hash=None):
     task = netius.servers.TorrentTask.__new__(netius.servers.TorrentTask)
     task.owner = _MockOwner()
@@ -155,24 +176,3 @@ def _build_task(info_hash=None):
     task.trigger = lambda *args, **kwargs: None
 
     return task
-
-
-class _MockOwner(object):
-
-    def __init__(self):
-        self.max_peers = netius.servers.torrent.MAX_PEERS
-
-    def warning(self, *args, **kwargs):
-        pass
-
-    def debug(self, *args, **kwargs):
-        pass
-
-
-class _MockResponse(object):
-
-    def __init__(self, payload):
-        self.payload = payload
-
-    def get_payload(self):
-        return self.payload


### PR DESCRIPTION
Pure relocation, no line of a helper or of a case is changed. `src/netius/test/clients/dht.py` already had the layout that the rest of the test tree did not follow, the cases first and the helpers after them, and three modules were out of step with it.

| Module | Helper | Was | Now |
| --- | --- | --- | --- |
| `test/servers/asgi.py` | `LegacyApp`, `ModernApp` | between `ASGIServerTest` and `ASGIStubTest` | after `LoadAppTest` |
| `test/servers/dhcp.py` | `build_request` | above `DHCPRequestTest` | after it |
| `test/servers/torrent.py` | `_build_task` | between the case and the two mocks | after `_MockResponse` |

Every one of them is only ever named from inside a method, so the move is safe: the name is resolved when the case runs and not when the module is imported.

## One module deliberately left alone

`test/common/http2.py` keeps `_pack_frame` where it is. It is not the same situation: the module builds its frame constants by calling it at import time, so moving the definition below them fails on the spot.

```
    SETTINGS_FRAME = _pack_frame(
E   NameError: name '_pack_frame' is not defined
```

Moving the constants down with it would put module constants below the cases, which is worse than the inconsistency it would fix.

## Verification

- full suite green on Python 3.14, 3.5 and 2.7
- `black --check` and `mypy.stubtest` clean

No `CHANGELOG.md` entry: nothing observable changes for a user of the package.
