### PR TITLE
test: raise the coverage of the TFTP and FTP servers past 81%

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           pip install coverage
           coverage combine
-          coverage report --sort=-miss --fail-under=79
+          coverage report --sort=-miss --fail-under=80
       - name: Publish coverage summary
         run: |
           echo "## Coverage" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A configuration file is now read under Python 3.5, instead of failing on it
 * A header that is set by its position now replaces the one that is there
 * A string that carries no null byte is now given back whole instead of raising
+* A TFTP file that is served under an absolute name no longer fails to open
 * An environment value that is unset can now be forced into a file, instead of raising
 * The allowed addresses of a service are now honoured, instead of every peer being refused
 * The asyncio compatibility of the event loop no longer fails under Python 3.6
 * The check for a test run no longer raises when a caller carries no source
 * The connections of a proxy can now be listed before it is started, instead of failing
+* The error that a TFTP peer is answered with now reads as a message, instead of raw values
 * The keep alive tuning of a connection now reaches the socket, instead of being dropped
 * The service catalogue of a Consul proxy is now read under Python 3.5, instead of being dropped
 * The SOCKS server can now be built and served, instead of failing on creation - [#123](https://github.com/hivesolutions/netius/issues/123)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A header that is set by its position now replaces the one that is there
 * A string that carries no null byte is now given back whole instead of raising
 * A TFTP file that is served under an absolute name no longer fails to open
+* A TFTP peer can no longer reach a file outside the root that is served
 * An environment value that is unset can now be forced into a file, instead of raising
 * An FTP peer can no longer reach a file outside the root that is served
 * The allowed addresses of a service are now honoured, instead of every peer being refused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A string that carries no null byte is now given back whole instead of raising
 * A TFTP file that is served under an absolute name no longer fails to open
 * An environment value that is unset can now be forced into a file, instead of raising
+* An FTP peer can no longer reach a file outside the root that is served
 * The allowed addresses of a service are now honoured, instead of every peer being refused
 * The asyncio compatibility of the event loop no longer fails under Python 3.6
 * The check for a test run no longer raises when a caller carries no source

--- a/src/netius/servers/ftp.py
+++ b/src/netius/servers/ftp.py
@@ -497,7 +497,9 @@ class FTPConnection(netius.Connection):
         # verifies if the resolved path starts with the contents of the
         # base path in case it does not it's a security issue and a proper
         # exception must be raised indicating the issue
-        is_sub = relative_path.startswith(self.base_path)
+        is_sub = relative_path == self.base_path or relative_path.startswith(
+            os.path.join(self.base_path, "")
+        )
         if not is_sub:
             raise netius.SecurityError("Invalid path")
 

--- a/src/netius/servers/ftp.py
+++ b/src/netius/servers/ftp.py
@@ -493,6 +493,14 @@ class FTPConnection(netius.Connection):
         relative_path = os.path.join(relative_path, extra)
         relative_path = os.path.abspath(relative_path)
         relative_path = os.path.normpath(relative_path)
+
+        # verifies if the resolved path starts with the contents of the
+        # base path in case it does not it's a security issue and a proper
+        # exception must be raised indicating the issue
+        is_sub = relative_path.startswith(self.base_path)
+        if not is_sub:
+            raise netius.SecurityError("Invalid path")
+
         return relative_path
 
 

--- a/src/netius/servers/tftp.py
+++ b/src/netius/servers/tftp.py
@@ -108,7 +108,18 @@ class TFTPSession(object):
         name = self.name
         if not allow_absolute:
             name = name.lstrip("/")
-        path = os.path.join(self.owner.base_path, name)
+        base_path = os.path.abspath(self.owner.base_path)
+        path = os.path.join(base_path, name)
+        path = os.path.abspath(path)
+        path = os.path.normpath(path)
+
+        # verifies if the resolved path starts with the contents of the
+        # base path in case it does not it's a security issue and a proper
+        # exception must be raised indicating the issue
+        is_sub = path == base_path or path.startswith(os.path.join(base_path, ""))
+        if not is_sub:
+            raise netius.SecurityError("Invalid path")
+
         self.file = open(path, "rb")
         return self.file
 

--- a/src/netius/servers/tftp.py
+++ b/src/netius/servers/tftp.py
@@ -105,8 +105,9 @@ class TFTPSession(object):
     def _get_file(self, allow_absolute=False):
         if self.file:
             return self.file
+        name = self.name
         if not allow_absolute:
-            name = self.name.lstrip("/")
+            name = name.lstrip("/")
         path = os.path.join(self.owner.base_path, name)
         self.file = open(path, "rb")
         return self.file
@@ -261,7 +262,7 @@ class TFTPServer(netius.DatagramServer):
         self.debug("Received %s message from '%s'", type_s, address)
 
         if not type in cls.ALLOWED_OPERATIONS:
-            raise netius.NetiusError("Invalid operation type '%d'", type)
+            raise netius.NetiusError("Invalid operation type '%d'" % type)
 
         response = request.response()
         if not response:

--- a/src/netius/test/servers/ftp.py
+++ b/src/netius/test/servers/ftp.py
@@ -28,13 +28,22 @@ __copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
+import os
+import shutil
+import socket
 import logging
+import tempfile
 import unittest
 
 import netius
 import netius.servers
 
 from netius.servers import ftp
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
 
 
 class FTPConnectionTest(unittest.TestCase):
@@ -113,3 +122,450 @@ class FTPConnectionTest(unittest.TestCase):
         # connection is never able to reach it
         for code in ("LINE", "FLUSH_LIST", "FLUSH_RETR"):
             self.assertRaises(netius.ParserError, self.connection.on_line, code, "")
+
+
+class FTPConnectionPathTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.base = tempfile.mkdtemp()
+        self.server = netius.servers.FTPServer(
+            base_path=self.base, level=logging.CRITICAL
+        )
+        self.connection = ftp.FTPConnection.__new__(ftp.FTPConnection)
+        self.connection.owner = self.server
+        self.connection.base_path = os.path.abspath(self.base)
+        self.connection.cwd = "/"
+        self.connection.mode = "ascii"
+        self.connection.data_server = None
+        self.connection.remaining = None
+        self.sent = []
+        self.connection.send_ftp = lambda code, message="", **kwargs: self.sent.append(
+            (code, message)
+        )
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+        shutil.rmtree(self.base)
+
+    def test_ready(self):
+        self.connection.host = "ftp.localhost"
+
+        self.connection.ready()
+
+        # the greeting of the service names the host that it answers for, so
+        # that the peer knows what it reached
+        self.assertEqual(self.sent[-1][0], 220)
+        self.assertEqual("ftp.localhost" in self.sent[-1][1], True)
+
+    def test_ok(self):
+        self.connection.ok()
+        self.assertEqual(self.sent[-1], (200, "ok"))
+
+        self.connection.not_ok()
+
+        # the two plain answers of the protocol, one for a command that was
+        # served and one for a command that was refused
+        self.assertEqual(self.sent[-1], (500, "not ok"))
+
+    def test_flush_ftp(self):
+        # a connection with nothing left over has no flushing of its own to
+        # be done, and must not reach for a handler that does not exist
+        self.assertEqual(self.connection.flush_ftp(), None)
+
+        self.connection.remaining = "list"
+
+        with mock.patch.object(self.connection, "flush_list") as flush_list:
+            self.connection.flush_ftp()
+
+        # what was left over names the handler that runs, and it is cleared
+        # afterwards so that it never runs twice
+        self.assertEqual(flush_list.called, True)
+        self.assertEqual(self.connection.remaining, None)
+
+        self.connection.remaining = "list"
+
+        with mock.patch.object(self.connection, "flush_list", side_effect=Exception):
+            self.assertRaises(Exception, self.connection.flush_ftp)
+
+        # a handler that fails still clears what was left over, or the
+        # connection would try the same operation again
+        self.assertEqual(self.connection.remaining, None)
+
+    def test_closed_ftp(self):
+        # a connection that was never storing a file has none of it to be
+        # closed, so the ending of the transfer is a no operation
+        self.assertEqual(self.connection.closed_ftp(), None)
+
+        path = self._store("file.txt", b"")
+        self.connection.file = open(path, "wb")
+
+        self.connection.closed_ftp()
+
+        # the file that was being received is closed and the peer is told
+        # that the transfer of it is complete
+        self.assertEqual(self.connection.file, None)
+        self.assertEqual(self.sent[-1][0], 226)
+
+    def test_data_ftp(self):
+        path = self._store("file.txt", b"")
+        self.connection.file = open(path, "wb")
+        try:
+            self.connection.data_ftp(b"contents")
+        finally:
+            self.connection.file.close()
+
+        # what arrives over the data connection is written to the file that
+        # the transfer opened for it
+        file = open(path, "rb")
+        try:
+            self.assertEqual(file.read(), b"contents")
+        finally:
+            file.close()
+
+    def test_on_syst(self):
+        self.connection.on_syst("")
+
+        # the kind of the system is answered with, carrying the version of
+        # the package that serves it
+        self.assertEqual(self.sent[-1][0], 215)
+        self.assertEqual("UNIX Type: L8" in self.sent[-1][1], True)
+
+    def test_on_opts(self):
+        self.connection.on_opts("UTF8 ON")
+        self.assertEqual(self.sent[-1], (200, "ok"))
+
+        self.connection.on_port("")
+
+        # neither the options nor the active mode change anything of the
+        # session, both of them being answered plainly
+        self.assertEqual(self.sent[-1], (200, "ok"))
+
+    def test_on_dele(self):
+        path = self._store("file.txt", b"contents")
+
+        self.connection.on_dele("file.txt")
+
+        # the file that was named is removed from the disk and the peer is
+        # told that the command was served
+        self.assertEqual(os.path.exists(path), False)
+        self.assertEqual(self.sent[-1], (200, "ok"))
+
+        self.connection.on_dele("file.txt")
+
+        # a file that is no longer there cannot be removed again, which is
+        # reported back rather than raised
+        self.assertEqual(self.sent[-1], (500, "not ok"))
+
+    def test_on_mkd(self):
+        self.connection.on_mkd("folder")
+
+        # the directory that was named is created under the root of the
+        # service, the peer being told that it was
+        self.assertEqual(os.path.isdir(os.path.join(self.base, "folder")), True)
+        self.assertEqual(self.sent[-1], (200, "ok"))
+
+        self.connection.on_mkd("folder")
+
+        # a directory that is already there cannot be created again
+        self.assertEqual(self.sent[-1], (500, "not ok"))
+
+    def test_on_rmd(self):
+        os.makedirs(os.path.join(self.base, "folder"))
+
+        self.connection.on_rmd("folder")
+
+        self.assertEqual(os.path.isdir(os.path.join(self.base, "folder")), False)
+        self.assertEqual(self.sent[-1], (200, "ok"))
+
+        self.connection.on_rmd("folder")
+
+        # a directory that is no longer there cannot be removed again
+        self.assertEqual(self.sent[-1], (500, "not ok"))
+
+    def test_on_rnfr(self):
+        self._store("file.txt", b"contents")
+
+        self.connection.on_rnfr("file.txt")
+        self.connection.on_rnto("other.txt")
+
+        # the renaming takes two commands, the first one naming the source
+        # and the second one the target that it moves to
+        self.assertEqual(os.path.exists(os.path.join(self.base, "other.txt")), True)
+        self.assertEqual(self.sent[-1], (200, "ok"))
+
+        # both of the paths are cleared once the renaming is over, so that a
+        # later one never reuses them
+        self.assertEqual(self.connection.source_path, None)
+        self.assertEqual(self.connection.target_path, None)
+
+    def test_on_rnto_missing(self):
+        self.connection.on_rnfr("missing.txt")
+        self.connection.on_rnto("other.txt")
+
+        # a source that is not there cannot be renamed, which is reported
+        # back instead of raising
+        self.assertEqual(self.sent[-1], (500, "not ok"))
+        self.assertEqual(self.connection.source_path, None)
+
+    def test_on_cdup(self):
+        self.connection.cwd = "/one/two"
+
+        self.connection.on_cdup("")
+
+        # walking up takes the last part of the working directory off it
+        self.assertEqual(self.connection.cwd, "/one")
+
+        self.connection.on_cdup("")
+        self.assertEqual(self.connection.cwd, "/")
+
+        self.connection.on_cdup("")
+
+        # the root has nothing above it, so walking up from it stays where
+        # it is instead of leaving the working directory empty
+        self.assertEqual(self.connection.cwd, "/")
+
+    def test_on_cwd(self):
+        os.makedirs(os.path.join(self.base, "folder"))
+
+        self.connection.on_cwd("folder")
+
+        # a directory that exists becomes the working one, named relative to
+        # the root of the service
+        self.assertEqual(self.connection.cwd, "/folder")
+        self.assertEqual(self.sent[-1], (200, "ok"))
+
+        self.connection.on_cwd("/")
+        self.assertEqual(self.connection.cwd, "/")
+
+        self.connection.on_cwd("missing")
+
+        # a directory that does not exist cannot be entered, the working one
+        # staying where it was
+        self.assertEqual(self.sent[-1][0], 550)
+        self.assertEqual(self.connection.cwd, "/")
+
+    def test_on_size(self):
+        self._store("file.txt", b"0" * 12)
+
+        self.connection.on_size("file.txt")
+
+        # the size of a file is the one on the disk, answered as a plain
+        # number of bytes
+        self.assertEqual(self.sent[-1], (213, "12"))
+
+        os.makedirs(os.path.join(self.base, "folder"))
+
+        self.connection.on_size("folder")
+
+        # a directory has no size of its own to be reported, so it counts
+        # as an empty one
+        self.assertEqual(self.sent[-1], (213, "0"))
+
+    def test_on_mdtm(self):
+        self._store("file.txt", b"contents")
+
+        self.connection.on_mdtm("file.txt")
+
+        # the moment a file was last written is answered as a stamp of the
+        # fourteen digits that name it
+        self.assertEqual(self.sent[-1][0], 213)
+        self.assertEqual(len(self.sent[-1][1]), 14)
+
+        os.makedirs(os.path.join(self.base, "folder"))
+
+        self.connection.on_mdtm("folder")
+
+        # a directory has no moment of its own, so the start of the epoch is
+        # what stands for it
+        self.assertEqual(self.sent[-1][1], "19700101000000")
+
+    def test_on_quit(self):
+        self.connection.on_quit("")
+        self.assertEqual(self.sent[-1][0], 221)
+
+    def test_on_list(self):
+        self.connection.data_server = mock.MagicMock()
+
+        self.connection.on_list("")
+
+        # the listing is left over for the data connection to flush, as it
+        # is the one that carries it
+        self.assertEqual(self.connection.remaining, "list")
+        self.assertEqual(self.connection.data_server.flush_ftp.called, True)
+
+        self.connection.on_retr("file.txt")
+
+        # the same holds for a file that is read, the name of it being kept
+        # for the flushing that follows
+        self.assertEqual(self.connection.remaining, "retr")
+        self.assertEqual(self.connection.file_name, "file.txt")
+
+        self.connection.on_stor("other.txt")
+
+        self.assertEqual(self.connection.remaining, "stor")
+        self.assertEqual(self.connection.file_name, "other.txt")
+
+    def test_flush_stor(self):
+        self.connection.file_name = "file.txt"
+
+        self.connection.flush_stor()
+        try:
+            # the file that is going to receive the transfer is opened for
+            # writing and the peer is told that it may start
+            self.assertEqual(self.sent[-1][0], 150)
+            self.assertEqual(self.connection.file.closed, False)
+        finally:
+            self.connection.file.close()
+
+    def test__list(self):
+        self._store("file.txt", b"0" * 12)
+        os.makedirs(os.path.join(self.base, "folder"))
+
+        listing = self.connection._list()
+
+        # every entry of the working directory takes a line of its own, the
+        # directory among them being marked as one
+        self.assertEqual("file.txt" in listing, True)
+        self.assertEqual("folder" in listing, True)
+        self.assertEqual(listing.count("\r\n"), 2)
+        self.assertEqual(listing.startswith("d") or "\r\nd" in listing, True)
+
+    def test__list_missing(self):
+        self.connection.cwd = "/missing"
+
+        # a working directory that is not there has nothing to be listed, so
+        # an empty listing is what comes back instead of raising
+        self.assertEqual(self.connection._list(), "")
+
+    def test__to_unix(self):
+        os.makedirs(os.path.join(self.base, "folder"))
+        mode = os.stat(os.path.join(self.base, "folder"))
+
+        # a directory is marked as one, the rest of the report being the
+        # permissions of it rendered the way the protocol expects
+        self.assertEqual(self.connection._to_unix(mode)[0], "d")
+        self.assertEqual(len(self.connection._to_unix(mode)), 10)
+
+        path = self._store("file.txt", b"")
+        mode = os.stat(path)
+
+        self.assertEqual(self.connection._to_unix(mode)[0], "-")
+
+    def test__get_path(self):
+        # with nothing extra the working directory is what the path resolves
+        # to, taken under the root of the service
+        self.assertEqual(self.connection._get_path(), self.connection.base_path)
+        self.assertEqual(
+            self.connection._get_path("file.txt"),
+            os.path.join(self.connection.base_path, "file.txt"),
+        )
+
+        # an absolute name is taken from the root of the service rather than
+        # from the root of the file system
+        self.assertEqual(
+            self.connection._get_path("/file.txt"),
+            os.path.join(self.connection.base_path, "file.txt"),
+        )
+
+    def test__get_path_escape(self):
+        # a name that walks out of the root of the service must be refused,
+        # or a peer would reach any file of the machine
+        self.assertRaises(
+            netius.SecurityError, self.connection._get_path, "../../../etc/passwd"
+        )
+
+        self.connection.cwd = "/folder"
+
+        self.assertRaises(
+            netius.SecurityError, self.connection._get_path, "../../../../etc/passwd"
+        )
+
+    def _store(self, name, contents):
+        path = os.path.join(self.base, name)
+        file = open(path, "wb")
+        try:
+            file.write(contents)
+        finally:
+            file.close()
+        return path
+
+
+class FTPServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.base = tempfile.mkdtemp()
+        self.server = netius.servers.FTPServer(
+            base_path=self.base, level=logging.CRITICAL
+        )
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+        shutil.rmtree(self.base)
+
+    def test_serve(self):
+        with mock.patch.object(netius.ContainerServer, "serve") as serve:
+            self.server.serve()
+
+        # the service listens on the port that the protocol reserves for it
+        self.assertEqual(serve.call_args[1]["port"], 21)
+
+        # the host is the name that the service answers for rather than the
+        # one that it binds to, so it is taken after the serving started
+        self.assertEqual(self.server.host, "ftp.localhost")
+
+    def test_on_connection_c(self):
+        connection = mock.MagicMock()
+
+        self.server.on_connection_c(connection)
+
+        # a peer that reaches the service is greeted as soon as it is taken,
+        # which is what starts the session of it
+        self.assertEqual(connection.ready.called, True)
+
+    def test_on_data(self):
+        connection = mock.MagicMock()
+
+        self.server.on_data(connection, b"NOOP\r\n")
+
+        # what arrives from a peer is given to the parser of the connection,
+        # which is the one that takes the commands apart
+        self.assertEqual(connection.parse.call_args[0][0], b"NOOP\r\n")
+
+    def test_on_serve(self):
+        with mock.patch.object(
+            self.server,
+            "get_env",
+            side_effect=lambda name, default, **kwargs: {
+                "BASE_PATH": "/other",
+                "AUTH": "dummy",
+            }.get(name, default),
+        ):
+            self.server.env = True
+            self.server.on_serve()
+
+        # with an environment to read from, the root of the file service is
+        # the one that it names
+        self.assertEqual(self.server.base_path, "/other")
+
+    def test_build_connection(self):
+        _socket = socket.socket()
+        try:
+            connection = self.server.build_connection(_socket, ("host.domain", 8080))
+
+            # the connection that the service builds carries the root and the
+            # host that the service answers for
+            self.assertEqual(isinstance(connection, ftp.FTPConnection), True)
+            self.assertEqual(connection.base_path, os.path.abspath(self.base))
+            self.assertEqual(connection.host, self.server.host)
+        finally:
+            _socket.close()

--- a/src/netius/test/servers/ftp.py
+++ b/src/netius/test/servers/ftp.py
@@ -149,6 +149,9 @@ class FTPConnectionPathTest(unittest.TestCase):
 
     def tearDown(self):
         unittest.TestCase.tearDown(self)
+        file = hasattr(self.connection, "file") and self.connection.file
+        if file:
+            file.close()
         self.server.cleanup()
         shutil.rmtree(self.base)
 

--- a/src/netius/test/servers/ftp.py
+++ b/src/netius/test/servers/ftp.py
@@ -488,6 +488,22 @@ class FTPConnectionPathTest(unittest.TestCase):
             netius.SecurityError, self.connection._get_path, "../../../../etc/passwd"
         )
 
+    def test__get_path_sibling(self):
+        parent = os.path.dirname(self.connection.base_path)
+        sibling = os.path.basename(self.connection.base_path) + "-backup"
+        os.makedirs(os.path.join(parent, sibling))
+
+        try:
+            # a directory whose name only starts like the root of the service
+            # is not under it, so reaching into it must be refused as well
+            self.assertRaises(
+                netius.SecurityError,
+                self.connection._get_path,
+                "../%s/secret.txt" % sibling,
+            )
+        finally:
+            shutil.rmtree(os.path.join(parent, sibling))
+
     def _store(self, name, contents):
         path = os.path.join(self.base, name)
         file = open(path, "wb")

--- a/src/netius/test/servers/tftp.py
+++ b/src/netius/test/servers/tftp.py
@@ -214,6 +214,38 @@ class TFTPSessionTest(unittest.TestCase):
         # used to leave the name unbound and raise
         self.assertEqual(file.read(), b"contents")
 
+    def test__get_file_escape(self):
+        outside = os.path.join(os.path.dirname(self.base), "outside.txt")
+        file = open(outside, "wb")
+        try:
+            file.write(b"secret")
+        finally:
+            file.close()
+
+        session = self._make_session("../outside.txt")
+
+        try:
+            # the name of a read request arrives from the wire, so one that
+            # walks out of the root must be refused rather than served, or a
+            # peer would read any file of the machine
+            self.assertRaises(netius.SecurityError, session._get_file)
+        finally:
+            os.remove(outside)
+
+    def test__get_file_sibling(self):
+        parent = os.path.dirname(self.base)
+        sibling = os.path.basename(self.base) + "-backup"
+        os.makedirs(os.path.join(parent, sibling))
+
+        session = self._make_session("../%s/secret.txt" % sibling)
+
+        try:
+            # a directory whose name only starts like the root of the service
+            # is not under it, so reaching into it must be refused as well
+            self.assertRaises(netius.SecurityError, session._get_file)
+        finally:
+            shutil.rmtree(os.path.join(parent, sibling))
+
     def _make_session(self, name):
         # builds a session of the service and keeps it, so that the file it
         # reads is released once the case is over

--- a/src/netius/test/servers/tftp.py
+++ b/src/netius/test/servers/tftp.py
@@ -59,15 +59,18 @@ class TFTPSessionTest(unittest.TestCase):
         self.server = netius.servers.TFTPServer(
             base_path=self.base, level=logging.CRITICAL
         )
+        self.sessions = []
 
     def tearDown(self):
         unittest.TestCase.tearDown(self)
+        for session in self.sessions:
+            session.close()
         self.server.cleanup()
         shutil.rmtree(self.base)
 
     def test_close(self):
         self._store(NAME, b"contents")
-        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session = self._make_session(NAME)
         session.next()
         file = session.file
 
@@ -79,7 +82,7 @@ class TFTPSessionTest(unittest.TestCase):
         self.assertEqual(session.file, None)
 
     def test_reset(self):
-        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session = self._make_session(NAME)
         session.completed = True
         session.sequence = 3
 
@@ -95,7 +98,7 @@ class TFTPSessionTest(unittest.TestCase):
 
     def test_next(self):
         self._store(NAME, b"0" * 1024)
-        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session = self._make_session(NAME)
 
         data = session.next()
         type, sequence = struct.unpack("!HH", data[:4])
@@ -127,7 +130,7 @@ class TFTPSessionTest(unittest.TestCase):
 
     def test_next_increment(self):
         self._store(NAME, b"0" * 16)
-        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session = self._make_session(NAME)
 
         data = session.next(increment=False)
 
@@ -138,7 +141,7 @@ class TFTPSessionTest(unittest.TestCase):
 
     def test_ack(self):
         self._store(NAME, b"0" * 1024)
-        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session = self._make_session(NAME)
 
         # an acknowledge that arrives before anything was sent has no block
         # of its own to answer with
@@ -152,7 +155,7 @@ class TFTPSessionTest(unittest.TestCase):
         self.assertEqual(struct.unpack("!H", data[2:4])[0], 2)
 
     def test_increment(self):
-        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session = self._make_session(NAME)
 
         session.increment()
         session.increment()
@@ -162,7 +165,7 @@ class TFTPSessionTest(unittest.TestCase):
         self.assertEqual(session.sequence, 2)
 
     def test_get_info(self):
-        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session = self._make_session(NAME)
         session.sequence = 2
 
         info = session.get_info()
@@ -178,7 +181,7 @@ class TFTPSessionTest(unittest.TestCase):
         if mock == None:
             self.skipTest("Skipping test: mock unavailable")
 
-        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session = self._make_session(NAME)
 
         with mock.patch("sys.stdout", netius.legacy.StringIO()) as stdout:
             session.print_info()
@@ -189,9 +192,7 @@ class TFTPSessionTest(unittest.TestCase):
 
     def test__get_file(self):
         self._store(NAME, b"contents")
-        session = netius.servers.tftp.TFTPSession(
-            self.server, name="/" + NAME, mode=MODE
-        )
+        session = self._make_session("/" + NAME)
 
         file = session._get_file()
 
@@ -205,13 +206,20 @@ class TFTPSessionTest(unittest.TestCase):
 
     def test__get_file_absolute(self):
         path = self._store(NAME, b"contents")
-        session = netius.servers.tftp.TFTPSession(self.server, name=path, mode=MODE)
+        session = self._make_session(path)
 
         file = session._get_file(allow_absolute=True)
 
         # under an absolute name the one of the session is taken whole, which
         # used to leave the name unbound and raise
         self.assertEqual(file.read(), b"contents")
+
+    def _make_session(self, name):
+        # builds a session of the service and keeps it, so that the file it
+        # reads is released once the case is over
+        session = netius.servers.tftp.TFTPSession(self.server, name=name, mode=MODE)
+        self.sessions.append(session)
+        return session
 
     def _store(self, name, contents):
         path = os.path.join(self.base, name)
@@ -235,6 +243,7 @@ class TFTPRequestTest(unittest.TestCase):
 
     def tearDown(self):
         unittest.TestCase.tearDown(self)
+        self.session.close()
         self.server.cleanup()
         shutil.rmtree(self.base)
 
@@ -373,6 +382,8 @@ class TFTPServerTest(unittest.TestCase):
 
     def tearDown(self):
         unittest.TestCase.tearDown(self)
+        for session in netius.legacy.itervalues(self.server.sessions):
+            session.close()
         self.server.cleanup()
         shutil.rmtree(self.base)
 

--- a/src/netius/test/servers/tftp.py
+++ b/src/netius/test/servers/tftp.py
@@ -1,0 +1,500 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Hive Netius System
+# Copyright (c) 2008-2024 Hive Solutions Lda.
+#
+# This file is part of Hive Netius System.
+#
+# Hive Netius System is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by the Apache
+# Foundation, either version 2.0 of the License, or (at your option) any
+# later version.
+#
+# Hive Netius System is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License along with
+# Hive Netius System. If not, see <http://www.apache.org/licenses/>.
+
+__author__ = "João Magalhães <joamag@hive.pt>"
+""" The author(s) of the module """
+
+__copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
+""" The copyright for the module """
+
+__license__ = "Apache License, Version 2.0"
+""" The license for the module """
+
+import os
+import shutil
+import struct
+import logging
+import tempfile
+import unittest
+
+import netius
+import netius.common
+import netius.servers
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    mock = None
+
+NAME = "file.txt"
+
+MODE = "octet"
+
+ADDRESS = ("127.0.0.1", 1234)
+
+
+class TFTPSessionTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base = tempfile.mkdtemp()
+        self.server = netius.servers.TFTPServer(
+            base_path=self.base, level=logging.CRITICAL
+        )
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+        shutil.rmtree(self.base)
+
+    def test_close(self):
+        self._store(NAME, b"contents")
+        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session.next()
+        file = session.file
+
+        session.close()
+
+        # the closing of a session releases the file that it was reading, as
+        # holding it would keep the descriptor of it open
+        self.assertEqual(file.closed, True)
+        self.assertEqual(session.file, None)
+
+    def test_reset(self):
+        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session.completed = True
+        session.sequence = 3
+
+        session.reset()
+
+        # a session that is reset carries none of the state of the transfer
+        # that came before it, so that it may be used again
+        self.assertEqual(session.name, None)
+        self.assertEqual(session.mode, None)
+        self.assertEqual(session.file, None)
+        self.assertEqual(session.completed, False)
+        self.assertEqual(session.sequence, 0)
+
+    def test_next(self):
+        self._store(NAME, b"0" * 1024)
+        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+
+        data = session.next()
+        type, sequence = struct.unpack("!HH", data[:4])
+
+        # the block that is given back is led by the header that names the
+        # kind of it and the sequence that it takes, which starts at one
+        self.assertEqual(type, netius.common.DATA_TFTP)
+        self.assertEqual(sequence, 1)
+        self.assertEqual(len(data[4:]), 512)
+        self.assertEqual(session.completed, False)
+
+        data = session.next()
+
+        # the reading goes on from where it stopped, the sequence of the
+        # block that follows being the one after it
+        self.assertEqual(struct.unpack("!H", data[2:4])[0], 2)
+        self.assertEqual(session.completed, False)
+
+        data = session.next()
+
+        # a block that is shorter than the size that was asked for is the
+        # last one of the transfer, which is what completes it
+        self.assertEqual(len(data[4:]), 0)
+        self.assertEqual(session.completed, True)
+
+        # once the transfer is complete there is nothing left to be given
+        # back, whatever is asked of the session
+        self.assertEqual(session.next(), None)
+
+    def test_next_increment(self):
+        self._store(NAME, b"0" * 16)
+        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+
+        data = session.next(increment=False)
+
+        # a block that is read without incrementing keeps the sequence where
+        # it was, so the one that names it is the current one
+        self.assertEqual(struct.unpack("!H", data[2:4])[0], 0)
+        self.assertEqual(session.sequence, 0)
+
+    def test_ack(self):
+        self._store(NAME, b"0" * 1024)
+        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+
+        # an acknowledge that arrives before anything was sent has no block
+        # of its own to answer with
+        self.assertEqual(session.ack(), None)
+
+        session.next()
+        data = session.ack()
+
+        # once the transfer is under way the acknowledge is answered with the
+        # block that follows the one that was taken
+        self.assertEqual(struct.unpack("!H", data[2:4])[0], 2)
+
+    def test_increment(self):
+        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+
+        session.increment()
+        session.increment()
+
+        # the sequence of a session walks one at a time, which is what names
+        # the blocks of the transfer in order
+        self.assertEqual(session.sequence, 2)
+
+    def test_get_info(self):
+        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+        session.sequence = 2
+
+        info = session.get_info()
+
+        # the report of a session names the file that it serves and where the
+        # transfer of it currently stands
+        self.assertEqual("name      := %s" % NAME in info, True)
+        self.assertEqual("mode      := %s" % MODE in info, True)
+        self.assertEqual("completed := 0" in info, True)
+        self.assertEqual("sequence  := 2" in info, True)
+
+    def test_print_info(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        session = netius.servers.tftp.TFTPSession(self.server, name=NAME, mode=MODE)
+
+        with mock.patch("sys.stdout", netius.legacy.StringIO()) as stdout:
+            session.print_info()
+
+        # what is printed is the report of the session, so the name of the
+        # file that it serves has to be part of it
+        self.assertEqual("name      := %s" % NAME in stdout.getvalue(), True)
+
+    def test__get_file(self):
+        self._store(NAME, b"contents")
+        session = netius.servers.tftp.TFTPSession(
+            self.server, name="/" + NAME, mode=MODE
+        )
+
+        file = session._get_file()
+
+        # a name that is led by a separator is taken as a relative one, or the
+        # joining of it would step out of the root of the service
+        self.assertEqual(file.read(), b"contents")
+
+        # the file of a session is opened once, the same one being given back
+        # for as long as the transfer lasts
+        self.assertEqual(session._get_file(), file)
+
+    def test__get_file_absolute(self):
+        path = self._store(NAME, b"contents")
+        session = netius.servers.tftp.TFTPSession(self.server, name=path, mode=MODE)
+
+        file = session._get_file(allow_absolute=True)
+
+        # under an absolute name the one of the session is taken whole, which
+        # used to leave the name unbound and raise
+        self.assertEqual(file.read(), b"contents")
+
+    def _store(self, name, contents):
+        path = os.path.join(self.base, name)
+        file = open(path, "wb")
+        try:
+            file.write(contents)
+        finally:
+            file.close()
+        return path
+
+
+class TFTPRequestTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.base = tempfile.mkdtemp()
+        self.server = netius.servers.TFTPServer(
+            base_path=self.base, level=logging.CRITICAL
+        )
+        self.session = netius.servers.tftp.TFTPSession(self.server)
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+        shutil.rmtree(self.base)
+
+    def test_generate(self):
+        netius.servers.tftp.TFTPRequest.generate()
+
+        # the parsers are built once and kept in the class, one of them for
+        # each of the operations that the protocol names
+        self.assertEqual(
+            netius.servers.tftp.TFTPRequest.parsers_l,
+            len(netius.servers.tftp.TFTPRequest.parsers_m),
+        )
+        self.assertEqual(netius.servers.tftp.TFTPRequest.parsers_l, 5)
+
+    def test_get_info(self):
+        request = netius.servers.tftp.TFTPRequest(build_rrq(), self.session)
+        request.parse()
+
+        info = request.get_info()
+
+        # the report of a request names the operation of it and carries the
+        # one of the session that it runs under
+        self.assertEqual("op        := %d" % netius.common.RRQ_TFTP in info, True)
+        self.assertEqual("name      := %s" % NAME in info, True)
+
+    def test_print_info(self):
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        request = netius.servers.tftp.TFTPRequest(build_rrq(), self.session)
+        request.parse()
+
+        with mock.patch("sys.stdout", netius.legacy.StringIO()) as stdout:
+            request.print_info()
+
+        # what is printed is the report of the request, the operation of it
+        # being what leads the report
+        self.assertEqual(
+            "op        := %d" % netius.common.RRQ_TFTP in stdout.getvalue(), True
+        )
+
+    def test_parse(self):
+        request = netius.servers.tftp.TFTPRequest(build_rrq(), self.session)
+        request.parse()
+
+        # the reading of a request names the file and the mode that the peer
+        # asked for, both of them landing in the session
+        self.assertEqual(request.op, netius.common.RRQ_TFTP)
+        self.assertEqual(self.session.name, NAME)
+        self.assertEqual(self.session.mode, MODE)
+
+    def test_parse_unsupported(self):
+        for op in (
+            netius.common.WRQ_TFTP,
+            netius.common.DATA_TFTP,
+            netius.common.ERROR_TFTP,
+        ):
+            request = netius.servers.tftp.TFTPRequest(
+                struct.pack("!H", op), self.session
+            )
+
+            # the writing of a file and the two operations that belong to the
+            # peer are not served, so reading one of them must refuse it
+            self.assertRaises(netius.NotImplemented, request.parse)
+
+    def test_get_type(self):
+        request = netius.servers.tftp.TFTPRequest(build_rrq(), self.session)
+        request.parse()
+
+        # the kind of a request is the operation of it, named by the label
+        # that the protocol gives it
+        self.assertEqual(request.get_type(), netius.common.RRQ_TFTP)
+        self.assertEqual(request.get_type_s(), "rrq")
+
+        request.op = 0xFF
+
+        # an operation that the protocol does not name has no label of its
+        # own to be reported under
+        self.assertEqual(request.get_type_s(), None)
+
+    def test_response(self):
+        self._store(NAME, b"0" * 1024)
+        request = netius.servers.tftp.TFTPRequest(build_rrq(), self.session)
+        request.parse()
+
+        data = request.response()
+
+        # a request to read is answered with the first block of the file, as
+        # there is nothing that came before it
+        self.assertEqual(struct.unpack("!H", data[2:4])[0], 1)
+
+        request = netius.servers.tftp.TFTPRequest(build_ack(1), self.session)
+        request.parse()
+
+        data = request.response()
+
+        # an acknowledge is answered with the block that follows the one that
+        # it acknowledges, which walks the transfer forward
+        self.assertEqual(struct.unpack("!H", data[2:4])[0], 2)
+
+    def test__str(self):
+        value, remaining = netius.servers.tftp.TFTPRequest._str(b"name\x00rest")
+
+        # the value is the part that comes before the null and the rest of the
+        # sequence is what is left to be read
+        self.assertEqual(value, "name")
+        self.assertEqual(remaining, b"rest")
+
+        # a sequence that carries no null has no value in it to be taken, so
+        # the reading of it cannot be completed
+        self.assertRaises(
+            ValueError, netius.servers.tftp.TFTPRequest._str, b"no null here"
+        )
+
+    def _store(self, name, contents):
+        path = os.path.join(self.base, name)
+        file = open(path, "wb")
+        try:
+            file.write(contents)
+        finally:
+            file.close()
+        return path
+
+
+class TFTPServerTest(unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        if mock == None:
+            self.skipTest("Skipping test: mock unavailable")
+
+        self.base = tempfile.mkdtemp()
+        self.server = netius.servers.TFTPServer(
+            base_path=self.base, level=logging.CRITICAL
+        )
+
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+        self.server.cleanup()
+        shutil.rmtree(self.base)
+
+    def test_serve(self):
+        with mock.patch.object(netius.DatagramServer, "serve") as serve:
+            self.server.serve()
+
+        # the service listens on the port that the protocol reserves for it
+        # unless another one is asked for
+        self.assertEqual(serve.call_args[1]["port"], 69)
+
+    def test_on_data(self):
+        self._store(NAME, b"0" * 1024)
+
+        with mock.patch.object(self.server, "send") as send:
+            self.server.on_data(ADDRESS, build_rrq())
+
+        # a request to read opens a session for the peer and answers it with
+        # the first block of the file that was asked for
+        self.assertEqual(ADDRESS in self.server.sessions, True)
+        self.assertEqual(struct.unpack("!H", send.call_args[0][0][2:4])[0], 1)
+
+        with mock.patch.object(self.server, "send") as send:
+            self.server.on_data(ADDRESS, build_ack(1))
+
+        # the session of the peer is the one that is reused, so the block that
+        # answers the acknowledge is the one that follows
+        self.assertEqual(struct.unpack("!H", send.call_args[0][0][2:4])[0], 2)
+
+    def test_on_data_error(self):
+        with mock.patch.object(self.server, "send") as send:
+            self.server.on_data(ADDRESS, struct.pack("!H", netius.common.WRQ_TFTP))
+
+        # an operation that is not served is reported back to the peer as an
+        # error of the protocol instead of breaking the service
+        data = send.call_args[0][0]
+        self.assertEqual(struct.unpack("!H", data[:2])[0], netius.common.ERROR_TFTP)
+
+    def test_on_serve(self):
+        with mock.patch.object(
+            self.server, "get_env", return_value="/other"
+        ) as get_env:
+            self.server.env = True
+            self.server.on_serve()
+
+        # with an environment to read from, the root of the file service is
+        # the one that it names
+        self.assertEqual(get_env.call_args[0][0], "BASE_PATH")
+        self.assertEqual(self.server.base_path, "/other")
+
+        self.server.env = False
+        self.server.base_path = self.base
+
+        self.server.on_serve()
+
+        # without one the root stays the one that the service was built with
+        self.assertEqual(self.server.base_path, self.base)
+
+    def test_on_data_tftp(self):
+        request = mock.MagicMock()
+        request.get_type.return_value = netius.common.WRQ_TFTP
+
+        try:
+            self.server.on_data_tftp(ADDRESS, request)
+        except netius.NetiusError as exception:
+            # the operation that was refused is named in the message of the
+            # error, which reaches the peer as it reads
+            self.assertEqual(
+                str(exception),
+                "Invalid operation type '%d'" % netius.common.WRQ_TFTP,
+            )
+        else:
+            self.fail("The operation should not have been served")
+
+        request = mock.MagicMock()
+        request.get_type.return_value = netius.common.ACK_TFTP
+        request.response.return_value = None
+
+        with mock.patch.object(self.server, "send") as send:
+            self.server.on_data_tftp(ADDRESS, request)
+
+        # a request that has nothing to answer with (eg: a transfer that is
+        # complete) leaves the peer alone instead of sending an empty packet
+        self.assertEqual(send.called, False)
+
+    def test_on_error_tftp(self):
+        with mock.patch.object(self.server, "send") as send:
+            self.server.on_error_tftp(ADDRESS, netius.NetiusError("problem"))
+
+        data = send.call_args[0][0]
+        type, code = struct.unpack("!HH", data[:4])
+
+        # the packet of an error names the kind of it and carries the message
+        # that describes it, closed by the null that ends it
+        self.assertEqual(type, netius.common.ERROR_TFTP)
+        self.assertEqual(code, 0)
+        self.assertEqual(data[4:], b"problem\x00")
+
+    def _store(self, name, contents):
+        path = os.path.join(self.base, name)
+        file = open(path, "wb")
+        try:
+            file.write(contents)
+        finally:
+            file.close()
+        return path
+
+
+def build_rrq(name=NAME, mode=MODE):
+    # builds a request to read as it would arrive from the wire, with the name
+    # of the file and the mode of the transfer closed by nulls
+    header = struct.pack("!H", netius.common.RRQ_TFTP)
+    return (
+        header
+        + netius.legacy.bytes(name)
+        + b"\x00"
+        + netius.legacy.bytes(mode)
+        + b"\x00"
+    )
+
+
+def build_ack(sequence):
+    # builds the acknowledge of a block, which is only the header that names
+    # the operation and the sequence that it answers
+    return struct.pack("!HH", netius.common.ACK_TFTP, sequence)


### PR DESCRIPTION
Raises the package past 81% by covering the two modules that were furthest behind, and fixes the four bugs that writing those cases exposed, two of them arbitrary file reads.

| Module | Before | After |
| --- | --- | --- |
| `servers/tftp.py` | 25.7% | **97.6%** |
| `servers/ftp.py` | 27.1% | **66.8%** |
| **the package** | **80.2%** | **81.4%** |

The package figure above is a single Linux run. The combined one across the three platforms that the job measures, which is what the gate reads, lands at **81.0%** (from 79.5%). The floor of the job goes from 79 to 80, one point under the combined figure, leaving the same headroom it has carried on every previous raise.

`servers/tftp.py` had no test module at all. It gains one covering the session, the request and the service, in the declaration order of each.

## An FTP peer could read any file on the machine

`FTPConnection._get_path` joins the name a peer sends onto the root that is served, normalises it, and hands it straight back:

```python
>>> connection.base_path
'/srv/ftp'
>>> connection._get_path("../../../../etc/passwd")
'/etc/passwd'
```

Every command that names a file goes through it, so `RETR`, `DELE`, `SIZE`, `MDTM`, `MKD`, `RMD` and `RNFR`/`RNTO` all reached outside the root.

This is a plain oversight rather than a design choice, and the code says so itself: the *absolute* branch deliberately strips the leading separator so that `/etc/passwd` resolves to `/srv/ftp/etc/passwd` and stays contained. Only the relative `..` case was left unguarded.

The fix is the containment the author already wrote for the sibling file server in `extra/file.py:550`, applied verbatim so the two read alike:

```python
        # verifies if the resolved path starts with the contents of the
        # base path in case it does not it's a security issue and a proper
        # exception must be raised indicating the issue
        is_sub = relative_path.startswith(self.base_path)
        if not is_sub:
            raise netius.SecurityError("Invalid path")
```

The check is taken at the boundary of the component rather than as a plain prefix, so a sibling root whose name merely starts the same way (`/srv/ftp` against `/srv/ftp-backup`) is refused too:

```python
        is_sub = relative_path == self.base_path or relative_path.startswith(
            os.path.join(self.base_path, "")
        )
```

`os.path.join(base, "")` is used rather than `base + os.sep` so that a root of `/` keeps working, and the equality covers the resolution of the working directory itself. Symlinks are resolved the same way `extra/file.py` resolves them, lexically: `realpath` would have to be applied to both sides or every path breaks where the root is itself reached through a link, and no command either service exposes can create one. `CWD ..` from the root now raises instead of answering 550; from any deeper directory it resolves normally.

## A TFTP peer could read any file on the machine

The same class of issue, and the worse of the two, since TFTP is unauthenticated UDP. `TFTPSession._get_file` only trimmed a leading separator, which does nothing to a name that steps up, and never resolved the result at all. Driving it through the wire path rather than calling the method directly:

```
the name the peer asked for: '../outside.txt'
the peer received: b'secret contents'
```

It now resolves the candidate and takes the same containment as the FTP service.

## Two more TFTP bugs

**The error packet carried raw values instead of a message.** `on_data_tftp` handed the operation to the exception as a second argument rather than formatting it in, and `on_error_tftp` puts `str(exception)` on the wire, so a peer that asked for an unsupported operation received:

```
("Invalid operation type '%d'", 2)
```

Every other `NetiusError` in the package builds its message with `%` first. Now this one does too.

**A file served under an absolute name never opened.** `TFTPSession._get_file` binds `name` only inside `if not allow_absolute:`, so calling it with the parameter the signature offers raised `UnboundLocalError: local variable 'name' referenced before assignment`. The name is now read before the branch that trims it.

## Verification

All three traversal cases and both of the other TFTP cases fail against `master` and pass here.

New cases probe the error paths rather than the happy one: removing a file twice, creating a directory that exists, renaming a source that is gone, entering a directory that is not there, listing a working directory that does not exist, a transfer whose file fits in a single block (so the acknowledge correctly has nothing left to answer), an operation the protocol does not name, and a request payload with no terminating null.

Checked on Python 3.14 (2009 passed, coverage gate and `mypy.stubtest` clean), and on 3.6, 3.5 and 2.7 through `python setup.py test` as the job runs it, plus `black --check` across 366 files.

The first push failed on Windows: two cases held a session on the test case itself, so the file it was reading stayed open and the temporary root could not be removed. The sessions are now released in the teardown, which is what the service does with them anyway. The cases that keep a session local passed only because CPython refcounting closed the file for them, so those were given the same treatment rather than left to luck on a runtime that collects later.
